### PR TITLE
feat: draft management, AI news enrichment and draft library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 - **Markdown 写作台** — 桌面端使用 MDEditor 富编辑器，移动端降级为原生 textarea，底部实时显示字符数、段落数、标题层级与预计阅读时长
 - **成稿预览** — 切换到预览 tab 可查看接近公众号排版的最终效果，标题、h2/h3、引用块、行内代码均有独立样式
 - **Editorial context 卡片** — 标题写入状态、结构统计四格、可发布建议，始终与编辑器共存
-- **草稿库** — 持久化存储所有草稿（来源：手动创建 / AI 选题转稿 / 导入），支持状态跟踪（draft → ready → synced），可从写作台一键保存或从草稿库继续编辑
-- **AI 选题工作台** — 手动触发抓取，从 9 个 RSS 数据源拉取 24 小时内容，经标准化 → 聚类 → 多维评分后输出最多 10 条候选题，每条附带研究底稿（事件经过、重要性、影响方、写作切口建议）
-- **一键转稿** — 从工作台直接将研究底稿导入写作台，继续润色后发布
+- **草稿库** — 持久化存储所有草稿（来源：手动创建 / AI 选题转稿 / 导入），支持状态跟踪（draft → ready → synced）；稿件库页（`/drafts`）以「来源 → 写作台 → 分发」pipeline 行展示全部稿件，支持多选批量删除；写作台侧边草稿面板可快速切换草稿，同样支持编辑模式删除
+- **AI 选题工作台** — 手动触发抓取，从 9 个 RSS 数据源拉取 24 小时内容，经标准化 → 聚类 → 多维评分后输出最多 10 条候选题；每条附带研究底稿（事件经过、重要性、影响方、写作切口建议），底稿内嵌原文多张配图及其他来源报道视角
+- **一键转稿** — 从工作台直接将研究底稿导入写作台，底稿携带多图和多方视角，继续润色后发布；写作台支持「清空」一键重置编辑器
 - **多平台并发发布** — 基于 `Promise.allSettled` 并发执行，支持微信公众号、小红书、知乎、X (Twitter) 四大平台
 - **同步任务追踪** — 每次发布生成一条同步任务记录，包含各平台进度回执、失败原因、下一步建议（重新授权 / 修复内容 / 打开平台等）；支持重试与手动标记完成
 - **平台连接管理** — 设置页统一管理各平台凭证；OAuth 平台支持一键授权跳转，微信 / X 支持凭证验证；连接状态持久化，展示上次验证时间与账号信息
@@ -39,7 +39,9 @@ src/
 │   ├── layout.tsx / layout.css.ts       # 根布局（侧边栏 + 主内容区）
 │   ├── page.tsx / page.css.ts           # 写作台：编辑器 + 平台选择 + 发布
 │   ├── drafts/
-│   │   └── page.tsx / page.css.ts       # 草稿库页
+│   │   ├── page.tsx                     # 稿件库页（metadata + 入口）
+│   │   ├── DraftsPageClient.tsx         # 稿件库客户端（编辑模式状态）
+│   │   └── drafts.page.css.ts           # 稿件库页样式
 │   ├── ai-news/
 │   │   ├── page.tsx                     # 选题工作台页（SSR metadata）
 │   │   └── error.tsx / error.css.ts     # 错误边界
@@ -72,8 +74,9 @@ src/
 │   │   └── PageSection.tsx / PageSection.css.ts
 │   ├── editor/
 │   │   ├── MarkdownEditor.tsx / editor.css.ts   # MDEditor + 预览区
+│   │   ├── DraftPanel.tsx / DraftPanel.css.ts   # 右侧草稿面板（含编辑模式）
 │   │   ├── EditorialContextCard.tsx             # 编辑上下文卡片
-│   │   └── RecentDraftBar.tsx                   # 最近草稿快速入口
+│   │   └── RecentDraftBar.tsx                   # 最近草稿快速入口（移动端）
 │   ├── drafts/
 │   │   └── DraftLibraryClient.tsx / drafts.css.ts
 │   ├── news/

--- a/src/app/drafts/DraftsPageClient.tsx
+++ b/src/app/drafts/DraftsPageClient.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Pencil, Plus } from 'lucide-react';
+import AppShellHeader from '@/components/layout/AppShellHeader';
+import DraftLibraryClient from '@/components/drafts/DraftLibraryClient';
+import * as styles from './drafts.page.css';
+
+export default function DraftsPageClient() {
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  return (
+    <div className={styles.pageWrap}>
+      <AppShellHeader
+        kicker="Draft library"
+        title="稿件库"
+        description="管理所有草稿，追踪从选题到分发的完整链路。"
+        action={
+          <div className={styles.headerActions}>
+            {isEditMode ? (
+              <button
+                type="button"
+                className={styles.editCancelButton}
+                onClick={() => setIsEditMode(false)}
+              >
+                取消编辑
+              </button>
+            ) : (
+              <>
+                <Link href="/" className={styles.newDraftLink}>
+                  <Plus size={14} />
+                  新建稿件
+                </Link>
+                <button
+                  type="button"
+                  className={styles.editToggleButton}
+                  onClick={() => setIsEditMode(true)}
+                >
+                  <Pencil size={14} />
+                  编辑
+                </button>
+              </>
+            )}
+          </div>
+        }
+      />
+      <DraftLibraryClient
+        isEditMode={isEditMode}
+        onExitEditMode={() => setIsEditMode(false)}
+      />
+    </div>
+  );
+}

--- a/src/app/drafts/drafts.page.css.ts
+++ b/src/app/drafts/drafts.page.css.ts
@@ -1,0 +1,62 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+export const pageWrap = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+});
+
+export const headerActions = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+export const newDraftLink = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  background: vars.color.accent,
+  padding: '8px 14px',
+  fontSize: '14px',
+  fontWeight: 500,
+  color: '#ffffff',
+  textDecoration: 'none',
+  transition: 'opacity 150ms',
+  ':hover': {
+    opacity: 0.9,
+  },
+});
+
+export const editToggleButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '8px 14px',
+  fontSize: '14px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'color 150ms, border-color 150ms',
+  ':hover': {
+    color: vars.color.text,
+    borderColor: vars.color.borderStrong,
+  },
+});
+
+export const editCancelButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.accentSoft,
+  padding: '8px 14px',
+  fontSize: '14px',
+  color: vars.color.accent,
+  cursor: 'pointer',
+});

--- a/src/app/drafts/page.tsx
+++ b/src/app/drafts/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import DraftsPageClient from './DraftsPageClient';
+
+export const metadata: Metadata = {
+  title: '稿件库 | Publio',
+  description: '管理所有草稿，查看分发进展。',
+};
+
+export default function DraftsPage() {
+  return <DraftsPageClient />;
+}

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -132,6 +132,25 @@ export const headerActions = style({
   gap: '8px',
 });
 
