### PR TITLE
chore: disable automated dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore"
+    # Keep Dependabot available for dependency metadata, but do not open
+    # routine version update pull requests. Dependency updates are handled
+    # manually so project history stays maintainer-authored.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- stop routine Dependabot version update pull requests
- keep dependency alerts available while handling dependency updates manually
- disable automated security-fix pull requests in repository settings

## Verification
- Ran `git diff --check`
- Confirmed automated security-fix pull requests are disabled through GitHub API
- Re-enabled vulnerability alerts through GitHub API