### PR TITLE
feat: OAuth + Cookie dual-track platform integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.23.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Setup pnpm
         run: |
@@ -32,6 +55,26 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.23.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.23.0
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@10.23.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -39,16 +40,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.23.0
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@10.23.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -62,16 +64,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.23.0
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@10.23.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.23.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -39,16 +39,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.23.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -62,16 +62,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.23.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/src/app/api/platforms/[platform]/connection/check/route.ts
+++ b/src/app/api/platforms/[platform]/connection/check/route.ts
@@ -2,8 +2,24 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { PlatformId } from '@/types';
 import { PLATFORM_CONNECTIONS } from '@/lib/platformConnections';
 import { getConnectionRecordStore } from '@/lib/platformConnections/registry';
+import {
+  checkWechat,
+  checkXiaohongshu,
+  checkZhihu,
+  checkX,
+  type CheckResult,
+} from '@/lib/platformConnections/checkers';
 
 const VALID_PLATFORMS = new Set<string>(['wechat', 'xiaohongshu', 'zhihu', 'x']);
+
+type PlatformChecker = () => Promise<CheckResult>;
+
+const CHECKERS: Record<PlatformId, PlatformChecker> = {
+  wechat: checkWechat,
+  xiaohongshu: checkXiaohongshu,
+  zhihu: checkZhihu,
+  x: checkX,
+};
 
 export async function POST(
   _request: NextRequest,
@@ -22,23 +38,29 @@ export async function POST(
   }
 
   const checkedAt = new Date().toISOString();
+  const checker = CHECKERS[platformId];
+  const result = await checker();
 
-  // For manual-mode platforms (e.g. zhihu), we only verify that
-  // the required env keys are present — no live API call.
-  const missingKeys = definition.requiredKeys.filter(
-    (key) => !process.env[key]?.trim(),
-  );
-  const ok = missingKeys.length === 0;
-  const failureReason = ok
-    ? undefined
-    : `缺少必要凭证: ${missingKeys.join(', ')}`;
-
-  const record = getConnectionRecordStore().markChecked(platformId, {
+  // 持久化检查结果（markChecked 更新 lastCheckedAt + failureReason）
+  const store = getConnectionRecordStore();
+  store.markChecked(platformId, {
     platform: platformId,
-    ok,
-    failureReason,
+    ok: result.ok,
+    failureReason: result.failureReason,
     checkedAt,
   });
 
-  return NextResponse.json({ ok, failureReason, checkedAt, record });
+  // 同时更新账号元数据和 token 过期时间
+  if (result.ok) {
+    store.upsertRecord(platformId, {
+      ...(result.accountName ? { accountName: result.accountName } : {}),
+      ...(result.expiresAt ? { expiresAt: result.expiresAt } : {}),
+      lastCheckedAt: checkedAt,
+      failureReason: undefined,
+    });
+  }
+
+  const record = store.getRecord(platformId);
+
+  return NextResponse.json({ ok: result.ok, failureReason: result.failureReason, accountName: result.accountName, checkedAt, record });
 }

--- a/src/app/api/platforms/[platform]/connection/oauth/callback/__tests__/route.test.ts
+++ b/src/app/api/platforms/[platform]/connection/oauth/callback/__tests__/route.test.ts
@@ -5,8 +5,8 @@ function makeParams(platform: string) {
   return { params: Promise.resolve({ platform }) };
 }
 
-function makeRequest(body: unknown) {
-  return new Request('http://localhost/api/platforms/wechat/connection/oauth/callback', {
+function makeRequest(body: unknown, platform = 'wechat') {
+  return new Request(`http://localhost/api/platforms/${platform}/connection/oauth/callback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -24,17 +24,17 @@ describe('/api/platforms/[platform]/connection/oauth/callback', () => {
     expect(res.status).toBe(400);
   });
 
-  test('returns 400 when code is missing', async () => {
-    const res = await POST(makeRequest({}) as any, makeParams('wechat') as any);
+  test('returns 400 for POST to wechat (OAuth callback must use GET redirect, not POST)', async () => {
+    const res = await POST(makeRequest({ code: 'auth-code-123' }, 'wechat') as any, makeParams('wechat') as any);
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toMatch(/code/);
+    expect(json.error).toBeTruthy();
   });
 
-  test('returns 501 for oauth platform not yet implemented (wechat)', async () => {
-    const res = await POST(makeRequest({ code: 'auth-code-123' }) as any, makeParams('wechat') as any);
-    expect(res.status).toBe(501);
+  test('returns 400 for POST to xiaohongshu (OAuth callback must use GET redirect, not POST)', async () => {
+    const res = await POST(makeRequest({ code: 'auth-code-123' }, 'xiaohongshu') as any, makeParams('xiaohongshu') as any);
+    expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.platform).toBe('wechat');
+    expect(json.error).toBeTruthy();
   });
 });

--- a/src/app/api/platforms/[platform]/connection/oauth/callback/route.ts
+++ b/src/app/api/platforms/[platform]/connection/oauth/callback/route.ts
@@ -2,22 +2,97 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { PlatformId } from '@/types';
 import { PLATFORM_CONNECTIONS } from '@/lib/platformConnections';
 import { getConnectionRecordStore } from '@/lib/platformConnections/registry';
+import { consumeNonce } from '@/lib/platformConnections/oauthNonce';
+import { writeEnvKey } from '@/lib/storage/envFile';
+import { getXhsConfig } from '@/lib/config';
 
 const VALID_PLATFORMS = new Set<string>(['wechat', 'xiaohongshu', 'zhihu', 'x']);
 
 /**
+ * GET /api/platforms/[platform]/connection/oauth/callback
+ *
+ * OAuth 授权码回调（平台 redirect 走 GET，query string 携带 code + state）。
+ * 当前支持小红书授权码换 access_token。
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ platform: string }> },
+) {
+  const { platform } = await params;
+
+  if (!VALID_PLATFORMS.has(platform)) {
+    return NextResponse.redirect(new URL('/settings?error=invalid_platform', request.url));
+  }
+
+  const platformId = platform as PlatformId;
+  const searchParams = request.nextUrl.searchParams;
+  const code = searchParams.get('code') ?? '';
+  const state = searchParams.get('state') ?? '';
+
+  if (!code) {
+    return NextResponse.redirect(new URL(`/settings?error=missing_code&platform=${platformId}`, request.url));
+  }
+
+  // 验证 state nonce（防 CSRF）
+  const noncePlatform = consumeNonce(state);
+  if (!noncePlatform || noncePlatform !== platformId) {
+    return NextResponse.redirect(new URL(`/settings?error=invalid_state&platform=${platformId}`, request.url));
+  }
+
+  if (platformId === 'xiaohongshu') {
+    const { appId, appSecret } = getXhsConfig();
+    const callbackUrl = new URL(
+      '/api/platforms/xiaohongshu/connection/oauth/callback',
+      request.url,
+    ).toString();
+
+    try {
+      const tokenRes = await fetch('https://open.xiaohongshu.com/api/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          app_id: appId,
+          app_secret: appSecret,
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: callbackUrl,
+        }),
+      });
+      const tokenData = await tokenRes.json();
+
+      if (tokenData.code !== 0 && tokenData.code !== 200) {
+        const msg = encodeURIComponent(tokenData.msg || tokenData.message || 'token_exchange_failed');
+        return NextResponse.redirect(new URL(`/settings?error=${msg}&platform=xiaohongshu`, request.url));
+      }
+
+      const accessToken = tokenData.data?.access_token || tokenData.access_token;
+      const expiresIn = tokenData.data?.expires_in || tokenData.expires_in || 7200;
+      const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+      // 写入 .env.local
+      await writeEnvKey('XHS_ACCESS_TOKEN', accessToken);
+
+      // 更新连接记录
+      getConnectionRecordStore().upsertRecord('xiaohongshu', {
+        connectedAt: new Date().toISOString(),
+        expiresAt,
+        failureReason: undefined,
+      });
+
+      return NextResponse.redirect(new URL('/settings?connected=xiaohongshu', request.url));
+    } catch (error) {
+      const msg = encodeURIComponent(error instanceof Error ? error.message : 'unknown_error');
+      return NextResponse.redirect(new URL(`/settings?error=${msg}&platform=xiaohongshu`, request.url));
+    }
+  }
+
+  return NextResponse.redirect(new URL(`/settings?error=unsupported_platform&platform=${platformId}`, request.url));
+}
+
+/**
  * POST /api/platforms/[platform]/connection/oauth/callback
  *
- * Handles the OAuth authorization code callback.
- * Expects `{ code, state }` in the request body.
- *
- * Currently returns a 501 stub — the token exchange logic is the integration
- * point for each platform's OAuth SDK. Once implemented, this handler should:
- * 1. Validate the `state` parameter against a session-stored nonce
- * 2. Exchange `code` for access/refresh tokens via the platform API
- * 3. Store tokens in `.env.local` (or a secrets store) via the settings API
- * 4. Call `getConnectionRecordStore().upsertRecord()` with account metadata
- * 5. Redirect the user back to `/settings`
+ * 保留原有 POST stub（兼容旧客户端调用）。
  */
 export async function POST(
   request: NextRequest,
@@ -43,23 +118,10 @@ export async function POST(
     );
   }
 
-  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
-  const code = typeof body.code === 'string' ? body.code.trim() : '';
-
-  if (!code) {
-    return NextResponse.json({ error: '缺少授权码 code' }, { status: 400 });
-  }
-
-  // Token exchange not yet implemented.
-  // When ready, exchange `code` for tokens here and call:
-  //   getConnectionRecordStore().upsertRecord(platformId, { connectedAt, accountName, ... })
-  void getConnectionRecordStore; // referenced so the import is not removed
+  void getConnectionRecordStore;
 
   return NextResponse.json(
-    {
-      error: 'OAuth token 交换尚未实现',
-      platform: platformId,
-    },
-    { status: 501 },
+    { error: '请通过浏览器重定向完成 OAuth 授权，而非直接调用此接口', platform: platformId },
+    { status: 400 },
   );
 }

--- a/src/app/api/platforms/[platform]/connection/oauth/start/__tests__/route.test.ts
+++ b/src/app/api/platforms/[platform]/connection/oauth/start/__tests__/route.test.ts
@@ -5,8 +5,8 @@ function makeParams(platform: string) {
   return { params: Promise.resolve({ platform }) };
 }
 
-function makeRequest() {
-  return new Request('http://localhost/api/platforms/wechat/connection/oauth/start', {
+function makeRequest(platform = 'wechat') {
+  return new Request(`http://localhost/api/platforms/${platform}/connection/oauth/start`, {
     method: 'POST',
   });
 }
@@ -24,11 +24,24 @@ describe('/api/platforms/[platform]/connection/oauth/start', () => {
     expect(json.error).toMatch(/手动凭证/);
   });
 
-  test('returns 501 for oauth platform not yet implemented (wechat)', async () => {
-    const res = await POST(makeRequest() as any, makeParams('wechat') as any);
-    expect(res.status).toBe(501);
+  test('returns 400 for wechat with requiresManualConfig (verify-only, no OAuth redirect)', async () => {
+    const res = await POST(makeRequest('wechat') as any, makeParams('wechat') as any);
+    expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.platform).toBe('wechat');
-    expect(json.error).toBeTruthy();
+    expect(json.requiresManualConfig).toBe(true);
+    expect(json.message).toBeTruthy();
+  });
+
+  test('returns 400 for x with requiresManualConfig (verify-only, no OAuth redirect)', async () => {
+    const res = await POST(makeRequest('x') as any, makeParams('x') as any);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.requiresManualConfig).toBe(true);
+  });
+
+  test('returns 400 for xiaohongshu when XHS_APP_ID is not configured', async () => {
+    // XHS_APP_ID not set in test env → 400
+    const res = await POST(makeRequest('xiaohongshu') as any, makeParams('xiaohongshu') as any);
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/platforms/[platform]/connection/oauth/start/route.ts
+++ b/src/app/api/platforms/[platform]/connection/oauth/start/route.ts
@@ -1,19 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { PlatformId } from '@/types';
 import { PLATFORM_CONNECTIONS } from '@/lib/platformConnections';
+import { createNonce } from '@/lib/platformConnections/oauthNonce';
+import { getXhsConfig } from '@/lib/config';
 
 const VALID_PLATFORMS = new Set<string>(['wechat', 'xiaohongshu', 'zhihu', 'x']);
 
-/**
- * POST /api/platforms/[platform]/connection/oauth/start
- *
- * Returns the authorization URL for the platform's OAuth flow.
- * The client should redirect the user to this URL.
- *
- * Currently returns a 501 for all platforms as real OAuth integrations
- * require platform-specific developer app credentials and callback URIs.
- * This endpoint is the designated integration point for future OAuth support.
- */
+// 微信和 X 不需要 OAuth 重定向，引导用户手动填写
+const MANUAL_CONFIG_PLATFORMS = new Set<PlatformId>(['wechat', 'x']);
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ platform: string }> },
@@ -38,15 +33,45 @@ export async function POST(
     );
   }
 
-  // OAuth flows require platform-specific client credentials and a registered
-  // callback URI. These are not yet configured — return a clear 501 with
-  // guidance for future implementation.
-  return NextResponse.json(
-    {
-      error: 'OAuth 授权流程尚未实现，请在设置页面手动填写 API 凭证',
-      platform: platformId,
-      mode: definition.mode,
-    },
-    { status: 501 },
-  );
+  // 微信/X：不需要 OAuth 重定向，直接引导手动配置 + 验证连接
+  if (MANUAL_CONFIG_PLATFORMS.has(platformId)) {
+    return NextResponse.json(
+      {
+        requiresManualConfig: true,
+        message: platformId === 'wechat'
+          ? '微信公众号使用 AppID + AppSecret 直接接入，无需 OAuth 授权。请填写凭证后点击「验证连接」。'
+          : '请在 developer.x.com 生成 Access Token，填写全部 4 个 key 后点击「验证连接」。',
+      },
+      { status: 400 },
+    );
+  }
+
+  // 小红书：生成 OAuth 授权 URL
+  if (platformId === 'xiaohongshu') {
+    const { appId } = getXhsConfig();
+    if (!appId) {
+      return NextResponse.json(
+        { error: '请先填写并保存 XHS_APP_ID，再发起授权' },
+        { status: 400 },
+      );
+    }
+
+    const state = createNonce('xiaohongshu');
+    const callbackUrl = new URL(
+      '/api/platforms/xiaohongshu/connection/oauth/callback',
+      request.url,
+    ).toString();
+
+    const authUrl =
+      `https://oauth.xiaohongshu.com/authorize` +
+      `?client_id=${encodeURIComponent(appId)}` +
+      `&redirect_uri=${encodeURIComponent(callbackUrl)}` +
+      `&response_type=code` +
+      `&scope=note.create` +
+      `&state=${encodeURIComponent(state)}`;
+
+    return NextResponse.json({ authUrl });
+  }
+
+  return NextResponse.json({ error: '该平台暂不支持 OAuth 授权流程' }, { status: 501 });
 }

--- a/src/app/api/platforms/connection/records/route.ts
+++ b/src/app/api/platforms/connection/records/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { getConnectionRecordStore } from '@/lib/platformConnections/registry';
+
+/**
+ * GET /api/platforms/connection/records
+ *
+ * 返回所有平台的连接记录（accountName、lastCheckedAt、failureReason、expiresAt 等）。
+ * 用于设置页面加载时展示真实连接状态。
+ */
+export async function GET() {
+  const records = getConnectionRecordStore().listRecords();
+  return NextResponse.json(records);
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
+import { parseEnvFile, serializeEnvFile } from '@/lib/storage/envFile';
 
 const ENV_FILE = join(process.cwd(), '.env.local');
 
@@ -18,43 +19,6 @@ function maskValue(key: string, value: string): string {
     return '****' + value.slice(-4);
   }
   return value;
-}
-
-function parseEnvFile(content: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIndex = trimmed.indexOf('=');
-    if (eqIndex === -1) continue;
-    const key = trimmed.slice(0, eqIndex).trim();
-    const value = trimmed.slice(eqIndex + 1).trim();
-    result[key] = value;
-  }
-  return result;
-}
-
-function serializeEnvFile(values: Record<string, string>): string {
-  const lines = [
-    '# WeChat Official Account',
-    `WECHAT_APP_ID=${values.WECHAT_APP_ID || ''}`,
-    `WECHAT_APP_SECRET=${values.WECHAT_APP_SECRET || ''}`,
-    '',
-    '# Xiaohongshu (RED)',
-    `XHS_APP_ID=${values.XHS_APP_ID || ''}`,
-    `XHS_APP_SECRET=${values.XHS_APP_SECRET || ''}`,
-    `XHS_ACCESS_TOKEN=${values.XHS_ACCESS_TOKEN || ''}`,
-    '',
-    '# Zhihu',
-    `ZHIHU_COOKIE=${values.ZHIHU_COOKIE || ''}`,
-    '',
-    '# X (Twitter)',
-    `X_API_KEY=${values.X_API_KEY || ''}`,
-    `X_API_SECRET=${values.X_API_SECRET || ''}`,
-    `X_ACCESS_TOKEN=${values.X_ACCESS_TOKEN || ''}`,
-    `X_ACCESS_TOKEN_SECRET=${values.X_ACCESS_TOKEN_SECRET || ''}`,
-  ];
-  return lines.join('\n') + '\n';
 }
 
 export async function GET() {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import {
   Save,
   Eye,
@@ -15,7 +16,7 @@ import {
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import SurfaceCard from '@/components/layout/SurfaceCard';
 import { getPlatformConnectionProfiles } from '@/lib/platformConnections/profiles';
-import type { PlatformConnectionMode, PlatformConnectionStatus } from '@/lib/platformConnections/types';
+import type { PlatformConnectionMode, PlatformConnectionStatus, PlatformConnectionRecord } from '@/lib/platformConnections/types';
 import type { PlatformId } from '@/types';
 import {
   WechatIcon,
@@ -60,7 +61,7 @@ const platformConfigs: PlatformConfig[] = [
     fields: [
       { key: 'XHS_APP_ID', label: 'App ID', type: 'text', placeholder: '输入小红书 App ID' },
       { key: 'XHS_APP_SECRET', label: 'App Secret', type: 'password', placeholder: '输入小红书 App Secret' },
-      { key: 'XHS_ACCESS_TOKEN', label: 'Access Token', type: 'password', placeholder: '输入小红书 Access Token' },
+      { key: 'XHS_ACCESS_TOKEN', label: 'Access Token', type: 'password', placeholder: '输入小红书 Access Token（可选，授权后自动写入）' },
     ],
   },
   {
@@ -88,6 +89,9 @@ const platformConfigs: PlatformConfig[] = [
   },
 ];
 
+// 这些平台不走 OAuth 重定向，直接调 check 验证凭证
+const VERIFY_ONLY_PLATFORMS = new Set<PlatformId>(['wechat', 'x']);
+
 const statusLabels: Record<PlatformConnectionStatus, string> = {
   connected: '已连接',
   available: '可授权',
@@ -98,6 +102,7 @@ interface CheckState {
   checking: boolean;
   ok?: boolean;
   failureReason?: string;
+  accountName?: string;
   checkedAt?: string;
 }
 
@@ -106,7 +111,18 @@ interface DisconnectState {
   done?: boolean;
 }
 
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  return `${Math.floor(hours / 24)} 天前`;
+}
+
 export default function SettingsPage() {
+  const searchParams = useSearchParams();
   const [values, setValues] = useState<Record<string, string>>({});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   const [saved, setSaved] = useState(false);
@@ -116,7 +132,21 @@ export default function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [checkStates, setCheckStates] = useState<Record<string, CheckState>>({});
   const [disconnectStates, setDisconnectStates] = useState<Record<string, DisconnectState>>({});
+  const [connectionRecords, setConnectionRecords] = useState<Record<PlatformId, PlatformConnectionRecord>>({} as Record<PlatformId, PlatformConnectionRecord>);
   const connectionProfiles = getPlatformConnectionProfiles(values);
+
+  // 检测 OAuth callback 后的 ?connected= 参数
+  useEffect(() => {
+    const connected = searchParams.get('connected') as PlatformId | null;
+    const error = searchParams.get('error');
+    if (connected) {
+      const platformName = platformConfigs.find((p) => p.id === connected)?.name ?? connected;
+      setNoticeMessage(`${platformName} 授权成功，连接已建立。`);
+      setExpandedPlatform(connected);
+    } else if (error) {
+      setErrorMessage(`授权失败：${decodeURIComponent(error)}`);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     let cancelled = false;
@@ -125,10 +155,21 @@ export default function SettingsPage() {
       try {
         setLoading(true);
         setErrorMessage('');
-        const response = await fetch('/api/settings', { cache: 'no-store' });
-        const data = (await response.json()) as Record<string, string>;
-        if (!response.ok) throw new Error('加载设置失败，请稍后重试');
+        const [settingsRes, recordsRes] = await Promise.all([
+          fetch('/api/settings', { cache: 'no-store' }),
+          fetch('/api/platforms/connection/records', { cache: 'no-store' }),
+        ]);
+        const data = (await settingsRes.json()) as Record<string, string>;
+        if (!settingsRes.ok) throw new Error('加载设置失败，请稍后重试');
         if (!cancelled) setValues(data);
+
+        if (recordsRes.ok) {
+          const records = (await recordsRes.json()) as PlatformConnectionRecord[];
+          if (!cancelled) {
+            const recordMap = Object.fromEntries(records.map((r) => [r.platform, r])) as Record<PlatformId, PlatformConnectionRecord>;
+            setConnectionRecords(recordMap);
+          }
+        }
       } catch (error) {
         if (!cancelled) {
           setErrorMessage(error instanceof Error ? error.message : '加载设置失败，请稍后重试');
@@ -163,22 +204,27 @@ export default function SettingsPage() {
       return;
     }
 
+    // 微信/X 不走 OAuth redirect，直接验证连接
+    if (VERIFY_ONLY_PLATFORMS.has(platformId)) {
+      await handleCheckConnection(platformId);
+      return;
+    }
+
     try {
       const res = await fetch(`/api/platforms/${platformId}/connection/oauth/start`, { method: 'POST' });
-      const data = (await res.json()) as { authUrl?: string; error?: string };
+      const data = (await res.json()) as { authUrl?: string; error?: string; requiresManualConfig?: boolean };
 
-      if (res.status === 501) {
-        // OAuth not yet implemented — guide user to manual credential entry
-        setNoticeMessage(`${platformName} OAuth 授权入口已预留，当前请在下方手动填写 API 凭证完成连接。`);
+      if (data.requiresManualConfig || !res.ok) {
+        setNoticeMessage(data.error || `${platformName} 请填写凭证后点击「验证连接」。`);
         return;
       }
 
-      if (!res.ok || !data.authUrl) {
-        setErrorMessage(data.error || `${platformName} 授权失败，请稍后重试`);
+      if (!data.authUrl) {
+        setErrorMessage(`${platformName} 授权失败，请稍后重试`);
         return;
       }
 
-      // Redirect to the platform's OAuth authorization page
+      // 跳转到平台 OAuth 授权页
       window.location.href = data.authUrl;
     } catch {
       setErrorMessage(`${platformName} 授权请求失败，请稍后重试`);
@@ -189,10 +235,10 @@ export default function SettingsPage() {
     setCheckStates((prev) => ({ ...prev, [platformId]: { checking: true } }));
     try {
       const res = await fetch(`/api/platforms/${platformId}/connection/check`, { method: 'POST' });
-      const data = (await res.json()) as { ok: boolean; failureReason?: string; checkedAt?: string };
+      const data = (await res.json()) as { ok: boolean; failureReason?: string; accountName?: string; checkedAt?: string };
       setCheckStates((prev) => ({
         ...prev,
-        [platformId]: { checking: false, ok: data.ok, failureReason: data.failureReason, checkedAt: data.checkedAt },
+        [platformId]: { checking: false, ok: data.ok, failureReason: data.failureReason, accountName: data.accountName, checkedAt: data.checkedAt },
       }));
     } catch {
       setCheckStates((prev) => ({
@@ -236,6 +282,43 @@ export default function SettingsPage() {
     }
   }
 
+  function renderCheckResult(platformId: PlatformId) {
+    const ck = checkStates[platformId];
+    const record = connectionRecords[platformId];
+
+    if (ck && !ck.checking) {
+      if (ck.ok) {
+        return (
+          <p className={styles.checkResultOk}>
+            <CheckCircle2 size={13} />
+            {ck.accountName ? `连接正常（${ck.accountName}）` : '连接正常'}
+          </p>
+        );
+      }
+      return <p className={styles.checkResultFail}>连接异常：{ck.failureReason ?? '未知原因'}</p>;
+    }
+
+    if (disconnectStates[platformId]?.done) {
+      return <p className={styles.checkResultOk}>连接记录已清除</p>;
+    }
+
+    // 从持久化 records 中展示上次验证信息
+    if (record?.lastCheckedAt) {
+      const timeAgo = formatRelativeTime(record.lastCheckedAt);
+      if (record.failureReason) {
+        return <p className={styles.checkResultFail}>上次验证（{timeAgo}）失败：{record.failureReason}</p>;
+      }
+      return (
+        <p className={styles.checkResultOk}>
+          <CheckCircle2 size={13} />
+          {record.accountName ? `${record.accountName} · ` : ''}上次验证：{timeAgo}
+        </p>
+      );
+    }
+
+    return null;
+  }
+
   return (
     <div className={styles.pageWrap}>
       <AppShellHeader
@@ -272,6 +355,7 @@ export default function SettingsPage() {
           const isExpanded = expandedPlatform === platform.id;
           const { Icon } = platform;
           const connectionProfile = connectionProfiles.find((profile) => profile.platform === platform.id);
+          const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
 
           return (
             <SurfaceCard key={platform.id} tone="soft" className={styles.accordionCard}>
@@ -349,42 +433,39 @@ export default function SettingsPage() {
                         <p className={styles.fieldHint}>{platform.hint}</p>
                       </div>
 
-                      {/* 步骤 2：账号授权 */}
+                      {/* 步骤 2：账号授权 / 验证连接 */}
                       <div className={styles.oauthStep}>
                         <div className={styles.oauthStepHeader}>
                           <span className={connectionProfile.status === 'connected' ? styles.oauthStepBadgeActive : styles.oauthStepBadge}>2</span>
-                          <p className={styles.oauthStepTitle}>账号授权</p>
+                          <p className={styles.oauthStepTitle}>{isVerifyOnly ? '验证连接' : '账号授权'}</p>
                         </div>
                         <p className={styles.oauthStepDesc}>
-                          {connectionProfile.status === 'connected'
-                            ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
-                            : connectionProfile.missingKeys.length > 0
-                              ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
-                              : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
+                          {isVerifyOnly
+                            ? connectionProfile.status === 'connected'
+                              ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
+                              : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
+                            : connectionProfile.status === 'connected'
+                              ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
+                              : connectionProfile.missingKeys.length > 0
+                                ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
+                                : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
                         </p>
-                        {/* 连接检查 / 断开结果 */}
-                        {(() => {
-                          const ck = checkStates[platform.id];
-                          if (ck && !ck.checking) {
-                            if (ck.ok) return <p className={styles.checkResultOk}><CheckCircle2 size={13} /> 连接正常</p>;
-                            return <p className={styles.checkResultFail}>连接异常：{ck.failureReason ?? '未知原因'}</p>;
-                          }
-                          if (disconnectStates[platform.id]?.done) {
-                            return <p className={styles.checkResultOk}>连接记录已清除</p>;
-                          }
-                          return null;
-                        })()}
+                        {renderCheckResult(platform.id)}
                         <div className={styles.oauthAuthorizeRow}>
                           <button
                             type="button"
                             className={styles.authorizeButton}
-                            disabled={connectionProfile.missingKeys.length > 0}
+                            disabled={connectionProfile.missingKeys.length > 0 || checkStates[platform.id]?.checking}
                             onClick={() => void handleConnectionAction(platform.id, platform.name, connectionProfile.mode)}
                           >
-                            <Zap size={15} />
-                            {connectionProfile.status === 'connected' ? '重新授权' : '一键授权'}
+                            {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
+                            {checkStates[platform.id]?.checking
+                              ? '验证中…'
+                              : isVerifyOnly
+                                ? connectionProfile.status === 'connected' ? '重新验证' : '验证连接'
+                                : connectionProfile.status === 'connected' ? '重新授权' : '一键授权'}
                           </button>
-                          {connectionProfile.status === 'connected' ? (
+                          {connectionProfile.status === 'connected' && !isVerifyOnly ? (
                             <>
                               <button
                                 type="button"
@@ -410,7 +491,7 @@ export default function SettingsPage() {
                       </div>
                     </div>
                   ) : (
-                    // ── Manual 平台（知乎）：纯表单 ──────────────────────
+                    // ── Manual 平台（知乎）：纯表单 + 测试连接 ───────────
                     <>
                       <div className={styles.fieldList}>
                         {platform.fields.map((field) => (
@@ -453,6 +534,19 @@ export default function SettingsPage() {
                         ))}
                       </div>
                       <p className={styles.fieldHint}>{platform.hint}</p>
+                      {/* 知乎：测试连接区域 */}
+                      <div className={styles.oauthAuthorizeRow}>
+                        <button
+                          type="button"
+                          className={styles.checkButton}
+                          disabled={checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']}
+                          onClick={() => void handleCheckConnection(platform.id)}
+                        >
+                          <RefreshCw size={13} />
+                          {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
+                        </button>
+                      </div>
+                      {renderCheckResult(platform.id)}
                     </>
                   )}
                 </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import {
   Save,
@@ -121,7 +121,7 @@ function formatRelativeTime(iso: string): string {
   return `${Math.floor(hours / 24)} 天前`;
 }
 
-export default function SettingsPage() {
+function SettingsContent() {
   const searchParams = useSearchParams();
   const [values, setValues] = useState<Record<string, string>>({});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
@@ -556,5 +556,13 @@ export default function SettingsPage() {
         })}
       </div>
     </div>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Suspense>
+      <SettingsContent />
+    </Suspense>
   );
 }

--- a/src/lib/platformConnections/checkers.ts
+++ b/src/lib/platformConnections/checkers.ts
@@ -1,0 +1,100 @@
+/**
+ * 各平台连接状态的真实 API 探针。
+ * 每个 checker 做一次实际 API 调用来验证凭证有效性。
+ */
+import { TwitterApi } from 'twitter-api-v2';
+import { getWechatConfig, getXhsConfig, getZhihuConfig, getXConfig } from '@/lib/config';
+import { getXhsAccessToken } from '@/lib/publishers/xiaohongshu';
+
+export interface CheckResult {
+  ok: boolean;
+  failureReason?: string;
+  accountName?: string;
+  expiresAt?: string;
+}
+
+export async function checkWechat(): Promise<CheckResult> {
+  const { appId, appSecret } = getWechatConfig();
+  if (!appId || !appSecret) {
+    return { ok: false, failureReason: '缺少 WECHAT_APP_ID 或 WECHAT_APP_SECRET' };
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${appId}&secret=${appSecret}`
+    );
+    const data = await res.json();
+
+    if (data.errcode) {
+      return { ok: false, failureReason: `微信凭证无效: ${data.errmsg} (${data.errcode})` };
+    }
+
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, failureReason: `网络请求失败: ${error instanceof Error ? error.message : '未知错误'}` };
+  }
+}
+
+export async function checkXiaohongshu(): Promise<CheckResult> {
+  const { appId, appSecret } = getXhsConfig();
+  if (!appId || !appSecret) {
+    return { ok: false, failureReason: '缺少 XHS_APP_ID 或 XHS_APP_SECRET' };
+  }
+
+  try {
+    await getXhsAccessToken(appId, appSecret);
+    const expiresAt = new Date(Date.now() + 7200 * 1000).toISOString();
+    return { ok: true, expiresAt };
+  } catch (error) {
+    return { ok: false, failureReason: error instanceof Error ? error.message : '获取 access_token 失败' };
+  }
+}
+
+export async function checkZhihu(): Promise<CheckResult> {
+  const { cookie } = getZhihuConfig();
+  if (!cookie) {
+    return { ok: false, failureReason: '缺少 ZHIHU_COOKIE' };
+  }
+
+  try {
+    const res = await fetch('https://www.zhihu.com/api/v4/me', {
+      headers: {
+        Cookie: cookie,
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+      },
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, failureReason: 'Cookie 已过期或无效，请重新从浏览器复制' };
+    }
+
+    if (!res.ok) {
+      return { ok: false, failureReason: `知乎接口返回 ${res.status}` };
+    }
+
+    const data = await res.json();
+    return { ok: true, accountName: data.name || data.id };
+  } catch (error) {
+    return { ok: false, failureReason: `网络请求失败: ${error instanceof Error ? error.message : '未知错误'}` };
+  }
+}
+
+export async function checkX(): Promise<CheckResult> {
+  const { apiKey, apiSecret, accessToken, accessTokenSecret } = getXConfig();
+  if (!apiKey || !apiSecret || !accessToken || !accessTokenSecret) {
+    return { ok: false, failureReason: '缺少 X API 凭证，请填写全部 4 个 key' };
+  }
+
+  try {
+    const client = new TwitterApi({
+      appKey: apiKey,
+      appSecret: apiSecret,
+      accessToken,
+      accessSecret: accessTokenSecret,
+    });
+    const { data } = await client.v2.me();
+    return { ok: true, accountName: `@${data.username}` };
+  } catch (error) {
+    return { ok: false, failureReason: `X API 凭证无效: ${error instanceof Error ? error.message : '未知错误'}` };
+  }
+}

--- a/src/lib/platformConnections/oauthNonce.ts
+++ b/src/lib/platformConnections/oauthNonce.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'crypto';
+import type { PlatformId } from '@/types';
+
+const NONCE_TTL_MS = 10 * 60 * 1000; // 10 分钟
+
+interface NonceEntry {
+  platform: PlatformId;
+  createdAt: number;
+}
+
+const nonceStore = new Map<string, NonceEntry>();
+
+export function createNonce(platform: PlatformId): string {
+  const nonce = randomUUID();
+  nonceStore.set(nonce, { platform, createdAt: Date.now() });
+  return nonce;
+}
+
+export function consumeNonce(nonce: string): PlatformId | null {
+  const entry = nonceStore.get(nonce);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > NONCE_TTL_MS) {
+    nonceStore.delete(nonce);
+    return null;
+  }
+  nonceStore.delete(nonce);
+  return entry.platform;
+}

--- a/src/lib/platformConnections/profiles.ts
+++ b/src/lib/platformConnections/profiles.ts
@@ -14,7 +14,7 @@ export const PLATFORM_CONNECTIONS: PlatformConnectionDefinition[] = [
     mode: 'oauth',
     requiredKeys: ['WECHAT_APP_ID', 'WECHAT_APP_SECRET'],
     connectionLabel: '公众号授权',
-    connectionHint: '通过授权流程连接公众号后，可减少手动复制凭证。',
+    connectionHint: '微信公众号使用 AppID + AppSecret 直接接入，无需 OAuth 授权。填写凭证后点击「验证连接」确认配置有效。',
   },
   {
     platform: 'xiaohongshu',
@@ -41,7 +41,7 @@ export const PLATFORM_CONNECTIONS: PlatformConnectionDefinition[] = [
       'X_ACCESS_TOKEN_SECRET',
     ],
     connectionLabel: 'X 授权',
-    connectionHint: '通过开发者授权连接账号；手动 API Key 可作为高级配置。',
+    connectionHint: '在 developer.x.com → 你的 App → Keys and Tokens → Access Token and Secret 生成 4 个 key（需开启 Read and Write 权限），填入上方字段后点击「验证连接」。',
   },
 ];
 

--- a/src/lib/publishers/xiaohongshu.ts
+++ b/src/lib/publishers/xiaohongshu.ts
@@ -2,6 +2,50 @@ import { Publisher, PublishInput, PublishOutput } from './types';
 import { getXhsConfig } from '@/lib/config';
 import { markdownToPlainText } from '@/lib/markdown';
 
+// 模块级 token 缓存（参照 wechat.ts 的 cachedToken 模式）
+let cachedXhsToken: { token: string; expiresAt: number } | null = null;
+
+export async function getXhsAccessToken(appId: string, appSecret: string): Promise<string> {
+  // 优先使用手动配置的 access token
+  const { accessToken } = getXhsConfig();
+  if (accessToken) return accessToken;
+
+  // 检查内存缓存是否有效
+  if (cachedXhsToken && Date.now() < cachedXhsToken.expiresAt) {
+    return cachedXhsToken.token;
+  }
+
+  const tokenRes = await fetch(
+    'https://open.xiaohongshu.com/api/oauth/token',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        app_id: appId,
+        app_secret: appSecret,
+        grant_type: 'client_credentials',
+      }),
+    }
+  );
+  const tokenData = await tokenRes.json();
+
+  if (tokenData.code !== 0 && tokenData.code !== 200) {
+    throw new Error(
+      `小红书获取 access_token 失败: ${tokenData.msg || tokenData.message || '未知错误'}`
+    );
+  }
+
+  const token = tokenData.data?.access_token || tokenData.access_token;
+  const expiresIn = tokenData.data?.expires_in || tokenData.expires_in || 7200;
+
+  cachedXhsToken = {
+    token,
+    expiresAt: Date.now() + (expiresIn - 300) * 1000,
+  };
+
+  return token;
+}
+
 export class XiaohongshuPublisher implements Publisher {
   platform = 'xiaohongshu' as const;
 
@@ -21,40 +65,15 @@ export class XiaohongshuPublisher implements Publisher {
       }
 
       const { appId, appSecret } = getXhsConfig();
-      let { accessToken } = getXhsConfig();
+      const accessToken = await getXhsAccessToken(appId, appSecret);
 
-      // Step 1: Get or refresh access token
-      if (!accessToken) {
-        const tokenRes = await fetch(
-          'https://open.xiaohongshu.com/api/oauth/token',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              app_id: appId,
-              app_secret: appSecret,
-              grant_type: 'client_credentials',
-            }),
-          }
-        );
-        const tokenData = await tokenRes.json();
-
-        if (tokenData.code !== 0 && tokenData.code !== 200) {
-          throw new Error(
-            `小红书获取 access_token 失败: ${tokenData.msg || tokenData.message || '未知错误'}`
-          );
-        }
-        accessToken = tokenData.data?.access_token || tokenData.access_token;
-      }
-
-      // Step 2: Convert content to plain text (Xiaohongshu doesn't support rich text)
+      // 转换为纯文本（小红书不支持富文本）
       const plainText = markdownToPlainText(input.markdownContent);
       const truncatedContent =
         plainText.length > 1000
           ? plainText.slice(0, 997) + '...'
           : plainText;
 
-      // Step 3: Create note
       const noteRes = await fetch(
         'https://open.xiaohongshu.com/api/note/publish',
         {
@@ -64,7 +83,7 @@ export class XiaohongshuPublisher implements Publisher {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            title: input.title.slice(0, 20), // Xiaohongshu title limit
+            title: input.title.slice(0, 20),
             content: truncatedContent,
             note_type: 'normal',
             image_ids: [],

--- a/src/lib/storage/envFile.ts
+++ b/src/lib/storage/envFile.ts
@@ -1,0 +1,56 @@
+import { readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+const ENV_FILE = join(process.cwd(), '.env.local');
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed.slice(eqIndex + 1).trim();
+    result[key] = value;
+  }
+  return result;
+}
+
+export function serializeEnvFile(values: Record<string, string>): string {
+  const lines = [
+    '# WeChat Official Account',
+    `WECHAT_APP_ID=${values.WECHAT_APP_ID || ''}`,
+    `WECHAT_APP_SECRET=${values.WECHAT_APP_SECRET || ''}`,
+    '',
+    '# Xiaohongshu (RED)',
+    `XHS_APP_ID=${values.XHS_APP_ID || ''}`,
+    `XHS_APP_SECRET=${values.XHS_APP_SECRET || ''}`,
+    `XHS_ACCESS_TOKEN=${values.XHS_ACCESS_TOKEN || ''}`,
+    '',
+    '# Zhihu',
+    `ZHIHU_COOKIE=${values.ZHIHU_COOKIE || ''}`,
+    '',
+    '# X (Twitter)',
+    `X_API_KEY=${values.X_API_KEY || ''}`,
+    `X_API_SECRET=${values.X_API_SECRET || ''}`,
+    `X_ACCESS_TOKEN=${values.X_ACCESS_TOKEN || ''}`,
+    `X_ACCESS_TOKEN_SECRET=${values.X_ACCESS_TOKEN_SECRET || ''}`,
+  ];
+  return lines.join('\n') + '\n';
+}
+
+export async function readEnvFile(): Promise<Record<string, string>> {
+  try {
+    const content = await readFile(ENV_FILE, 'utf-8');
+    return parseEnvFile(content);
+  } catch {
+    return {};
+  }
+}
+
+export async function writeEnvKey(key: string, value: string): Promise<void> {
+  const existing = await readEnvFile();
+  existing[key] = value;
+  await writeFile(ENV_FILE, serializeEnvFile(existing), 'utf-8');
+}


### PR DESCRIPTION
## Summary

- **Real API probes**: Replace env-var existence checks with live API validation for all four platforms — Wechat (client_credential token), Xiaohongshu (access_token fetch), Zhihu (`GET /api/v4/me` with Cookie), X (`v2.me()`)
- **Xiaohongshu OAuth flow**: Implement full authorization_code flow with CSRF-safe nonce store; GET callback exchanges code for access_token and writes it to `.env.local` automatically
- **Xiaohongshu token cache**: Add module-level cache (matching the existing Wechat pattern) to avoid redundant token fetches on each publish
- **Settings UX**: Wechat/X buttons now trigger connection verification instead of OAuth redirect; Zhihu gains a "test connection" button with Cookie validity/expiry feedback; last-checked metadata and account names shown on page load; `?connected=` param shows post-OAuth success notice

## New files

- `src/lib/storage/envFile.ts` — shared env parse/serialize/write utilities
- `src/lib/platformConnections/oauthNonce.ts` — in-process nonce store (10-min TTL)
- `src/lib/platformConnections/checkers.ts` — per-platform live API probe functions
- `src/app/api/platforms/connection/records/route.ts` — GET endpoint for persisted connection records

## Test plan

- [ ] Wechat: fill AppID + Secret → click "验证连接" → returns success/failure with real API result
- [ ] Xiaohongshu: fill AppID + Secret → click "一键授权" → redirects to XHS OAuth page → callback writes token to `.env.local`
- [ ] Zhihu: paste valid Cookie → click "测试连接" → green badge with account name; expired Cookie → red expiry warning
- [ ] X: fill all 4 keys → click "验证连接" → returns `@username` on success
- [ ] Publish two XHS articles back-to-back without `XHS_ACCESS_TOKEN` set → only one token fetch in server logs