+export const newDraftButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '6px 10px',
+  fontSize: '14px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'background-color 150ms, color 150ms, border-color 150ms',
+  ':hover': {
+    background: vars.color.canvasDeep,
+    color: vars.color.text,
+    borderColor: vars.color.borderStrong,
+  },
+});
+
 // 面板切换按钮，仅桌面端显示（带文字标签，避免与复制按钮混淆）
 export const panelToggle = recipe({
   base: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Eye, Files, SquarePen } from 'lucide-react';
+import { Eye, Files, SquarePen, Eraser } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import MarkdownEditor from '@/components/editor/MarkdownEditor';
@@ -126,6 +126,15 @@ function HomePageContent() {
             </div>
             <button
               type="button"
+              onClick={handleNewDraft}
+              className={styles.newDraftButton}
+              title="清空写作台"
+            >
+              <Eraser size={15} />
+              清空
+            </button>
+            <button
+              type="button"
               onClick={() => setIsPanelOpen((v) => !v)}
               className={styles.panelToggle({ active: isPanelOpen })}
               title={isPanelOpen ? '收起草稿' : '展开草稿'}
@@ -138,13 +147,6 @@ function HomePageContent() {
       />
 
       <div className={styles.editorLayout}>
-        <div
-          className={styles.panelOuter}
-          style={{ width: isPanelOpen ? '216px' : 0 }}
-        >
-          <DraftPanel onNewDraft={handleNewDraft} />
-        </div>
-
         <div className={styles.editorSection}>
           {draftLoadError ? (
             <div className={styles.draftLoadError} role="status">
@@ -183,6 +185,13 @@ function HomePageContent() {
           {overallStatus !== 'idle' && (
             <PublishStatusPanel />
           )}
+        </div>
+
+        <div
+          className={styles.panelOuter}
+          style={{ width: isPanelOpen ? '216px' : 0 }}
+        >
+          <DraftPanel onNewDraft={handleNewDraft} />
         </div>
       </div>
     </div>

--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowRight, FileText, RefreshCcw, Newspaper, PenLine, ArrowRightCircle } from 'lucide-react';
+import { FileText, RefreshCcw, Newspaper, PenLine, ArrowRightCircle, Trash2 } from 'lucide-react';
 import type { ContentDraft, DraftSource, DraftStatus } from '@/lib/drafts/types';
 import type { SyncTask, SyncTaskStatus } from '@/lib/sync/types';
+import { deleteDraft } from '@/lib/drafts/client';
 import * as styles from './drafts.css';
 
 interface DraftsResponse {
@@ -50,16 +51,26 @@ function formatDraftTime(value: string) {
   }).format(timestamp);
 }
 
-function createExcerpt(content: string) {
-  const plain = content.replace(/\s+/g, ' ').trim();
-  return plain.length > 96 ? `${plain.slice(0, 96)}...` : plain;
+interface Props {
+  isEditMode: boolean;
+  onExitEditMode: () => void;
 }
 
-export default function DraftLibraryClient() {
+export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props) {
   const [drafts, setDrafts] = useState<ContentDraft[]>([]);
   const [syncTasks, setSyncTasks] = useState<SyncTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setSelected(new Set());
+      setDeleteError('');
+    }
+  }, [isEditMode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,6 +114,33 @@ export default function DraftLibraryClient() {
     };
   }, []);
 
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  async function handleDeleteSelected() {
+    if (selected.size === 0 || deleting) return;
+    setDeleting(true);
+    setDeleteError('');
+    try {
+      await Promise.all(Array.from(selected).map((id) => deleteDraft(id)));
+      setDrafts((prev) => prev.filter((d) => !selected.has(d.id)));
+      onExitEditMode();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : '删除失败，请稍后重试。');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
   if (loading) {
     return (
       <div className={styles.statePanel}>
@@ -132,132 +170,151 @@ export default function DraftLibraryClient() {
           从写作台新建内容，或从选题台把研究底稿加入稿件库。
         </p>
         <Link href="/" className={styles.primaryLink}>
-          新建稿件
-          <ArrowRight size={15} />
+          去写作台
         </Link>
       </div>
     );
   }
 
-  const aiNewsDrafts = drafts.filter((d) => d.source === 'ai-news');
-
   return (
     <div className={styles.pageContent}>
-      {aiNewsDrafts.length > 0 && (
-        <section className={styles.pipelineSection}>
-          <h2 className={styles.pipelineSectionTitle}>
-            内容链路
-          </h2>
-          <p className={styles.pipelineSectionDesc}>
-            从 AI 选题台生成的稿件及其分发进展。
-          </p>
-          <div className={styles.pipelineList}>
-            {aiNewsDrafts.map((draft) => {
-              const syncTask = syncTasks.find((t) => t.draftId === draft.id);
-              return (
-                <div key={draft.id} className={styles.pipelineRow}>
-                  <div className={styles.pipelineStep}>
-                    <span className={styles.pipelineStepIcon}>
-                      <Newspaper size={14} />
-                    </span>
-                    <div className={styles.pipelineStepContent}>
-                      <span className={styles.pipelineStepLabel}>选题台</span>
-                      <Link href="/ai-news" className={styles.pipelineStepLink}>
-                        重新选题
-                      </Link>
-                    </div>
-                  </div>
-                  <ArrowRightCircle size={14} className={styles.pipelineArrow} />
-                  <div className={styles.pipelineStep}>
-                    <span className={styles.pipelineStepIcon}>
-                      <PenLine size={14} />
-                    </span>
-                    <div className={styles.pipelineStepContent}>
-                      <span className={styles.pipelineStepLabel} title={draft.title}>
-                        {draft.title.length > 24 ? `${draft.title.slice(0, 24)}…` : draft.title}
-                      </span>
-                      <Link href={`/?draftId=${draft.id}`} className={styles.pipelineStepLink}>
-                        {statusLabels[draft.status]}，去编辑
-                      </Link>
-                    </div>
-                  </div>
-                  <ArrowRightCircle size={14} className={styles.pipelineArrow} />
-                  <div className={styles.pipelineStep}>
-                    <span className={styles.pipelineStepIcon}>
-                      <FileText size={14} />
-                    </span>
-                    <div className={styles.pipelineStepContent}>
-                      {syncTask ? (
-                        <>
-                          <span className={styles.pipelineStepLabel}>
-                            {syncStatusLabels[syncTask.status]}
-                          </span>
-                          <Link
-                            href={`/sync-tasks/${syncTask.id}`}
-                            className={styles.pipelineStepLink}
-                          >
-                            查看详情
-                          </Link>
-                        </>
-                      ) : (
-                        <span className={styles.pipelineStepLabel}>尚未分发</span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+      {isEditMode && (
+        <div className={styles.editModeBar}>
+          <div className={styles.editModeBarLeft}>
+            <span className={styles.editModeCount}>已选 {selected.size} 篇</span>
+            {deleteError ? (
+              <span className={styles.deleteErrorText}>{deleteError}</span>
+            ) : null}
           </div>
-        </section>
+          <div className={styles.editModeBarRight}>
+            <button
+              type="button"
+              className={styles.editModeCancelButton}
+              onClick={onExitEditMode}
+              disabled={deleting}
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              className={styles.editModeDeleteButton}
+              onClick={() => void handleDeleteSelected()}
+              disabled={selected.size === 0 || deleting}
+            >
+              <Trash2 size={13} />
+              {deleting ? '删除中...' : `删除${selected.size > 0 ? `(${selected.size})` : ''}`}
+            </button>
+          </div>
+        </div>
       )}
 
-      <div className={styles.draftList}>
+      <div className={styles.pipelineList}>
         {drafts.map((draft) => {
-          const latestSyncTask = syncTasks.find((task) => task.draftId === draft.id);
+          const syncTask = syncTasks.find((t) => t.draftId === draft.id);
+          const isSelected = selected.has(draft.id);
 
           return (
-            <article key={draft.id} className={styles.draftCard}>
-              <div className={styles.draftMetaRow}>
-                <span className={styles.statusBadge}>{statusLabels[draft.status]}</span>
-                <span className={styles.sourceBadge}>{sourceLabels[draft.source]}</span>
-                <time className={styles.updatedTime} dateTime={draft.updatedAt}>
-                  {formatDraftTime(draft.updatedAt)}
-                </time>
-              </div>
+            <div
+              key={draft.id}
+              className={
+                isEditMode
+                  ? styles.pipelineRowSelectable({ selected: isSelected })
+                  : styles.pipelineCard
+              }
+              onClick={isEditMode ? () => toggleSelect(draft.id) : undefined}
+              role={isEditMode ? 'checkbox' : undefined}
+              aria-checked={isEditMode ? isSelected : undefined}
+              tabIndex={isEditMode ? 0 : undefined}
+              onKeyDown={isEditMode ? (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                  e.preventDefault();
+                  toggleSelect(draft.id);
+                }
+              } : undefined}
+            >
+              {isEditMode && (
+                <input
+                  type="checkbox"
+                  className={styles.draftCardCheckbox}
+                  checked={isSelected}
+                  onChange={() => toggleSelect(draft.id)}
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label={`选择稿件 ${draft.title}`}
+                />
+              )}
 
-              <div>
-                <h2 className={styles.draftTitle}>{draft.title}</h2>
-                <p className={styles.draftExcerpt}>{createExcerpt(draft.content)}</p>
-                {latestSyncTask ? (
-                  <div className={styles.syncSummary}>
-                    <p className={styles.syncTitle}>
-                      最近分发：{syncStatusLabels[latestSyncTask.status]}
-                    </p>
-                    <p className={styles.syncText}>
-                      {latestSyncTask.receipts.length} 个平台，更新于 {formatDraftTime(latestSyncTask.updatedAt)}
-                    </p>
+              <div className={styles.pipelineStep}>
+                <span className={styles.pipelineStepIcon}>
+                  <Newspaper size={14} />
+                </span>
+                <div className={styles.pipelineStepContent}>
+                  <span className={styles.pipelineStepLabel}>
+                    {sourceLabels[draft.source]}
+                  </span>
+                  {draft.source === 'ai-news' && (
                     <Link
-                      href={`/sync-tasks/${latestSyncTask.id}`}
-                      className={styles.syncDetailLink}
+                      href="/ai-news"
+                      className={styles.pipelineStepLink}
+                      onClick={(e) => e.stopPropagation()}
                     >
-                      查看分发详情
+                      重新选题
                     </Link>
-                  </div>
-                ) : null}
+                  )}
+                </div>
               </div>
 
-              <Link
-                href={`/?draftId=${draft.id}`}
-                className={styles.editLink}
-                aria-label={`继续编辑 ${draft.title}`}
-              >
-                继续编辑
-                <ArrowRight size={15} />
-              </Link>
-            </article>
+              <ArrowRightCircle size={14} className={styles.pipelineArrow} />
+
+              <div className={styles.pipelineStep}>
+                <span className={styles.pipelineStepIcon}>
+                  <PenLine size={14} />
+                </span>
+                <div className={styles.pipelineStepContent}>
+                  <span className={styles.pipelineStepLabel} title={draft.title}>
+                    {draft.title.length > 24 ? `${draft.title.slice(0, 24)}…` : draft.title}
+                  </span>
+                  <Link
+                    href={`/?draftId=${draft.id}`}
+                    className={styles.pipelineStepLink}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {statusLabels[draft.status]}，去编辑
+                  </Link>
+                </div>
+              </div>
+
+              <ArrowRightCircle size={14} className={styles.pipelineArrow} />
+
+              <div className={styles.pipelineStep}>
+                <span className={styles.pipelineStepIcon}>
+                  <FileText size={14} />
+                </span>
+                <div className={styles.pipelineStepContent}>
+                  {syncTask ? (
+                    <>
+                      <span className={styles.pipelineStepLabel}>
+                        {syncStatusLabels[syncTask.status]}
+                      </span>
+                      <Link
+                        href={`/sync-tasks/${syncTask.id}`}
+                        className={styles.pipelineStepLink}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        查看详情
+                      </Link>
+                    </>
+                  ) : (
+                    <span className={styles.pipelineStepLabel}>尚未分发</span>
+                  )}
+                </div>
+              </div>
+            </div>
           );
         })}
       </div>
     </div>
   );
 }
+
+// suppress unused import warning – formatDraftTime kept for future use
+void formatDraftTime;

--- a/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
+++ b/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
@@ -34,6 +34,19 @@ vi.mock('@/components/drafts/drafts.css', () => ({
   pipelineStepLabel: 'pipelineStepLabel',
   pipelineStepLink: 'pipelineStepLink',
   pipelineArrow: 'pipelineArrow',
+  pipelineCard: 'pipelineCard',
+  pipelineRowSelectable: (variants: { selected?: boolean }) =>
+    variants?.selected ? 'pipelineRowSelectable-selected' : 'pipelineRowSelectable',
+  editModeBar: 'editModeBar',
+  editModeBarLeft: 'editModeBarLeft',
+  editModeBarRight: 'editModeBarRight',
+  editModeCount: 'editModeCount',
+  editModeDeleteButton: 'editModeDeleteButton',
+  editModeCancelButton: 'editModeCancelButton',
+  draftCardCheckbox: 'draftCardCheckbox',
+  deleteErrorText: 'deleteErrorText',
+  listHeader: 'listHeader',
+  editToggleButton: 'editToggleButton',
 }));
 
 describe('DraftLibraryClient', () => {
@@ -83,23 +96,25 @@ describe('DraftLibraryClient', () => {
       })),
     );
 
-    render(createElement(DraftLibraryClient));
+    render(createElement(DraftLibraryClient, { isEditMode: false, onExitEditMode: vi.fn() }));
 
-    // Title appears in both the pipeline section and the draft card
+    // Title appears in the pipeline step label
     await waitFor(() => {
       expect(screen.getAllByText('AI 话题稿件').length).toBeGreaterThan(0);
     });
-    expect(screen.getByText('待同步')).toBeInTheDocument();
+    // Status label for 'ready' draft
+    expect(screen.getByText('待同步，去编辑')).toBeInTheDocument();
+    // Source label for 'ai-news'
     expect(screen.getByText('AI 选题')).toBeInTheDocument();
-    expect(screen.getByText('最近分发：部分完成')).toBeInTheDocument();
-    expect(screen.getByText((_, node) => (
-      node?.textContent?.startsWith('2 个平台，更新于 2026年4月11日') === true
-    ))).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: '查看分发详情' })).toHaveAttribute(
+    // Sync task status label for 'partial'
+    expect(screen.getByText('部分完成')).toBeInTheDocument();
+    // Link to sync task detail
+    expect(screen.getByRole('link', { name: '查看详情' })).toHaveAttribute(
       'href',
       '/sync-tasks/sync-1',
     );
-    expect(screen.getByRole('link', { name: '继续编辑 AI 话题稿件' })).toHaveAttribute(
+    // Link to edit draft
+    expect(screen.getByRole('link', { name: '待同步，去编辑' })).toHaveAttribute(
       'href',
       '/?draftId=draft-1',
     );
@@ -117,7 +132,7 @@ describe('DraftLibraryClient', () => {
       }),
     );
 
-    render(createElement(DraftLibraryClient));
+    render(createElement(DraftLibraryClient, { isEditMode: false, onExitEditMode: vi.fn() }));
 
     await waitFor(() => {
       expect(screen.getByText('还没有稿件')).toBeInTheDocument();

--- a/src/components/drafts/drafts.css.ts
+++ b/src/components/drafts/drafts.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/styles/tokens.css';
 
 export const draftList = style({
@@ -286,4 +287,200 @@ export const pipelineStepLink = style({
 export const pipelineArrow = style({
   color: vars.color.textMuted,
   flexShrink: 0,
+});
+
+export const deleteErrorText = style({
+  fontSize: '13px',
+  color: vars.color.errorText,
+});
+
+// Pipeline card (normal mode)
+export const pipelineCard = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  flexWrap: 'wrap',
+  padding: '4px 0',
+});
+
+// Pipeline card (edit/selectable mode)
+export const pipelineRowSelectable = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    flexWrap: 'wrap',
+    borderRadius: vars.radius.lg,
+    padding: '4px 6px',
+    cursor: 'pointer',
+    transition: 'background-color 150ms',
+  },
+  variants: {
+    selected: {
+      true: {
+        background: vars.color.accentSoft,
+      },
+      false: {
+        ':hover': {
+          background: 'rgba(0,0,0,0.03)',
+        },
+      },
+    },
+  },
+  defaultVariants: { selected: false },
+});
+
+// Edit mode toolbar
+export const editModeBar = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '12px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.bgElevated,
+  padding: '10px 14px',
+});
+
+export const editModeBarLeft = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+});
+
+export const editModeBarRight = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+export const editModeCount = style({
+  fontSize: '13px',
+  color: vars.color.textMuted,
+});
+
+export const editModeDeleteButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.errorBorder}`,
+  background: vars.color.errorBg,
+  padding: '6px 12px',
+  fontSize: '13px',
+  fontWeight: 500,
+  color: vars.color.errorText,
+  cursor: 'pointer',
+  transition: 'opacity 150ms',
+  selectors: {
+    '&:disabled': {
+      opacity: 0.4,
+      cursor: 'not-allowed',
+    },
+  },
+});
+
+export const editModeCancelButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '6px 12px',
+  fontSize: '13px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'color 150ms, border-color 150ms',
+  ':hover': {
+    color: vars.color.text,
+    borderColor: vars.color.borderStrong,
+  },
+});
+
+export const draftCardSelectable = recipe({
+  base: {
+    display: 'grid',
+    gap: '18px',
+    borderRadius: vars.radius.xl,
+    border: `1px solid ${vars.color.border}`,
+    background: vars.color.surface,
+    padding: '18px',
+    cursor: 'pointer',
+    transition: 'border-color 150ms, background-color 150ms',
+    '@media': {
+      'screen and (min-width: 760px)': {
+        gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+        alignItems: 'center',
+      },
+    },
+  },
+  variants: {
+    selected: {
+      true: {
+        borderColor: vars.color.accent,
+        background: vars.color.accentSoft,
+      },
+      false: {
+        ':hover': {
+          borderColor: vars.color.borderStrong,
+        },
+      },
+    },
+  },
+  defaultVariants: { selected: false },
+});
+
+export const draftCardCheckbox = style({
+  flexShrink: 0,
+  width: '18px',
+  height: '18px',
+  borderRadius: '4px',
+  border: `2px solid ${vars.color.borderStrong}`,
+  background: vars.color.bgElevated,
+  appearance: 'none',
+  cursor: 'pointer',
+  position: 'relative',
+  selectors: {
+    '&:checked': {
+      background: vars.color.accent,
+      borderColor: vars.color.accent,
+    },
+    '&:checked::after': {
+      content: '""',
+      position: 'absolute',
+      left: '3px',
+      top: '1px',
+      width: '8px',
+      height: '5px',
+      borderLeft: `2px solid #ffffff`,
+      borderBottom: `2px solid #ffffff`,
+      transform: 'rotate(-45deg)',
+    },
+  },
+});
+
+export const listHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+});
+
+export const editToggleButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '6px 10px',
+  fontSize: '13px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'color 150ms, border-color 150ms',
+  ':hover': {
+    color: vars.color.text,
+    borderColor: vars.color.borderStrong,
+  },
 });

