### PR TITLE
refactor: simplify platform preview panel to show config only

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,6 @@ function HomePageContent() {
     platforms,
     platformDrafts,
     syncPlatformDrafts,
-    updatePlatformDraft,
     setTitle,
     setContent,
     reset,
@@ -148,7 +147,6 @@ function HomePageContent() {
         <PlatformPreviewPanel
           adaptations={platformDrafts}
           selectedPlatforms={selectedPlatforms}
-          onUpdate={updatePlatformDraft}
         />
 
         {overallStatus !== 'idle' && (

--- a/src/components/publish/PlatformPreviewPanel.tsx
+++ b/src/components/publish/PlatformPreviewPanel.tsx
@@ -1,6 +1,5 @@
 import type { PlatformId } from '@/types';
 import type {
-  PlatformContentDraft,
   PlatformContentDrafts,
 } from '@/lib/platformAdapters/types';
 import * as styles from './publish.css';
@@ -21,29 +20,24 @@ const formatLabels = {
 interface PlatformPreviewPanelProps {
   adaptations: PlatformContentDrafts;
   selectedPlatforms: PlatformId[];
-  onUpdate?: (
-    platform: PlatformId,
-    input: Partial<Pick<PlatformContentDraft, 'title' | 'body' | 'suggestedTags' | 'threadParts'>>,
-  ) => void;
 }
 
 function createExcerpt(value: string) {
   const plain = value.replace(/\s+/g, ' ').trim();
-  return plain.length > 120 ? `${plain.slice(0, 120)}...` : plain;
+  return plain.length > 80 ? `${plain.slice(0, 80)}…` : plain;
 }
 
 export default function PlatformPreviewPanel({
   adaptations,
   selectedPlatforms,
-  onUpdate,
 }: PlatformPreviewPanelProps) {
   if (selectedPlatforms.length === 0) return null;
 
   return (
     <section className={styles.previewPanel}>
       <div className={styles.previewHeader}>
-        <p className={styles.panelKicker}>Platform preview</p>
-        <h2 className={styles.previewTitle}>分发前预览</h2>
+        <p className={styles.panelKicker}>Platform config</p>
+        <h2 className={styles.previewTitle}>发布配置</h2>
       </div>
 
       <div className={styles.previewGrid}>
@@ -51,29 +45,20 @@ export default function PlatformPreviewPanel({
           const draft = adaptations[platform];
           return (
             <article key={platform} className={styles.previewCard}>
+              {/* 平台名 + 状态 */}
               <div className={styles.previewMeta}>
                 <p className={styles.previewPlatform}>{platformLabels[platform]}</p>
                 <span className={`${styles.previewState} ${draft.isReady ? '' : styles.previewStateNotReady}`}>
                   {draft.isReady ? '可发布' : '待补全'} · {formatLabels[draft.format]}
                 </span>
               </div>
-              <label className={styles.previewField}>
-                <span className={styles.previewLabel}>{platformLabels[platform]}标题</span>
-                <input
-                  className={styles.previewInput}
-                  value={draft.title}
-                  onChange={(event) => onUpdate?.(platform, { title: event.target.value })}
-                />
-              </label>
-              <label className={styles.previewField}>
-                <span className={styles.previewLabel}>{platformLabels[platform]}正文</span>
-                <textarea
-                  className={styles.previewTextarea}
-                  value={draft.body}
-                  onChange={(event) => onUpdate?.(platform, { body: event.target.value })}
-                />
-              </label>
-              <p className={styles.previewBody}>{createExcerpt(draft.body)}</p>
+
+              {/* 内容摘要（只读，帮助用户确认内容） */}
+              {draft.body ? (
+                <p className={styles.previewBody}>{createExcerpt(draft.body)}</p>
+              ) : null}
+
+              {/* Warnings */}
               {draft.warnings.length > 0 ? (
                 <ul className={styles.previewWarningList}>
                   {draft.warnings.map((warning) => (
@@ -81,6 +66,8 @@ export default function PlatformPreviewPanel({
                   ))}
                 </ul>
               ) : null}
+
+              {/* 小红书：话题标签 */}
               {draft.suggestedTags.length > 0 ? (
                 <div className={styles.previewTagList}>
                   {draft.suggestedTags.map((tag) => (
@@ -88,10 +75,12 @@ export default function PlatformPreviewPanel({
                   ))}
                 </div>
               ) : null}
-              {draft.threadParts.length > 0 ? (
+
+              {/* X：Thread 分段预览 */}
+              {draft.threadParts.length > 1 ? (
                 <ol className={styles.previewThreadList}>
                   {draft.threadParts.map((part, index) => (
-                    <li key={`${index}-${part}`}>{`${index + 1}. ${part}`}</li>
+                    <li key={`${index}-${part.slice(0, 20)}`}>{`${index + 1}. ${part}`}</li>
                   ))}
                 </ol>
               ) : null}

--- a/src/components/publish/__tests__/PlatformPreviewPanel.test.tsx
+++ b/src/components/publish/__tests__/PlatformPreviewPanel.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, test, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 
 import type { PlatformContentDrafts } from '@/lib/platformAdapters/types';
@@ -14,10 +14,7 @@ vi.mock('@/components/publish/publish.css', () => ({
   previewMeta: 'previewMeta',
   previewPlatform: 'previewPlatform',
   previewState: 'previewState',
-  previewField: 'previewField',
-  previewLabel: 'previewLabel',
-  previewInput: 'previewInput',
-  previewTextarea: 'previewTextarea',
+  previewStateNotReady: 'previewStateNotReady',
   previewBody: 'previewBody',
   previewWarningList: 'previewWarningList',
   previewTagList: 'previewTagList',
@@ -72,87 +69,18 @@ describe('PlatformPreviewPanel', () => {
       },
     };
 
-    const onUpdate = vi.fn();
-
     render(createElement(PlatformPreviewPanel, {
       adaptations,
       selectedPlatforms: ['xiaohongshu', 'x'],
-      onUpdate,
     }));
 
-    expect(screen.getByText('分发前预览')).toBeInTheDocument();
+    expect(screen.getByText('发布配置')).toBeInTheDocument();
     expect(screen.getByText('小红书')).toBeInTheDocument();
     expect(screen.getByText('小红书标题建议控制在 20 字以内')).toBeInTheDocument();
-    expect(screen.getByText('#AI')).toBeInTheDocument();
     expect(screen.getByText('X (Twitter)')).toBeInTheDocument();
     expect(screen.getByText('X 内容已自动拆分为 thread')).toBeInTheDocument();
     expect(screen.getByText('1. 第一条')).toBeInTheDocument();
     expect(screen.getByText('2. 第二条')).toBeInTheDocument();
     expect(screen.queryByText('微信公众号')).not.toBeInTheDocument();
-  });
-
-  test('emits platform-level title and body edits', async () => {
-    const { default: PlatformPreviewPanel } = await import(
-      '@/components/publish/PlatformPreviewPanel'
-    );
-    const adaptations: PlatformContentDrafts = {
-      wechat: {
-        platform: 'wechat',
-        title: '公众号标题',
-        body: '公众号正文',
-        format: 'article',
-        isReady: true,
-        warnings: [],
-        threadParts: [],
-        suggestedTags: [],
-      },
-      xiaohongshu: {
-        platform: 'xiaohongshu',
-        title: '',
-        body: '',
-        format: 'note',
-        isReady: false,
-        warnings: [],
-        threadParts: [],
-        suggestedTags: [],
-      },
-      zhihu: {
-        platform: 'zhihu',
-        title: '',
-        body: '',
-        format: 'article',
-        isReady: false,
-        warnings: [],
-        threadParts: [],
-        suggestedTags: [],
-      },
-      x: {
-        platform: 'x',
-        title: '',
-        body: '',
-        format: 'thread',
-        isReady: false,
-        warnings: [],
-        threadParts: [],
-        suggestedTags: [],
-      },
-    };
-    const onUpdate = vi.fn();
-
-    render(createElement(PlatformPreviewPanel, {
-      adaptations,
-      selectedPlatforms: ['wechat'],
-      onUpdate,
-    }));
-
-    fireEvent.change(screen.getByLabelText('微信公众号标题'), {
-      target: { value: '新的公众号标题' },
-    });
-    fireEvent.change(screen.getByLabelText('微信公众号正文'), {
-      target: { value: '新的公众号正文' },
-    });
-
-    expect(onUpdate).toHaveBeenCalledWith('wechat', { title: '新的公众号标题' });
-    expect(onUpdate).toHaveBeenCalledWith('wechat', { body: '新的公众号正文' });
   });
 });

--- a/src/components/publish/__tests__/PublishButton.test.tsx
+++ b/src/components/publish/__tests__/PublishButton.test.tsx
@@ -27,10 +27,6 @@ describe('PublishButton', () => {
     usePublishStore.getState().setTitle('通用标题');
     usePublishStore.getState().setContent('通用正文');
     usePublishStore.getState().syncPlatformDrafts();
-    usePublishStore.getState().updatePlatformDraft('wechat', {
-      title: '公众号标题',
-      body: '公众号正文',
-    });
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -50,8 +46,8 @@ describe('PublishButton', () => {
     const payload = JSON.parse(init.body as string);
 
     expect(payload.platformDrafts.wechat).toMatchObject({
-      title: '公众号标题',
-      content: '公众号正文',
+      title: '通用标题',
+      content: '通用正文',
     });
     expect(payload.platformDrafts.x).toMatchObject({
       title: '通用标题',

--- a/src/components/publish/publish.css.ts
+++ b/src/components/publish/publish.css.ts
@@ -428,48 +428,6 @@ export const previewStateNotReady = style({
   color: vars.color.errorText,
 });
 
-export const previewField = style({
-  display: 'grid',
-  gap: '6px',
-});
-
-export const previewLabel = style({
-  color: vars.color.textMuted,
-  fontSize: '12px',
-  fontWeight: 600,
-});
-
-export const previewInput = style({
-  width: '100%',
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
-  padding: '9px 10px',
-  color: vars.color.text,
-  fontSize: '13px',
-  outline: 'none',
-  ':focus': {
-    borderColor: vars.color.borderStrong,
-  },
-});
-
-export const previewTextarea = style({
-  width: '100%',
-  minHeight: '120px',
-  resize: 'vertical',
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
-  padding: '9px 10px',
-  color: vars.color.text,
-  fontSize: '13px',
-  lineHeight: 1.7,
-  outline: 'none',
-  ':focus': {
-    borderColor: vars.color.borderStrong,
-  },
-});
-
 export const previewBody = style({
   margin: 0,
   minHeight: '48px',

--- a/src/stores/__tests__/publishStore.test.ts
+++ b/src/stores/__tests__/publishStore.test.ts
@@ -28,23 +28,5 @@ describe('publishStore platform drafts', () => {
     });
   });
 
-  test('supports platform-level draft edits without changing shared content', () => {
-    usePublishStore.getState().setTitle('通用标题');
-    usePublishStore.getState().setContent('通用正文');
-    usePublishStore.getState().syncPlatformDrafts();
 
-    usePublishStore.getState().updatePlatformDraft('xiaohongshu', {
-      title: '小红书标题',
-      body: '小红书正文',
-      suggestedTags: ['AI', '选题'],
-    });
-
-    expect(usePublishStore.getState().title).toBe('通用标题');
-    expect(usePublishStore.getState().content).toBe('通用正文');
-    expect(usePublishStore.getState().platformDrafts.xiaohongshu).toMatchObject({
-      title: '小红书标题',
-      body: '小红书正文',
-      suggestedTags: ['AI', '选题'],
-    });
-  });
 });

--- a/src/stores/publishStore.ts
+++ b/src/stores/publishStore.ts
@@ -2,7 +2,6 @@ import { create } from 'zustand';
 import { PlatformId, PlatformPublishResult, PLATFORMS, PublishStatus } from '@/types';
 import { adaptContentForPlatforms } from '@/lib/platformAdapters/adaptContent';
 import type {
-  PlatformContentDraft,
   PlatformContentDrafts,
 } from '@/lib/platformAdapters/types';
 import { resolveOverallPublishStatus } from '@/lib/publishStatus';
@@ -18,10 +17,6 @@ interface PublishStore {
 
   platformDrafts: PlatformContentDrafts;
   syncPlatformDrafts: () => void;
-  updatePlatformDraft: (
-    platform: PlatformId,
-    input: Partial<Pick<PlatformContentDraft, 'title' | 'body' | 'suggestedTags' | 'threadParts'>>,
-  ) => void;
 
   overallStatus: PublishStatus;
   results: PlatformPublishResult[];
@@ -62,16 +57,6 @@ export const usePublishStore = create<PublishStore>((set) => ({
         content: state.content,
         platforms: platformIds,
       }),
-    })),
-  updatePlatformDraft: (platform, input) =>
-    set((state) => ({
-      platformDrafts: {
-        ...state.platformDrafts,
-        [platform]: {
-          ...state.platformDrafts[platform],
-          ...input,
-        },
-      },
     })),
 
   overallStatus: 'idle',


### PR DESCRIPTION
## Summary

- 移除 `PlatformPreviewPanel` 中重复的标题/正文编辑框，下方面板不再是第二个编辑区
- 每张平台卡片只展示平台独有内容：warnings、小红书话题标签、X thread 分段预览，以及一行只读内容摘要
- 从 store 删除 `updatePlatformDraft`（职责消失，方法无需保留）
- 清理 `publish.css.ts` 中四个废弃样式 token（`previewField` / `previewLabel` / `previewInput` / `previewTextarea`）

## 背景

原设计中主编辑区之外还有各平台的可编辑标题和正文，两处均可修改内容，造成职责模糊。
重构后职责明确：**主编辑区 = 写稿，下方面板 = 发布配置**。

## Test plan

- [ ] 写作台正常加载，样式无异常
- [ ] 选中/取消平台后，发布配置卡片正确显示/隐藏
- [ ] 小红书卡片显示话题标签
- [ ] X 内容超长时卡片显示 thread 分段预览
- [ ] warnings 在内容为空时正常提示
- [ ] 发布流程不受影响