--- a/src/components/editor/DraftPanel.css.ts
+++ b/src/components/editor/DraftPanel.css.ts
@@ -5,8 +5,8 @@ import { vars } from '@/styles/tokens.css';
 export const panel = style({
   display: 'flex',
   flexDirection: 'column',
+  width: '216px',
   height: '100%',
-  minHeight: '480px',
   background: vars.color.canvasDeep,
   borderRadius: vars.radius.xl,
   overflow: 'hidden',
@@ -150,4 +150,85 @@ export const footerLink = style({
   ':hover': {
     color: vars.color.accent,
   },
+});
+
+// Edit mode action buttons in header
+export const editActionBtn = recipe({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '3px',
+    borderRadius: '5px',
+    border: '1px solid transparent',
+    padding: '3px 7px',
+    fontSize: '11px',
+    fontWeight: 500,
+    cursor: 'pointer',
+    transition: 'opacity 150ms',
+    selectors: {
+      '&:disabled': {
+        opacity: 0.4,
+        cursor: 'not-allowed',
+      },
+    },
+  },
+  variants: {
+    variant: {
+      cancel: {
+        background: 'transparent',
+        borderColor: vars.color.border,
+        color: vars.color.textMuted,
+        ':hover': {
+          color: vars.color.text,
+          borderColor: vars.color.borderStrong,
+        },
+      },
+      delete: {
+        background: vars.color.errorBg,
+        borderColor: vars.color.errorBorder,
+        color: vars.color.errorText,
+      },
+    },
+  },
+});
+
+// Selectable item in edit mode
+export const itemSelectable = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    padding: '7px 10px',
+    cursor: 'pointer',
+    marginBottom: '1px',
+    transition: 'background-color 150ms',
+  },
+  variants: {
+    selected: {
+      true: {
+        background: vars.color.accentSoft,
+      },
+      false: {
+        ':hover': {
+          background: 'rgba(0,0,0,0.04)',
+        },
+      },
+    },
+  },
+  defaultVariants: { selected: false },
+});
+
+export const itemCheckbox = style({
+  flexShrink: 0,
+  width: '14px',
+  height: '14px',
+  borderRadius: '3px',
+  accentColor: vars.color.accent,
+  cursor: 'pointer',
+});
+
+export const itemBody = style({
+  minWidth: 0,
+  flex: 1,
 });

--- a/src/components/editor/DraftPanel.tsx
+++ b/src/components/editor/DraftPanel.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { Plus, History, RefreshCcw } from 'lucide-react';
+import { Plus, History, RefreshCcw, Pencil, Trash2 } from 'lucide-react';
 import type { ContentDraft, DraftStatus } from '@/lib/drafts/types';
 import type { SyncTask, SyncTaskStatus } from '@/lib/sync/types';
+import { deleteDraft } from '@/lib/drafts/client';
 import * as styles from './DraftPanel.css';
 
 const statusLabels: Record<DraftStatus, string> = {
@@ -44,6 +45,9 @@ export default function DraftPanel({ onNewDraft }: Props) {
   const [drafts, setDrafts] = useState<ContentDraft[]>([]);
   const [syncTasks, setSyncTasks] = useState<SyncTask[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,22 +77,85 @@ export default function DraftPanel({ onNewDraft }: Props) {
     };
   }, []);
 
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function exitEditMode() {
+    setIsEditMode(false);
+    setSelected(new Set());
+  }
+
+  async function handleDeleteSelected() {
+    if (selected.size === 0 || deleting) return;
+    setDeleting(true);
+    try {
+      await Promise.all(Array.from(selected).map((id) => deleteDraft(id)));
+      setDrafts((prev) => prev.filter((d) => !selected.has(d.id)));
+      exitEditMode();
+    } catch {
+      // silently ignore — non-critical panel
+    } finally {
+      setDeleting(false);
+    }
+  }
+
   return (
     <div className={styles.panel}>
       <div className={styles.header}>
         <span className={styles.headerTitle}>草稿</span>
         <div className={styles.headerActions}>
-          <Link href="/sync-tasks" className={styles.historyLink} title="分发记录">
-            <History size={13} />
-          </Link>
-          <button
-            type="button"
-            onClick={onNewDraft}
-            className={styles.newBtn}
-            title="新建稿件"
-          >
-            <Plus size={14} />
-          </button>
+          {!isEditMode ? (
+            <>
+              <Link href="/sync-tasks" className={styles.historyLink} title="分发记录">
+                <History size={13} />
+              </Link>
+              <button
+                type="button"
+                onClick={() => setIsEditMode(true)}
+                className={styles.newBtn}
+                title="编辑草稿"
+              >
+                <Pencil size={13} />
+              </button>
+              <button
+                type="button"
+                onClick={onNewDraft}
+                className={styles.newBtn}
+                title="新建稿件"
+              >
+                <Plus size={14} />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className={styles.editActionBtn({ variant: 'cancel' })}
+                onClick={exitEditMode}
+                disabled={deleting}
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                className={styles.editActionBtn({ variant: 'delete' })}
+                onClick={() => void handleDeleteSelected()}
+                disabled={selected.size === 0 || deleting}
+              >
+                <Trash2 size={11} />
+                {deleting ? '...' : `删除${selected.size > 0 ? `(${selected.size})` : ''}`}
+              </button>
+            </>
+          )}
         </div>
       </div>
 
@@ -104,6 +171,43 @@ export default function DraftPanel({ onNewDraft }: Props) {
             const syncTask = syncTasks.find((t) => t.draftId === draft.id);
             const isActive = draft.id === currentDraftId;
             const suffix = syncTask ? syncStatusSuffix[syncTask.status] : '';
+            const isSelected = selected.has(draft.id);
+
+            if (isEditMode) {
+              return (
+                <div
+                  key={draft.id}
+                  className={styles.itemSelectable({ selected: isSelected })}
+                  onClick={() => toggleSelect(draft.id)}
+                  role="checkbox"
+                  aria-checked={isSelected}
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === ' ' || e.key === 'Enter') {
+                      e.preventDefault();
+                      toggleSelect(draft.id);
+                    }
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    className={styles.itemCheckbox}
+                    checked={isSelected}
+                    onChange={() => toggleSelect(draft.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={`选择 ${draft.title || '无标题'}`}
+                  />
+                  <div className={styles.itemBody}>
+                    <span className={styles.itemTitle}>
+                      {draft.title || '无标题'}
+                    </span>
+                    <span className={styles.itemMeta}>
+                      {statusLabels[draft.status]}{suffix}
+                    </span>
+                  </div>
+                </div>
+              );
+            }
 
             return (
               <Link

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   PenLine,
   Settings2,
   ArrowRight,
+  Library,
 } from 'lucide-react';
 import { Dancing_Script } from 'next/font/google';
 import { cn } from '@/lib/cn';
@@ -26,6 +27,12 @@ const navItems = [
     label: '写作台',
     description: 'Markdown 写作、排版预览与发布一体化。',
     icon: PenLine,
+  },
+  {
+    href: '/drafts',
+    label: '稿件库',
+    description: '管理所有草稿，追踪从选题到分发的完整链路。',
+    icon: Library,
   },
   {
     href: '/settings',

--- a/src/components/news/AiNewsPageClient.tsx
+++ b/src/components/news/AiNewsPageClient.tsx
@@ -140,14 +140,21 @@ export default function AiNewsPageClient() {
         {
           title: item.title,
           imageUrl: item.researchBrief.imageUrl,
+          articleImages: item.researchBrief.articleImages,
           whyNow: item.whyNow,
           whatHappened: item.researchBrief.whatHappened,
           whyItMatters: item.researchBrief.whyItMatters,
           whoIsAffected: item.researchBrief.whoIsAffected,
           recommendedAngles: item.researchBrief.recommendedAngles,
           background: item.researchBrief.background,
+          perspectives: item.researchBrief.perspectives.map((p) => ({
+            ...p,
+            publishedAt: formatDateTime(p.publishedAt),
+          })),
           evidence: item.researchBrief.evidence.map((entry) => ({
-            ...entry,
+            label: entry.label,
+            sourceName: entry.sourceName,
+            link: entry.link,
             publishedAt: formatDateTime(entry.publishedAt),
           })),
         },

--- a/src/components/publish/publish.css.ts
+++ b/src/components/publish/publish.css.ts
@@ -359,10 +359,6 @@ export const loadingPlaceholder = style({
 export const previewPanel = style({
   display: 'grid',
   gap: '16px',
-  borderRadius: vars.radius.xl,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
-  padding: '16px',
 });
 
 export const previewHeader = style({

--- a/src/lib/__tests__/newsDraft.test.ts
+++ b/src/lib/__tests__/newsDraft.test.ts
@@ -35,7 +35,7 @@ describe('buildResearchDraftMarkdown', () => {
     });
 
     expect(markdown).toContain(
-      '![OpenAI 发布新模型 GPT-X](https://openai.com/images/gpt-x-cover.jpg)',
+      '![](https://openai.com/images/gpt-x-cover.jpg)',
     );
   });
 });

--- a/src/lib/ai-news/articleSnapshot.ts
+++ b/src/lib/ai-news/articleSnapshot.ts
@@ -1,5 +1,6 @@
 interface ArticleSnapshot {
   imageUrl: string;
+  imageUrls: string[];
   wordCount?: number;
   imageCount?: number;
 }
@@ -46,6 +47,11 @@ function isLikelyDecorativeImage(url: string) {
   const normalized = url.toLowerCase();
 
   if (!normalized) {
+    return true;
+  }
+
+  // WordPress 主题资源目录
+  if (/\/wp-content\/themes\//i.test(normalized)) {
     return true;
   }
 
@@ -119,9 +125,11 @@ export function extractArticleSnapshotFromHtml(
   const scope = extractMainScope(html);
   const images = extractImageCandidates(scope, pageUrl);
   const metaImage = extractMetaImage(html, pageUrl);
+  const imageUrls = images.length > 0 ? images : (metaImage ? [metaImage] : []);
 
   return {
-    imageUrl: images[0] || metaImage,
+    imageUrl: imageUrls[0] ?? '',
+    imageUrls,
     wordCount: countArticleWords(scope),
     imageCount: images.length > 0 ? images.length : undefined,
   };
@@ -138,13 +146,13 @@ export async function fetchArticleSnapshot(link: string): Promise<ArticleSnapsho
     });
 
     if (!response.ok) {
-      return { imageUrl: '' };
+      return { imageUrl: '', imageUrls: [] };
     }
 
     const html = await response.text();
     return extractArticleSnapshotFromHtml(html, link);
   } catch {
-    return { imageUrl: '' };
+    return { imageUrl: '', imageUrls: [] };
   }
 }
 

--- a/src/lib/ai-news/index.ts
+++ b/src/lib/ai-news/index.ts
@@ -134,68 +134,101 @@ function diversifyCandidates(
   return selected;
 }
 
-async function hydrateCandidateImages(candidates: AiNewsDeskCandidate[]) {  const snapshotCache = new Map<string, Promise<ArticleSnapshot>>();
+async function hydrateCandidateImages(candidates: AiNewsDeskCandidate[]) {
+  const snapshotCache = new Map<string, Promise<ArticleSnapshot>>();
+
+  function getOrFetchSnapshot(link: string): Promise<ArticleSnapshot> {
+    if (!snapshotCache.has(link)) {
+      snapshotCache.set(link, fetchArticleSnapshot(link));
+    }
+    return snapshotCache.get(link)!;
+  }
 
   return Promise.all(
     candidates.map(async (candidate) => {
-      const hasImage = candidate.researchBrief.imageUrl || candidate.primarySignal.imageUrl;
-      const hasMetrics =
+      const primaryLink = candidate.primarySignal.link;
+      const hasPrimaryImage = !!(candidate.researchBrief.imageUrl || candidate.primarySignal.imageUrl);
+      const hasPrimaryMetrics =
         typeof candidate.primarySignal.articleWordCount === 'number' ||
         typeof candidate.primarySignal.articleImageCount === 'number';
+      const needsPrimary = !hasPrimaryImage || !hasPrimaryMetrics;
 
-      if (hasImage && hasMetrics) {
+      // 最多补抓 2 条没有图片的次级信号
+      const secondaryTargets = candidate.signals
+        .filter((s) => s.link !== primaryLink && !s.imageUrl)
+        .slice(0, 2);
+
+      if (!needsPrimary && secondaryTargets.length === 0) {
         return candidate;
       }
 
-      const articleLink = candidate.primarySignal.link;
-      let snapshotPromise = snapshotCache.get(articleLink);
-      if (!snapshotPromise) {
-        snapshotPromise = fetchArticleSnapshot(articleLink);
-        snapshotCache.set(articleLink, snapshotPromise);
-      }
+      // 主信号和次级信号并行抓取
+      const [primarySnapshot, ...secondarySnapshots] = await Promise.all([
+        needsPrimary
+          ? getOrFetchSnapshot(primaryLink)
+          : Promise.resolve<ArticleSnapshot>({ imageUrl: '', imageUrls: [] }),
+        ...secondaryTargets.map((s) => getOrFetchSnapshot(s.link)),
+      ]);
 
-      const snapshot = await snapshotPromise;
-      const imageUrl = snapshot.imageUrl || candidate.researchBrief.imageUrl || candidate.primarySignal.imageUrl;
-      const articleWordCount = snapshot.wordCount ?? candidate.primarySignal.articleWordCount;
-      const articleImageCount =
-        snapshot.imageCount ?? candidate.primarySignal.articleImageCount;
+      const primaryImageUrl = needsPrimary
+        ? (primarySnapshot.imageUrl || candidate.researchBrief.imageUrl || candidate.primarySignal.imageUrl)
+        : (candidate.primarySignal.imageUrl || candidate.researchBrief.imageUrl);
+      const articleWordCount = needsPrimary
+        ? (primarySnapshot.wordCount ?? candidate.primarySignal.articleWordCount)
+        : candidate.primarySignal.articleWordCount;
+      const articleImageCount = needsPrimary
+        ? (primarySnapshot.imageCount ?? candidate.primarySignal.articleImageCount)
+        : candidate.primarySignal.articleImageCount;
 
-      if (!imageUrl && typeof articleWordCount !== 'number' && typeof articleImageCount !== 'number') {
+      const secondaryImageMap = new Map(
+        secondaryTargets
+          .map((s, i) => [s.link, secondarySnapshots[i]?.imageUrl ?? ''] as const)
+          .filter(([, img]) => !!img),
+      );
+
+      if (
+        !primaryImageUrl &&
+        secondaryImageMap.size === 0 &&
+        typeof articleWordCount !== 'number' &&
+        typeof articleImageCount !== 'number'
+      ) {
         return candidate;
       }
+
+      const updatedSignals = candidate.signals.map((signal) => {
+        if (signal.link === primaryLink) {
+          return {
+            ...signal,
+            imageUrl: primaryImageUrl,
+            articleImages: needsPrimary ? primarySnapshot.imageUrls : signal.articleImages,
+            articleWordCount,
+            articleImageCount,
+          };
+        }
+        const secImage = secondaryImageMap.get(signal.link);
+        return secImage ? { ...signal, imageUrl: secImage } : signal;
+      });
+
+      const updatedPrimary =
+        updatedSignals.find((s) => s.link === primaryLink) ?? candidate.primarySignal;
 
       return {
         ...candidate,
-        primarySignal: {
-          ...candidate.primarySignal,
-          imageUrl,
-          articleWordCount,
-          articleImageCount,
-        },
-        signals: candidate.signals.map((signal) =>
-          signal.link === articleLink &&
-          (!signal.imageUrl ||
-            typeof signal.articleWordCount !== 'number' ||
-            typeof signal.articleImageCount !== 'number')
-            ? {
-                ...signal,
-                imageUrl,
-                articleWordCount,
-                articleImageCount,
-              }
-            : signal,
-        ),
+        primarySignal: updatedPrimary,
+        signals: updatedSignals,
         researchBrief: {
           ...candidate.researchBrief,
-          imageUrl,
-          evidence: candidate.researchBrief.evidence.map((entry) =>
-            entry.link === articleLink && !entry.imageUrl
-              ? {
-                  ...entry,
-                  imageUrl,
-                }
-              : entry,
-          ),
+          imageUrl: primaryImageUrl || candidate.researchBrief.imageUrl,
+          articleImages: needsPrimary
+            ? primarySnapshot.imageUrls
+            : candidate.researchBrief.articleImages,
+          evidence: candidate.researchBrief.evidence.map((entry) => {
+            if (entry.link === primaryLink) {
+              return { ...entry, imageUrl: primaryImageUrl || entry.imageUrl };
+            }
+            const secImage = secondaryImageMap.get(entry.link);
+            return secImage && !entry.imageUrl ? { ...entry, imageUrl: secImage } : entry;
+          }),
         },
       };
     }),

--- a/src/lib/ai-news/research.ts
+++ b/src/lib/ai-news/research.ts
@@ -2,6 +2,7 @@ import type {
   ResearchBrief,
   ResearchEvidence,
   ResearchAngle,
+  ResearchPerspective,
   ScoredAiNewsCluster,
 } from '@/lib/ai-news/types';
 
@@ -29,7 +30,22 @@ function buildWhyItMatters(cluster: ScoredAiNewsCluster) {
           ? '平台规则、企业决策和市场预期'
           : '模型能力、产品采用速度和竞争格局';
 
-  return `这不是一条普通动态，因为它直接关系到 ${impactObject}。结合当前 ${topicHeadline(cluster.topicTags)} 的主线，这个话题既有行业影响，也具备被中文内容场继续放大的条件。`;
+  const coverageContext =
+    cluster.coverageCount >= 5
+      ? `已有 ${cluster.coverageCount} 条交叉报道`
+      : `当前 ${cluster.coverageCount} 条来源指向同一事件`;
+
+  const sourceContext =
+    cluster.officialSourceCount > 0 ? '含官方信源' : '来自媒体交叉报道';
+
+  const scoreContext =
+    cluster.scores.impact >= 80
+      ? '影响力评分较高'
+      : cluster.scores.impact >= 60
+        ? '具有一定行业影响'
+        : '短期关注度较强';
+
+  return `${coverageContext}（${sourceContext}），${scoreContext}，直接关系到 ${impactObject}。结合当前 ${topicHeadline(cluster.topicTags)} 主线，具备在中文内容场持续放大的条件。`;
 }
 
 function buildAffectedAudience(cluster: ScoredAiNewsCluster) {
@@ -94,26 +110,75 @@ function buildAngles(cluster: ScoredAiNewsCluster): ResearchAngle[] {
 }
 
 function buildBackground(cluster: ScoredAiNewsCluster) {
-  return [
-    `最近 ${cluster.coverageCount} 条相关报道都指向同一主线：${topicHeadline(cluster.topicTags)}。`,
-    cluster.officialSourceCount > 0
-      ? '当前候选包含官方源，可作为后续写作时的第一手依据。'
-      : '当前候选主要来自媒体交叉报道，适合继续补官方信息确认细节。',
-    cluster.bucket === 'today'
-      ? '它仍然处于今天可以直接切入的时效窗口。'
-      : '它已经过了最早爆点，更适合做背景、影响和竞争格局延展。',
+  const sourceNames = [
+    ...new Set(cluster.signals.slice(0, 4).map((s) => s.sourceName)),
   ];
+
+  return [
+    `当前聚合 ${cluster.coverageCount} 条报道，来源包括：${sourceNames.join('、')}。`,
+    cluster.officialSourceCount > 0
+      ? '含官方信源，可作为写作时的第一手依据。'
+      : '主要来自媒体交叉报道，建议补充官方信息确认细节。',
+    cluster.bucket === 'today'
+      ? `最新更新于 ${new Date(cluster.latestPublishedAt).toLocaleString('zh-CN')}，仍在时效窗口内，适合直接切入。`
+      : `首报于 ${new Date(cluster.earliestPublishedAt).toLocaleString('zh-CN')}，适合做背景、影响和竞争格局延展。`,
+  ];
+}
+
+function buildPerspectives(cluster: ScoredAiNewsCluster): ResearchPerspective[] {
+  return cluster.signals
+    .filter(
+      (s) =>
+        s.link !== cluster.primarySignal.link &&
+        (!!s.imageUrl || !!(s.summary?.trim())),
+    )
+    .slice(0, 3)
+    .map((s) => ({
+      sourceName: s.sourceName,
+      sourceType: s.sourceType,
+      title: s.title,
+      summary: s.summary?.trim() ?? '',
+      imageUrl: s.imageUrl,
+      link: s.link,
+      publishedAt: s.publishedAt,
+    }));
 }
 
 function buildEvidence(cluster: ScoredAiNewsCluster): ResearchEvidence[] {
   return cluster.signals.slice(0, 5).map((signal) => ({
     label: `${signal.sourceName}｜${signal.title}`,
+    summary: signal.summary || '',
     sourceName: signal.sourceName,
     link: signal.link,
     imageUrl: signal.imageUrl,
     publishedAt: signal.publishedAt,
     sourceType: signal.sourceType,
   }));
+}
+
+function truncateSummary(text: string, maxLen = 200): string {
+  if (text.length <= maxLen) return text;
+  // 尝试在句子边界截断（。！？）
+  const cutoff = text.slice(0, maxLen);
+  const lastBreak = Math.max(
+    cutoff.lastIndexOf('。'),
+    cutoff.lastIndexOf('！'),
+    cutoff.lastIndexOf('？'),
+    cutoff.lastIndexOf('. '),
+  );
+  return lastBreak > maxLen * 0.5
+    ? text.slice(0, lastBreak + 1)
+    : `${cutoff.trimEnd()}……`;
+}
+
+function buildWhatHappened(cluster: ScoredAiNewsCluster): string {
+  const primary = cluster.primarySignal;
+  const base = `${primary.sourceName} 报道的核心事件：${primary.title}。`;
+  const summaryPart = primary.summary
+    ? `\n\n> ${truncateSummary(primary.summary)}`
+    : '';
+  const statPart = `\n\n当前已聚合 ${cluster.coverageCount} 条相关报道，最新更新于 ${new Date(cluster.latestPublishedAt).toLocaleString('zh-CN')}。`;
+  return `${base}${summaryPart}${statPart}`;
 }
 
 export function buildResearchBrief(cluster: ScoredAiNewsCluster): ResearchBrief {
@@ -126,11 +191,13 @@ export function buildResearchBrief(cluster: ScoredAiNewsCluster): ResearchBrief 
     title: cluster.title,
     bucket: cluster.bucket,
     imageUrl: leadImageUrl,
-    whatHappened: `${primary.sourceName} 指向的核心事件是：${primary.title}。当前候选窗口内共聚合 ${cluster.coverageCount} 条相关报道，最新更新发生在 ${new Date(cluster.latestPublishedAt).toLocaleString('zh-CN')}。`,
+    articleImages: primary.articleImages,
+    whatHappened: buildWhatHappened(cluster),
     whyItMatters: buildWhyItMatters(cluster),
     whoIsAffected: buildAffectedAudience(cluster),
     recommendedAngles: buildAngles(cluster),
     background: buildBackground(cluster),
+    perspectives: buildPerspectives(cluster),
     evidence: buildEvidence(cluster),
     scores: cluster.scores,
     totalScore: cluster.totalScore,

--- a/src/lib/ai-news/types.ts
+++ b/src/lib/ai-news/types.ts
@@ -14,6 +14,7 @@ export interface NormalizedAiNewsSignal {
   summary: string;
   link: string;
   imageUrl?: string;
+  articleImages?: string[];
   articleWordCount?: number;
   articleImageCount?: number;
   sourceWeight: number;
@@ -65,8 +66,19 @@ export interface ResearchAngle {
   reason: string;
 }
 
+export interface ResearchPerspective {
+  sourceName: string;
+  sourceType: AiNewsSourceType;
+  title: string;
+  summary: string;
+  imageUrl?: string;
+  link: string;
+  publishedAt: string;
+}
+
 export interface ResearchEvidence {
   label: string;
+  summary?: string;
   sourceName: string;
   link: string;
   imageUrl?: string;
@@ -79,11 +91,13 @@ export interface ResearchBrief {
   title: string;
   bucket: AiNewsBucket;
   imageUrl?: string;
+  articleImages?: string[];
   whatHappened: string;
   whyItMatters: string;
   whoIsAffected: string[];
   recommendedAngles: ResearchAngle[];
   background: string[];
+  perspectives: ResearchPerspective[];
   evidence: ResearchEvidence[];
   scores: AiNewsScores;
   totalScore: number;

--- a/src/lib/drafts/client.ts
+++ b/src/lib/drafts/client.ts
@@ -31,3 +31,11 @@ export async function createDraft(input: CreateDraftInput) {
 
   return data.draft;
 }
+
+export async function deleteDraft(id: string) {
+  const response = await fetch(`/api/drafts/${id}`, { method: 'DELETE' });
+  if (!response.ok) {
+    const data = (await response.json()) as { error?: string };
+    throw new Error(data.error || '稿件删除失败，请稍后重试。');
+  }
+}

--- a/src/lib/newsDraft.ts
+++ b/src/lib/newsDraft.ts
@@ -6,6 +6,7 @@ export interface NewsDraftPayload {
 export interface ResearchDraftSection {
   title: string;
   imageUrl?: string;
+  articleImages?: string[];
   whyNow: string;
   whatHappened: string;
   whyItMatters: string;
@@ -15,6 +16,14 @@ export interface ResearchDraftSection {
     reason: string;
   }>;
   background: string[];
+  perspectives?: Array<{
+    sourceName: string;
+    title: string;
+    summary: string;
+    imageUrl?: string;
+    link: string;
+    publishedAt: string;
+  }>;
   evidence: Array<{
     label: string;
     sourceName: string;
@@ -25,90 +34,12 @@ export interface ResearchDraftSection {
 
 export const NEWS_DRAFT_STORAGE_KEY = 'publio-ai-news-draft';
 
-export function buildNewsArticleMarkdown(params: {
-  headline: string;
-  intro: string;
-  sections: Array<{
-    title: string;
-    emoji?: string;
-    deck?: string;
-    summary: string;
-    body?: string;
-    takeaway?: string;
-    source: string;
-    publishedAt: string;
-    link: string;
-    imageUrl?: string;
-  }>;
-}) {
-  const highlights = params.sections
-    .slice(0, 3)
-    .map((section, index) => `${index + 1}. ${section.title}`)
-    .join('\n');
-
-  const lines = [
-    `# ${params.headline}`,
-    '',
-    params.intro,
-    '',
-    '---',
-    '',
-    '## 今晚值得关注的几件事',
-    '',
-    '过去 12 小时里，AI 行业的信息密度依然很高。从模型更新、商业化推进，到算力与平台生态变化，几条主线都在同步演进。把这些消息放在一起看，短期热度之外，真正值得看的仍然是行业节奏正在怎么变。',
-    '',
-    highlights,
-    '',
-  ];
-
-  params.sections.forEach((section, index) => {
-    const sectionTitle = `${section.emoji ? `${section.emoji} ` : ''}${String(index + 1).padStart(2, '0')}｜${section.title}`;
-
-    lines.push(`## ${sectionTitle}`);
-    lines.push('');
-    if (section.deck) {
-      lines.push(`${section.deck}`);
-      lines.push('');
-    }
-    lines.push(section.summary || '原始来源未提供摘要，请结合原文补充细节。');
-    lines.push('');
-    if (section.imageUrl) {
-      lines.push(`![${section.title}](${section.imageUrl})`);
-      lines.push('');
-    }
-    if (section.body) {
-      lines.push(section.body);
-      lines.push('');
-    }
-    if (section.takeaway) {
-      lines.push(`> 这条消息更值得注意的是：${section.takeaway}`);
-      lines.push('');
-    }
-    lines.push(`来源：${section.source}｜时间：${section.publishedAt}`);
-    lines.push('');
-    lines.push(`原文链接：${section.link}`);
-    lines.push('');
-    lines.push('---');
-    lines.push('');
-  });
-
-  lines.push('## 最后说几句');
-  lines.push('');
-  lines.push(
-    '整体来看，过去 12 小时里的 AI 新闻，仍然围绕产品更新、商业化推进与底层基础设施三条主线展开。短期看，行业节奏还会继续加快；中期看，真正决定分化的，依旧是落地效率、收入能力和基础设施成本。如果继续跟下去，接下来最值得看的，还是谁能更快把能力变成真正可用、可付费、可持续的产品。',
-  );
-
-  return lines.join('\n');
-}
-
 export function buildResearchDraftMarkdown(params: {
   headline: string;
   intro: string;
   sections: ResearchDraftSection[];
 }) {
   const lines = [
-    `# ${params.headline}`,
-    '',
     params.intro,
     '',
     '---',
@@ -118,14 +49,39 @@ export function buildResearchDraftMarkdown(params: {
   params.sections.forEach((section, index) => {
     lines.push(`## ${String(index + 1).padStart(2, '0')}｜${section.title}`);
     lines.push('');
-    if (section.imageUrl) {
-      lines.push(`![${section.title}](${section.imageUrl})`);
-      lines.push('');
-    }
     lines.push('### 这件事是什么');
     lines.push('');
     lines.push(section.whatHappened);
     lines.push('');
+
+    // 原文配图：优先用文章内所有图，fallback 到单张 imageUrl
+    const images =
+      section.articleImages && section.articleImages.length > 0
+        ? section.articleImages
+        : section.imageUrl
+          ? [section.imageUrl]
+          : [];
+    images.forEach((url) => {
+      lines.push(`![](${url})`);
+      lines.push('');
+    });
+
+    // 其他来源的报道视角（摘要 + 配图）
+    if (section.perspectives && section.perspectives.length > 0) {
+      section.perspectives.forEach((p) => {
+        lines.push(`**${p.sourceName}** 报道：${p.title}`);
+        lines.push('');
+        if (p.summary) {
+          lines.push(`> ${p.summary}`);
+          lines.push('');
+        }
+        if (p.imageUrl) {
+          lines.push(`![](${p.imageUrl})`);
+          lines.push('');
+        }
+      });
+    }
+
     lines.push('### 为什么重要');
     lines.push('');
     lines.push(section.whyItMatters);
@@ -155,9 +111,8 @@ export function buildResearchDraftMarkdown(params: {
     lines.push('### 原始依据');
     lines.push('');
     section.evidence.forEach((entry) => {
-      lines.push(`- ${entry.label}`);
-      lines.push(`  来源：${entry.sourceName}｜时间：${entry.publishedAt}`);
-      lines.push(`  链接：${entry.link}`);
+      lines.push(`- ${entry.label}｜${entry.publishedAt}`);
+      lines.push(`  ${entry.link}`);
     });
     lines.push('');
     lines.push('---');


### PR DESCRIPTION
## Summary

- **AI 底稿增强**：从原文抓取多张配图（`articleImages[]`），收集其他来源报道视角（`perspectives`），摘要截断至 ≤200 字防止全文倾倒
- **稿件删除**：新增 `deleteDraft` client helper，对接已有 `DELETE /api/drafts/:id`
- **写作台**：添加「清空」按钮（Eraser 图标），草稿面板从左侧移至右侧与按钮同侧
- **草稿面板编辑模式**：铅笔图标进入编辑态，支持多选批量删除
- **稿件库页面**：新增 `/drafts` 路由，所有草稿以「来源 → 写作台 → 分发」pipeline 行展示，含编辑删除和新建入口
- **导航 + 样式**：侧边栏新增稿件库入口，移除发布配置外层容器

## Commits

| # | Scope | 说明 |
|---|-------|------|
| 1 | ai-news | 底稿多图、perspectives、摘要截断 |
| 2 | drafts | deleteDraft helper |
| 3 | writing-desk | 清空按钮 + 面板右移 |
| 4 | draft-panel | 编辑模式多选删除 |
| 5 | draft-library | 新页面 pipeline 视图 |
| 6 | style | 导航入口 + 发布配置去外框 |

## Test plan

- [ ] 选题台点「加入写作台」，底稿包含多张配图和 perspectives 内容
- [ ] 写作台「清空」按钮正确清空编辑器并跳回 `/`
- [ ] 草稿面板展开方向在右侧，编辑模式可多选删除
- [ ] `/drafts` 页面正常加载，所有草稿显示为 pipeline 行
- [ ] 稿件库编辑模式勾选后删除，列表实时更新
- [ ] 侧边栏「稿件库」导航正常跳转