### PR TITLE
feat: publio transformation v2 - editor, drafts, publish, layout & news improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,15 @@
 
 | Layer | Tech |
 |-------|------|
-| Framework | Next.js 15.1.12 (App Router) |
+| Framework | Next.js 15 (App Router) |
 | Language | TypeScript 5 (strict mode) |
-| UI | React 19, Tailwind CSS 4, lucide-react |
+| UI | React 19, lucide-react |
+| CSS | vanilla-extract（@vanilla-extract/css + @vanilla-extract/recipes） |
 | Editor | @uiw/react-md-editor |
 | State | Zustand 5 |
 | Markdown | marked 15 |
 | Social API | twitter-api-v2 |
 | Lint | ESLint 9 + eslint-config-next |
-| CSS | Tailwind CSS 4 via @tailwindcss/postcss + PostCSS |
 | Package Manager | pnpm (dev script 中使用 pnpm run) |
 
 ## Architecture
@@ -31,49 +31,104 @@
 src/
 ├── app/                    # Next.js App Router 页面
 │   ├── layout.tsx            # 根布局（Sidebar + main）
-│   ├── page.tsx              # 首页：Markdown 编辑器 + 平台选择 + 发布
+│   ├── page.tsx              # 首页：写作台（编辑器 + 右侧发布面板 + 自动保存）
 │   ├── ai-news/
-│   │   ├── page.tsx          # AI 新闻聚合页（SSR metadata）
+│   │   ├── page.tsx          # AI 选题工作台（SSR metadata）
 │   │   └── error.tsx         # 错误边界
+│   ├── drafts/
+│   │   ├── page.tsx          # 稿件库页（SSR metadata）
+│   │   └── DraftsPageClient.tsx  # 稿件库客户端
 │   ├── settings/
-│   │   └── page.tsx          # 设置页
+│   │   └── page.tsx          # 设置页（API 凭证管理）
 │   └── api/                  # API Routes
 │       ├── ai-news/route.ts    # AI 新闻 RSS 聚合接口
-│       ├── publish/route.ts    # 统一发布接口
-│       ├── settings/route.ts   # 设置读写接口
-│       └── platforms/          # 各平台发布接口
-│           ├── wechat/route.ts
-│           ├── xiaohongshu/route.ts
-│           ├── zhihu/route.ts
-│           └── x/route.ts
+│       ├── publish/route.ts    # 统一发布接口（fire-and-forget）
+│       ├── settings/route.ts   # .env.local 读写接口
+│       ├── drafts/             # 草稿 CRUD
+│       │   ├── route.ts          # GET list / POST create
+│       │   └── [id]/route.ts     # GET / PATCH / DELETE
+│       ├── sync-tasks/         # 分发任务
+│       │   ├── route.ts
+│       │   └── [id]/route.ts
+│       └── platforms/          # 平台连接管理
+│           └── [platform]/connection/
+│               ├── check/route.ts
+│               ├── disconnect/route.ts
+│               ├── oauth/start/route.ts
+│               └── oauth/callback/route.ts
 ├── components/
 │   ├── layout/
-│   │   └── Sidebar.tsx       # 侧边导航栏
+│   │   ├── Sidebar.tsx           # 侧边导航栏
+│   │   ├── AppShellHeader.tsx    # 通用页头（kicker/title/description/action）
+│   │   └── SurfaceCard.tsx       # 卡片容器（tone 变体）
 │   ├── editor/
-│   │   └── MarkdownEditor.tsx  # Markdown 编辑器 + 发布态预览
+│   │   ├── MarkdownEditor.tsx    # Markdown 编辑器（@uiw/react-md-editor）
+│   │   ├── DraftPanel.tsx        # 草稿抽屉面板
+│   │   ├── RecentDraftBar.tsx    # 移动端最近草稿栏
+│   │   └── EditorialContextCard.tsx  # 稿件统计信号卡
 │   ├── news/
-│   │   └── AiNewsPageClient.tsx  # AI 新闻客户端组件
-│   └── publish/
-│       ├── PlatformSelector.tsx  # 平台选择器
-│       ├── PublishButton.tsx     # 发布按钮
-│       └── PublishStatusPanel.tsx  # 发布状态面板
+│   │   ├── AiNewsPageClient.tsx  # AI 选题工作台客户端
+│   │   ├── TopicSignalCard.tsx   # 话题信号卡片（含六维评分进度条）
+│   │   ├── TopicDeskHeader.tsx   # 选题工作台页头
+│   │   └── ScoreBar.tsx          # 单条评分进度条原子组件
+│   ├── publish/
+│   │   ├── PlatformSelector.tsx      # 平台选择器
+│   │   ├── PublishButton.tsx         # 发布按钮（发布后打开进度浮层）
+│   │   ├── PublishStatusPanel.tsx    # 发布状态面板
+│   │   ├── PlatformPreviewPanel.tsx  # 平台内容预览（可折叠）
+│   │   └── PublishProgressOverlay.tsx  # 发布进度浮层（右下角，轮询更新）
+│   ├── drafts/
+│   │   └── DraftLibraryClient.tsx   # 稿件库流水线视图（含彩色分发状态）
+│   └── sync/
+│       ├── SyncTaskList.tsx          # 分发记录列表
+│       └── SyncTaskDetail.tsx        # 分发详情面板
+├── hooks/
+│   └── useAutoSave.ts        # 防抖自动保存 hook（停止输入 1s 后触发）
 ├── lib/
-│   ├── aiNews.ts             # RSS 抓取、评分、排序、编辑内容生成
-│   ├── config.ts             # 各平台 API 配置（读取环境变量）
-│   ├── markdown.ts           # Markdown → 带样式 HTML 转换
-│   ├── newsDraft.ts          # 新闻草稿 localStorage 桥接
-│   └── publishers/           # 各平台发布器
-│       ├── types.ts
-│       ├── wechat.ts
-│       ├── x.ts
-│       ├── xiaohongshu.ts
-│       └── zhihu.ts
+│   ├── ai-news/              # AI 新闻引擎
+│   │   ├── index.ts            # 完整 pipeline（抓取→聚类→评分→排序）
+│   │   ├── sources.ts          # RSS 源定义
+│   │   ├── cluster.ts          # 话题聚类
+│   │   ├── score.ts            # 六维评分
+│   │   └── research.ts         # 研究底稿生成
+│   ├── drafts/
+│   │   ├── store.ts            # 草稿 CRUD（JSON 文件，原子写）
+│   │   ├── registry.ts         # 单例注册表
+│   │   ├── client.ts           # 客户端请求函数（updateDraft / ensureDraft）
+│   │   └── types.ts            # 类型定义
+│   ├── sync/
+│   │   ├── store.ts            # 分发任务 CRUD + 状态机
+│   │   ├── registry.ts         # 单例注册表
+│   │   └── types.ts
+│   ├── publishers/             # 各平台发布器
+│   │   ├── executePublish.ts
+│   │   ├── wechat.ts
+│   │   ├── x.ts
+│   │   ├── xiaohongshu.ts
+│   │   └── zhihu.ts
+│   ├── platformAdapters/       # 内容适配（各平台格式/字数校验）
+│   │   ├── adaptContent.ts
+│   │   └── types.ts
+│   ├── platformConnections/    # 平台连接管理
+│   │   ├── profiles.ts
+│   │   ├── checkers.ts
+│   │   └── index.ts
+│   ├── storage/                # 通用存储工具
+│   │   ├── jsonFileCollection.ts  # 原子写 JSON 文件
+│   │   ├── localDataPath.ts
+│   │   └── envFile.ts
+│   ├── markdown.ts             # Markdown → 带样式 HTML 转换
+│   ├── newsDraft.ts            # 新闻草稿 localStorage 桥接
+│   ├── config.ts               # 平台 API 配置
+│   └── publishStatus.ts        # 发布状态工具函数
 ├── stores/
-│   └── publishStore.ts      # Zustand 全局状态（标题/内容/平台/发布状态）
-├── types/
-│   └── index.ts              # 类型定义 + PLATFORMS 常量
+│   └── publishStore.ts      # Zustand 全局状态（title/content/platforms/currentDraftId/浮层）
+├── styles/
+│   └── tokens.css.ts        # 设计 token（颜色/圆角/字体）
+└── types/
+    └── index.ts              # 类型定义 + PLATFORMS 常量
 scripts/
-└── dev-safe.mjs              # 开发启动脚本（端口清理 + 缓存清除）
+└── dev-safe.ts               # 开发启动脚本（端口清理 + 缓存清除）
 ```
 
 ## Commands
@@ -118,20 +173,23 @@ pnpm lint
 - API Routes 使用 Route Handlers (`route.ts`)
 
 ### Styling
-- Tailwind CSS 4（通过 PostCSS 插件集成）
-- 内联 Tailwind 类名，大量使用自定义渐变和阴影
-- 设计风格：暖色调（橙/棕基调 `#d77443`, `#3a3029` 等）
-- 圆角大弧度 `rounded-[28px]`，卡片式布局
+- vanilla-extract（`@vanilla-extract/css` + `@vanilla-extract/recipes`）
+- 每个组件对应同目录的 `.css.ts` 文件
+- 设计 token 集中在 `src/styles/tokens.css.ts`（颜色、圆角、字体）
+- 设计风格：暖色调（橙/棕基调 `#D97757` accent），卡片式布局
 
 ### State Management
 - Zustand store 位于 `src/stores/`
-- 单一 `publishStore` 管理编辑器内容、平台选择、发布状态
+- 单一 `publishStore` 管理编辑器内容、平台选择、发布状态、当前草稿 ID、发布进度浮层
+- `useAutoSave` hook 防抖自动保存（`src/hooks/useAutoSave.ts`）
 - localStorage 用于新闻草稿临时传递 (`publio-ai-news-draft`)
 
 ### Patterns
 - **平台配置**: 环境变量读取集中在 `src/lib/config.ts`
-- **RSS 聚合**: 多源 RSS 抓取 → XML 解析 → 评分排序 → 编辑内容生成
-- **发布流程**: 编辑器 → 选平台 → 统一发布接口 → 各平台 publisher 分发
+- **RSS 聚合**: 多源 RSS 抓取 → 聚类 → 六维评分 → 排序 → 研究底稿生成
+- **发布流程**: 编辑器 → 选平台 → 统一发布接口（fire-and-forget）→ 原地浮层展示进度
+- **自动保存**: 停止输入 1s 后触发，首次保存自动创建草稿并更新 URL
+- **数据存储**: JSON 文件持久化（`.publio-data/`），原子写（`.tmp` + rename）
 - **中文注释**: 项目惯例，UI 文案以中文为主
 
 ## Environment Variables
@@ -148,5 +206,5 @@ pnpm lint
 - `.env` / `.env.local` 已在 `.gitignore` 中，不要提交密钥
 - `.next/` 和 `node_modules/` 不提交
 - `dist/` 目录已被 gitignore
-- `scripts/dev-safe.mjs` 会在开发启动前清理端口和 `.next/cache`
+- `scripts/dev-safe.ts` 会在开发启动前清理端口和 `.next/cache`
 - 中文注释和 UI 文案是项目惯例，保持一致

--- a/src/app/layout.css.ts
+++ b/src/app/layout.css.ts
@@ -17,12 +17,15 @@ export const main = style({
   minWidth: 0,
   flex: 1,
   padding: '16px',
+  paddingBottom: 'calc(16px + 57px + env(safe-area-inset-bottom))',
   '@media': {
     'screen and (min-width: 640px)': {
       padding: '16px 24px',
+      paddingBottom: 'calc(16px + 57px + env(safe-area-inset-bottom))',
     },
     'screen and (min-width: 1024px)': {
       padding: '24px 32px',
+      paddingBottom: '24px',
     },
   },
 });

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -8,14 +8,14 @@ export const pageWrap = style({
   gap: '24px',
 });
 
-// 双列容器：草稿面板 + 编辑主区
+// 最外层 flex 容器：草稿抽屉 + 主内容区
 export const editorLayout = style({
   display: 'flex',
   alignItems: 'stretch',
   gap: '16px',
 });
 
-// 面板外层：控制宽度动画，移动端隐藏
+// 草稿抽屉外层：控制宽度动画，移动端隐藏
 export const panelOuter = style({
   display: 'none',
   flexShrink: 0,
@@ -28,12 +28,44 @@ export const panelOuter = style({
   },
 });
 
+// 主内容区域：移动端单列，桌面端双列（编辑区 + 右侧控制面板）
+export const mainContentArea = style({
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      flexDirection: 'row',
+      alignItems: 'start',
+      gap: '20px',
+    },
+  },
+});
+
+// 左侧编辑内容区（撑满剩余宽度）
 export const editorSection = style({
   flex: 1,
   minWidth: 0,
   display: 'flex',
   flexDirection: 'column',
   gap: '16px',
+});
+
+// 右侧固定控制面板（桌面端 sticky，移动端退化为底部区块）
+export const rightPanel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      width: '280px',
+      flexShrink: 0,
+      position: 'sticky',
+      top: '24px',
+    },
+  },
 });
 
 // 仅移动端显示（< 1024px）

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -183,6 +183,21 @@ export const newDraftButton = style({
   },
 });
 
+export const newDraftButtonDanger = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.errorBorder}`,
+  background: vars.color.errorBg,
+  padding: '6px 10px',
+  fontSize: '14px',
+  fontWeight: 500,
+  color: vars.color.errorText,
+  cursor: 'pointer',
+  transition: 'background-color 150ms, color 150ms, border-color 150ms',
+});
+
 // 面板切换按钮，仅桌面端显示（带文字标签，避免与复制按钮混淆）
 export const panelToggle = recipe({
   base: {

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -193,3 +193,15 @@ export const panelToggle = recipe({
   },
   defaultVariants: { active: false },
 });
+
+// 自动保存状态提示
+export const saveStatusHint = style({
+  fontSize: '13px',
+  color: vars.color.textMuted,
+  display: 'none',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'inline',
+    },
+  },
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -170,23 +170,38 @@ function HomePageContent() {
       />
 
       <div className={styles.editorLayout}>
-        <div className={styles.editorSection}>
-          {draftLoadError ? (
-            <div className={styles.draftLoadError} role="status">
-              {draftLoadError}
+        <div
+          className={styles.panelOuter}
+          style={{ width: isPanelOpen ? '216px' : 0 }}
+        >
+          <DraftPanel onNewDraft={handleNewDraft} />
+        </div>
+
+        <div className={styles.mainContentArea}>
+          <div className={styles.editorSection}>
+            {draftLoadError ? (
+              <div className={styles.draftLoadError} role="status">
+                {draftLoadError}
+              </div>
+            ) : null}
+
+            <div className={styles.mobileOnly}>
+              <RecentDraftBar />
             </div>
-          ) : null}
 
-          <div className={styles.mobileOnly}>
-            <RecentDraftBar />
+            <div className={styles.editorCard}>
+              <MarkdownEditor activeTab={activeTab} />
+            </div>
           </div>
 
-          <div className={styles.editorCard}>
-            <MarkdownEditor activeTab={activeTab} />
-          </div>
-
-          <div className={styles.publishBar}>
+          <div className={styles.rightPanel}>
             <PlatformSelector />
+
+            <PlatformPreviewPanel
+              adaptations={platformDrafts}
+              selectedPlatforms={selectedPlatforms}
+            />
+
             <div className={styles.publishRight}>
               {overallStatus !== 'idle' && overallStatus !== 'publishing' && (
                 <button
@@ -198,23 +213,11 @@ function HomePageContent() {
               )}
               <PublishButton />
             </div>
+
+            {overallStatus !== 'idle' && (
+              <PublishStatusPanel />
+            )}
           </div>
-
-          <PlatformPreviewPanel
-            adaptations={platformDrafts}
-            selectedPlatforms={selectedPlatforms}
-          />
-
-          {overallStatus !== 'idle' && (
-            <PublishStatusPanel />
-          )}
-        </div>
-
-        <div
-          className={styles.panelOuter}
-          style={{ width: isPanelOpen ? '216px' : 0 }}
-        >
-          <DraftPanel onNewDraft={handleNewDraft} />
         </div>
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import PlatformSelector from '@/components/publish/PlatformSelector';
 import PublishButton from '@/components/publish/PublishButton';
 import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
 import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
+import PublishProgressOverlay from '@/components/publish/PublishProgressOverlay';
 import * as publishStyles from '@/components/publish/publish.css';
 import {
   NEWS_DRAFT_STORAGE_KEY,
@@ -226,6 +227,7 @@ function HomePageContent() {
           </div>
         </div>
       </div>
+      <PublishProgressOverlay />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import PublishButton from '@/components/publish/PublishButton';
 import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
 import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
 import PublishProgressOverlay from '@/components/publish/PublishProgressOverlay';
+import EditorialContextCard from '@/components/editor/EditorialContextCard';
 import * as publishStyles from '@/components/publish/publish.css';
 import { fetchDraftById } from '@/lib/drafts/client';
 import { useAutoSave } from '@/hooks/useAutoSave';
@@ -191,6 +192,8 @@ function HomePageContent() {
           </div>
 
           <div className={styles.rightPanel}>
+            <EditorialContextCard />
+
             <div className={publishStyles.rightPanelSection}>
               <span className={publishStyles.rightPanelSectionTitle}>发布到</span>
               <PlatformSelector />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Eye, Files, SquarePen, Eraser } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
@@ -42,6 +42,8 @@ function HomePageContent() {
   const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit');
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [draftLoadError, setDraftLoadError] = useState('');
+  const [clearConfirming, setClearConfirming] = useState(false);
+  const clearConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedPlatforms = useMemo(
     () => Object.entries(platforms)
       .filter(([, selected]) => selected)
@@ -68,6 +70,17 @@ function HomePageContent() {
     reset();
     router.replace('/');
   }, [reset, router, setContent, setTitle, setCurrentDraftId]);
+
+  const handleClearClick = useCallback(() => {
+    if (!clearConfirming) {
+      setClearConfirming(true);
+      clearConfirmTimerRef.current = setTimeout(() => setClearConfirming(false), 3000);
+      return;
+    }
+    if (clearConfirmTimerRef.current) clearTimeout(clearConfirmTimerRef.current);
+    setClearConfirming(false);
+    handleNewDraft();
+  }, [clearConfirming, handleNewDraft]);
 
   useEffect(() => {
     syncPlatformDrafts();
@@ -151,12 +164,12 @@ function HomePageContent() {
             </div>
             <button
               type="button"
-              onClick={handleNewDraft}
-              className={styles.newDraftButton}
-              title="清空写作台"
+              onClick={handleClearClick}
+              className={clearConfirming ? styles.newDraftButtonDanger : styles.newDraftButton}
+              title={clearConfirming ? '再次点击确认清空' : '清空写作台'}
             >
               <Eraser size={15} />
-              清空
+              {clearConfirming ? '确认清空？' : '清空'}
             </button>
             <button
               type="button"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,10 +14,6 @@ import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
 import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
 import PublishProgressOverlay from '@/components/publish/PublishProgressOverlay';
 import * as publishStyles from '@/components/publish/publish.css';
-import {
-  NEWS_DRAFT_STORAGE_KEY,
-  type NewsDraftPayload,
-} from '@/lib/newsDraft';
 import { fetchDraftById } from '@/lib/drafts/client';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import type { PlatformId } from '@/types';
@@ -85,21 +81,6 @@ function HomePageContent() {
   useEffect(() => {
     syncPlatformDrafts();
   }, [content, syncPlatformDrafts, title]);
-
-  useEffect(() => {
-    const rawDraft = window.localStorage.getItem(NEWS_DRAFT_STORAGE_KEY);
-    if (!rawDraft) return;
-
-    try {
-      const draft = JSON.parse(rawDraft) as NewsDraftPayload;
-      setTitle(draft.title || '');
-      setContent(draft.content || '');
-      reset();
-      window.localStorage.removeItem(NEWS_DRAFT_STORAGE_KEY);
-    } catch {
-      window.localStorage.removeItem(NEWS_DRAFT_STORAGE_KEY);
-    }
-  }, [reset, setContent, setTitle]);
 
   useEffect(() => {
     const draftId = searchParams.get('draftId');

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import PlatformSelector from '@/components/publish/PlatformSelector';
 import PublishButton from '@/components/publish/PublishButton';
 import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
 import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
+import * as publishStyles from '@/components/publish/publish.css';
 import {
   NEWS_DRAFT_STORAGE_KEY,
   type NewsDraftPayload,
@@ -195,28 +196,33 @@ function HomePageContent() {
           </div>
 
           <div className={styles.rightPanel}>
-            <PlatformSelector />
+            <div className={publishStyles.rightPanelSection}>
+              <span className={publishStyles.rightPanelSectionTitle}>发布到</span>
+              <PlatformSelector />
+            </div>
 
             <PlatformPreviewPanel
               adaptations={platformDrafts}
               selectedPlatforms={selectedPlatforms}
             />
 
-            <div className={styles.publishRight}>
-              {overallStatus !== 'idle' && overallStatus !== 'publishing' && (
-                <button
-                  onClick={reset}
-                  className={styles.resetLink}
-                >
-                  清除结果
-                </button>
-              )}
-              <PublishButton />
-            </div>
+            <div className={publishStyles.rightPanelSection}>
+              <div className={styles.publishRight}>
+                {overallStatus !== 'idle' && overallStatus !== 'publishing' && (
+                  <button
+                    onClick={reset}
+                    className={styles.resetLink}
+                  >
+                    清除结果
+                  </button>
+                )}
+                <PublishButton />
+              </div>
 
-            {overallStatus !== 'idle' && (
-              <PublishStatusPanel />
-            )}
+              {overallStatus !== 'idle' && (
+                <PublishStatusPanel />
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import {
   type NewsDraftPayload,
 } from '@/lib/newsDraft';
 import { fetchDraftById } from '@/lib/drafts/client';
+import { useAutoSave } from '@/hooks/useAutoSave';
 import type { PlatformId } from '@/types';
 import * as styles from './page.css';
 
@@ -31,6 +32,8 @@ function HomePageContent() {
     setContent,
     reset,
     overallStatus,
+    currentDraftId,
+    setCurrentDraftId,
   } = usePublishStore();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -44,12 +47,25 @@ function HomePageContent() {
     [platforms],
   );
 
+  const handleDraftCreated = useCallback((id: string) => {
+    setCurrentDraftId(id);
+    router.replace(`/?draftId=${id}`);
+  }, [setCurrentDraftId, router]);
+
+  const { saveStatus } = useAutoSave({
+    title,
+    content,
+    draftId: currentDraftId,
+    onDraftCreated: handleDraftCreated,
+  });
+
   const handleNewDraft = useCallback(() => {
     setTitle('');
     setContent('');
+    setCurrentDraftId(null);
     reset();
-    router.push('/');
-  }, [reset, router, setContent, setTitle]);
+    router.replace('/');
+  }, [reset, router, setContent, setTitle, setCurrentDraftId]);
 
   useEffect(() => {
     syncPlatformDrafts();
@@ -84,6 +100,7 @@ function HomePageContent() {
         if (cancelled) return;
         setTitle(draft.title);
         setContent(draft.content);
+        setCurrentDraftId(selectedDraftId);
         reset();
       } catch (error) {
         if (!cancelled) {
@@ -96,7 +113,7 @@ function HomePageContent() {
     return () => {
       cancelled = true;
     };
-  }, [reset, searchParams, setContent, setTitle]);
+  }, [reset, searchParams, setContent, setTitle, setCurrentDraftId]);
 
   return (
     <div className={styles.pageWrap}>
@@ -106,6 +123,12 @@ function HomePageContent() {
         description="在一个界面里完成写作、排版预览与多平台分发。"
         action={
           <div className={styles.headerActions}>
+            {saveStatus === 'saving' && (
+              <span className={styles.saveStatusHint}>保存中…</span>
+            )}
+            {saveStatus === 'saved' && (
+              <span className={styles.saveStatusHint}>已自动保存</span>
+            )}
             <div className={styles.tabSwitcher}>
               <button
                 type="button"

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -356,6 +356,13 @@ function SettingsContent() {
           const { Icon } = platform;
           const connectionProfile = connectionProfiles.find((profile) => profile.platform === platform.id);
           const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
+          const record = connectionRecords[platform.id];
+          // 账号名：优先用最新 check 结果，其次用持久化 record
+          const connectedAccountName =
+            (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
+            (!checkStates[platform.id] && record?.accountName) ||
+            null;
+          const isConnected = connectionProfile?.status === 'connected' && !disconnectStates[platform.id]?.done;
 
           return (
             <SurfaceCard key={platform.id} tone="soft" className={styles.accordionCard}>
@@ -371,7 +378,14 @@ function SettingsContent() {
                 </div>
                 <div className={styles.accordionBody}>
                   <p className={styles.accordionTitle}>{platform.name}</p>
-                  <p className={styles.accordionSummary}>{platform.summary}</p>
+                  {isConnected && connectedAccountName ? (
+                    <p className={styles.accordionAccountName}>
+                      <CheckCircle2 size={11} />
+                      {connectedAccountName}
+                    </p>
+                  ) : (
+                    <p className={styles.accordionSummary}>{platform.summary}</p>
+                  )}
                 </div>
                 <div className={styles.accordionToggle}>
                   {connectionProfile ? (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -276,6 +276,14 @@ function SettingsContent() {
       if (!response.ok || !data.success) throw new Error(data.error || '保存失败，请重试');
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
+
+      // Auto-verify all fully-configured platforms after save
+      const configuredPlatformIds = getPlatformConnectionProfiles(values)
+        .filter((p) => p.missingKeys.length === 0)
+        .map((p) => p.platform);
+      if (configuredPlatformIds.length > 0) {
+        void Promise.all(configuredPlatformIds.map((id) => handleCheckConnection(id)));
+      }
     } catch (error) {
       setSaved(false);
       setErrorMessage(error instanceof Error ? error.message : '保存失败，请重试');

--- a/src/app/settings/settings.css.ts
+++ b/src/app/settings/settings.css.ts
@@ -119,6 +119,17 @@ export const accordionSummary = style({
   color: vars.color.textMuted,
 });
 
+export const accordionAccountName = style({
+  margin: 0,
+  marginTop: '3px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontSize: '13px',
+  fontWeight: 500,
+  color: vars.color.successText,
+});
+
 export const accordionToggle = style({
   display: 'flex',
   flexShrink: 0,

--- a/src/app/sync-tasks/page.tsx
+++ b/src/app/sync-tasks/page.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import SyncTaskList from '@/components/sync/SyncTaskList';
 import { getSyncHistoryStore } from '@/lib/sync/registry';
@@ -14,10 +12,6 @@ export default function SyncTasksPage() {
 
   return (
     <div className={styles.pageWrap}>
-      <Link className={styles.backLink} href="/">
-        <ArrowLeft size={14} />
-        返回写作台
-      </Link>
       <AppShellHeader
         kicker="Sync history"
         title="分发记录"

--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -285,29 +285,34 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
 
               <ArrowRightCircle size={14} className={styles.pipelineArrow} />
 
-              <div className={styles.pipelineStep}>
-                <span className={styles.pipelineStepIcon}>
-                  <FileText size={14} />
-                </span>
-                <div className={styles.pipelineStepContent}>
-                  {syncTask ? (
-                    <>
-                      <span className={styles.pipelineStepLabel}>
-                        {syncStatusLabels[syncTask.status]}
-                      </span>
-                      <Link
-                        href={`/sync-tasks/${syncTask.id}`}
-                        className={styles.pipelineStepLink}
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        查看详情
-                      </Link>
-                    </>
-                  ) : (
-                    <span className={styles.pipelineStepLabel}>尚未分发</span>
-                  )}
+              {syncTask ? (
+                <div className={styles.syncStatusStepVariants[syncTask.status in styles.syncStatusStepVariants ? syncTask.status as keyof typeof styles.syncStatusStepVariants : 'default']}>
+                  <span className={styles.pipelineStepIcon}>
+                    <FileText size={14} />
+                  </span>
+                  <div className={styles.pipelineStepContent}>
+                    <span className={styles.syncStatusLabelVariants[syncTask.status in styles.syncStatusLabelVariants ? syncTask.status as keyof typeof styles.syncStatusLabelVariants : 'default']}>
+                      {syncStatusLabels[syncTask.status]}
+                    </span>
+                    <Link
+                      href={`/sync-tasks/${syncTask.id}`}
+                      className={styles.pipelineStepLink}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      查看详情
+                    </Link>
+                  </div>
                 </div>
-              </div>
+              ) : (
+                <div className={styles.syncStatusStepVariants.default}>
+                  <span className={styles.pipelineStepIcon}>
+                    <FileText size={14} />
+                  </span>
+                  <div className={styles.pipelineStepContent}>
+                    <span className={styles.syncStatusLabelVariants.default}>尚未分发</span>
+                  </div>
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -64,6 +64,7 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState('');
+  const [statusFilter, setStatusFilter] = useState<DraftStatus | 'all'>('all');
 
   useEffect(() => {
     if (!isEditMode) {
@@ -208,8 +209,23 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
         </div>
       )}
 
+      {!isEditMode && (
+        <div className={styles.filterBar}>
+          {(['all', 'draft', 'ready', 'syncing', 'synced', 'failed'] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              className={styles.filterChip({ active: statusFilter === s })}
+              onClick={() => setStatusFilter(s)}
+            >
+              {s === 'all' ? '全部' : statusLabels[s as DraftStatus]}
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className={styles.pipelineList}>
-        {drafts.map((draft) => {
+        {drafts.filter((d) => statusFilter === 'all' || d.status === statusFilter).map((draft) => {
           const syncTask = syncTasks.find((t) => t.draftId === draft.id);
           const isSelected = selected.has(draft.id);
 

--- a/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
+++ b/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
@@ -47,6 +47,11 @@ vi.mock('@/components/drafts/drafts.css', () => ({
   deleteErrorText: 'deleteErrorText',
   listHeader: 'listHeader',
   editToggleButton: 'editToggleButton',
+  syncStatusStepVariants: () => 'syncStatusStepVariants',
+  syncStatusLabelVariants: () => 'syncStatusLabelVariants',
+  filterBar: 'filterBar',
+  filterChip: (variants: { active?: boolean }) =>
+    variants?.active ? 'filterChip-active' : 'filterChip',
 }));
 
 describe('DraftLibraryClient', () => {

--- a/src/components/drafts/drafts.css.ts
+++ b/src/components/drafts/drafts.css.ts
@@ -557,3 +557,40 @@ export const syncStatusLabelVariants = styleVariants({
   'needs-action': { fontSize: '13px', fontWeight: 500, color: vars.color.warningText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   partial: { fontSize: '13px', fontWeight: 500, color: vars.color.warningText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
 });
+
+// 状态筛选栏
+export const filterBar = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '6px',
+});
+
+export const filterChip = recipe({
+  base: {
+    borderRadius: '999px',
+    border: `1px solid ${vars.color.border}`,
+    padding: '4px 12px',
+    fontSize: '12px',
+    cursor: 'pointer',
+    transition: 'background-color 150ms, color 150ms, border-color 150ms',
+  },
+  variants: {
+    active: {
+      true: {
+        background: vars.color.accent,
+        borderColor: vars.color.accent,
+        color: '#ffffff',
+        fontWeight: 500,
+      },
+      false: {
+        background: 'transparent',
+        color: vars.color.textMuted,
+        ':hover': {
+          borderColor: vars.color.borderStrong,
+          color: vars.color.text,
+        },
+      },
+    },
+  },
+  defaultVariants: { active: false },
+});

--- a/src/components/drafts/drafts.css.ts
+++ b/src/components/drafts/drafts.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/styles/tokens.css';
 
@@ -483,4 +483,77 @@ export const editToggleButton = style({
     color: vars.color.text,
     borderColor: vars.color.borderStrong,
   },
+});
+
+// 分发状态步骤变体（按状态显示不同颜色徽标）
+export const syncStatusStepVariants = styleVariants({
+  default: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    border: `1px solid ${vars.color.border}`,
+    background: vars.color.bgElevated,
+    padding: '8px 12px',
+    minWidth: '120px',
+  },
+  syncing: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    border: `1px solid ${vars.color.warningBorder}`,
+    background: vars.color.warningBg,
+    padding: '8px 12px',
+    minWidth: '120px',
+  },
+  completed: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    border: `1px solid ${vars.color.successBorder}`,
+    background: vars.color.successBg,
+    padding: '8px 12px',
+    minWidth: '120px',
+  },
+  failed: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    border: `1px solid ${vars.color.errorBorder}`,
+    background: vars.color.errorBg,
+    padding: '8px 12px',
+    minWidth: '120px',
+  },
+  'needs-action': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    border: `1px solid ${vars.color.warningBorder}`,
+    background: vars.color.warningBg,
+    padding: '8px 12px',
+    minWidth: '120px',
+  },
+  partial: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderRadius: vars.radius.lg,
+    border: `1px solid ${vars.color.warningBorder}`,
+    background: vars.color.warningBg,
+    padding: '8px 12px',
+    minWidth: '120px',
+  },
+});
+
+export const syncStatusLabelVariants = styleVariants({
+  default: { fontSize: '13px', fontWeight: 500, color: vars.color.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  syncing: { fontSize: '13px', fontWeight: 500, color: vars.color.warningText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  completed: { fontSize: '13px', fontWeight: 500, color: vars.color.successText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  failed: { fontSize: '13px', fontWeight: 500, color: vars.color.errorText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  'needs-action': { fontSize: '13px', fontWeight: 500, color: vars.color.warningText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  partial: { fontSize: '13px', fontWeight: 500, color: vars.color.warningText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
 });

--- a/src/components/editor/EditorialContextCard.tsx
+++ b/src/components/editor/EditorialContextCard.tsx
@@ -1,21 +1,16 @@
 'use client';
 
 import { usePublishStore } from '@/stores/publishStore';
-import SurfaceCard from '@/components/layout/SurfaceCard';
 import {
   countCharacters,
   countParagraphs,
   countHeadings,
   estimateReadTime,
 } from '@/lib/contentStats';
+import * as publishStyles from '@/components/publish/publish.css';
 import * as styles from './editor.css';
 
-interface StatPillProps {
-  label: string;
-  value: string;
-}
-
-function StatPill({ label, value }: StatPillProps) {
+function StatPill({ label, value }: { label: string; value: string }) {
   return (
     <div className={styles.statPill}>
       <div className={styles.statPillLabel}>{label}</div>
@@ -25,9 +20,8 @@ function StatPill({ label, value }: StatPillProps) {
 }
 
 export default function EditorialContextCard() {
-  const { title, content } = usePublishStore();
+  const { content } = usePublishStore();
 
-  const cleanTitle = title.trim();
   const cleanContent = content.trim();
   const characters = countCharacters(cleanContent);
   const paragraphs = countParagraphs(cleanContent);
@@ -35,54 +29,14 @@ export default function EditorialContextCard() {
   const readTime = estimateReadTime(cleanContent);
 
   return (
-    <SurfaceCard tone="accent" className={styles.contextCard}>
-      <div className={styles.contextInner}>
-        <div className={styles.contextHeader}>
-          <div className={styles.contextHeaderText}>
-            <p className={styles.contextKicker}>
-              Editorial context
-            </p>
-            <p className={styles.contextDesc}>
-              这里保留最必要的结构信号，帮助你判断稿件是否已经进入可发布状态。
-            </p>
-          </div>
-
-          <div className={styles.contextBadges}>
-            <span className={styles.contextBadgeNeutral}>
-              {cleanTitle ? '标题已写入' : '标题待补全'}
-            </span>
-            <span className={styles.contextBadgeAccent}>
-              Research-aware
-            </span>
-          </div>
-        </div>
-
-        {cleanTitle ? (
-          <div className={styles.titleBlock}>
-            <div className={styles.titleBlockLabel}>当前标题</div>
-            <div className={styles.titleBlockValue}>
-              {cleanTitle}
-            </div>
-          </div>
-        ) : (
-          <div className={styles.titleBlockEmpty}>
-            先补一个明确标题，后续的结构判断、导语节奏和发布预览会更容易对齐。
-          </div>
-        )}
-
-        <div className={styles.statsGrid}>
-          <StatPill label="字符" value={characters ? `${characters}` : '0'} />
-          <StatPill label="段落" value={paragraphs ? `${paragraphs}` : '0'} />
-          <StatPill label="标题层级" value={headings ? `${headings}` : '0'} />
-          <StatPill label="预计阅读" value={cleanContent ? readTime : '1 分钟'} />
-        </div>
-
-        <p className={styles.contextFooter}>
-          {cleanContent
-            ? '建议优先检查事实来源、时间线和关键术语，再把内容推向平台分发。'
-            : '内容尚未开始输入时，这里会保持轻量提示，不打断写作节奏。'}
-        </p>
+    <div className={publishStyles.rightPanelSection}>
+      <span className={publishStyles.rightPanelSectionTitle}>内容统计</span>
+      <div className={styles.statsGrid}>
+        <StatPill label="字符" value={characters ? `${characters}` : '0'} />
+        <StatPill label="段落" value={paragraphs ? `${paragraphs}` : '0'} />
+        <StatPill label="标题层级" value={headings ? `${headings}` : '0'} />
+        <StatPill label="阅读时长" value={cleanContent ? readTime : '—'} />
       </div>
-    </SurfaceCard>
+    </div>
   );
 }

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -114,19 +114,31 @@ export default function MarkdownEditor({ activeTab }: MarkdownEditorProps) {
       {/* 预览区 */}
       {activeTab === 'preview' && (
         <div className={styles.previewWrap}>
-          <div>
-            <div className={styles.previewTitleBlock}>
-              <p className={styles.previewKicker}>
-                成稿预览
-              </p>
-              <h3 className={styles.previewTitle}>
-                {title || '未命名稿件'}
-              </h3>
+          <div className={styles.previewPhoneFrame}>
+            {/* 模拟公众号/手机阅读顶栏 */}
+            <div className={styles.previewPhoneBar}>
+              <div className={styles.previewPhoneBarDots}>
+                <span className={styles.previewPhoneBarDot} />
+                <span className={styles.previewPhoneBarDot} />
+                <span className={styles.previewPhoneBarDot} />
+              </div>
+              <span className={styles.previewPhoneBarLabel}>成稿预览</span>
+              <div style={{ width: '36px' }} />
             </div>
-            <div
-              className={styles.previewContent}
-              dangerouslySetInnerHTML={{ __html: previewHtml }}
-            />
+            <div className={styles.previewInner}>
+              <div className={styles.previewTitleBlock}>
+                <p className={styles.previewKicker}>
+                  文章
+                </p>
+                <h3 className={styles.previewTitle}>
+                  {title || '未命名稿件'}
+                </h3>
+              </div>
+              <div
+                className={styles.previewContent}
+                dangerouslySetInnerHTML={{ __html: previewHtml }}
+              />
+            </div>
           </div>
         </div>
       )}

--- a/src/components/editor/editor.css.ts
+++ b/src/components/editor/editor.css.ts
@@ -138,6 +138,10 @@ export const statsDot = style({
 // Preview area
 export const previewWrap = style({
   padding: '24px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  background: vars.color.canvasDeep,
   '@media': {
     'screen and (min-width: 640px)': {
       padding: '32px',
@@ -146,6 +150,49 @@ export const previewWrap = style({
       minHeight: '420px',
     },
   },
+});
+
+// 模拟手机/公众号文章阅读容器
+export const previewPhoneFrame = style({
+  width: '100%',
+  maxWidth: '480px',
+  borderRadius: vars.radius.xl,
+  background: vars.color.surface,
+  boxShadow: '0 2px 16px rgba(0,0,0,0.08)',
+  overflow: 'hidden',
+});
+
+// 公众号风格顶部栏（模拟 status bar）
+export const previewPhoneBar = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '8px 14px',
+  borderBottom: `1px solid ${vars.color.borderFaint}`,
+  background: vars.color.bgElevated,
+});
+
+export const previewPhoneBarDot = style({
+  width: '6px',
+  height: '6px',
+  borderRadius: '50%',
+  background: vars.color.borderStrong,
+});
+
+export const previewPhoneBarDots = style({
+  display: 'flex',
+  gap: '4px',
+});
+
+export const previewPhoneBarLabel = style({
+  fontSize: '10px',
+  color: vars.color.textMuted,
+  letterSpacing: '0.08em',
+});
+
+// 文章内容内边距容器
+export const previewInner = style({
+  padding: '20px 20px 32px',
 });
 
 export const previewKicker = style({

--- a/src/components/layout/AppShellHeader.css.ts
+++ b/src/components/layout/AppShellHeader.css.ts
@@ -4,7 +4,9 @@ import { vars } from '@/styles/tokens.css';
 export const header = style({
   width: '100%',
   paddingTop: '8px',
-  paddingBottom: '8px',
+  paddingBottom: '16px',
+  marginBottom: '4px',
+  borderBottom: `1px solid ${vars.color.border}`,
 });
 
 export const inner = style({

--- a/src/components/layout/Sidebar.css.ts
+++ b/src/components/layout/Sidebar.css.ts
@@ -2,22 +2,80 @@ import { style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '@/styles/tokens.css';
 
 export const sidebar = style({
-  width: '100%',
-  borderBottom: `1px solid ${vars.color.border}`,
-  background: vars.color.bg,
-  color: vars.color.text,
+  display: 'none',
   '@media': {
     'screen and (min-width: 1024px)': {
+      display: 'block',
       position: 'sticky',
       top: 0,
       height: '100dvh',
       width: '18rem',
       flexShrink: 0,
-      borderBottom: 'none',
       borderRight: `1px solid ${vars.color.border}`,
+      background: vars.color.bg,
+      color: vars.color.text,
       overflowY: 'auto',
       overscrollBehavior: 'contain',
     },
+  },
+});
+
+export const mobileTabBar = style({
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  zIndex: 100,
+  display: 'flex',
+  alignItems: 'stretch',
+  background: vars.color.bg,
+  borderTop: `1px solid ${vars.color.border}`,
+  paddingBottom: 'env(safe-area-inset-bottom)',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'none',
+    },
+  },
+});
+
+export const mobileTabItem = styleVariants({
+  active: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '3px',
+    padding: '8px 4px',
+    textDecoration: 'none',
+    color: vars.color.accent,
+  },
+  inactive: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '3px',
+    padding: '8px 4px',
+    textDecoration: 'none',
+    color: vars.color.textMuted,
+    ':hover': {
+      color: vars.color.text,
+    },
+  },
+});
+
+export const mobileTabLabel = styleVariants({
+  active: {
+    fontSize: '10px',
+    fontWeight: 600,
+    lineHeight: 1,
+  },
+  inactive: {
+    fontSize: '10px',
+    fontWeight: 400,
+    lineHeight: 1,
   },
 });
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -53,57 +53,81 @@ export default function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className={styles.sidebar}>
-      <div className={styles.inner}>
-        <nav className={styles.nav}>
-          {navItems.map((item) => {
-            const isActive =
-              pathname === item.href ||
-              (item.href !== '/' && pathname.startsWith(item.href));
-            const Icon = item.icon;
-            const state = isActive ? 'active' : 'inactive';
+    <>
+      <aside className={styles.sidebar}>
+        <div className={styles.inner}>
+          <nav className={styles.nav}>
+            {navItems.map((item) => {
+              const isActive =
+                pathname === item.href ||
+                (item.href !== '/' && pathname.startsWith(item.href));
+              const Icon = item.icon;
+              const state = isActive ? 'active' : 'inactive';
 
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={cn(styles.navItemBase, styles.navItemVariants[state])}
-              >
-                <span className={styles.navIndicator[state]} />
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(styles.navItemBase, styles.navItemVariants[state])}
+                >
+                  <span className={styles.navIndicator[state]} />
 
-                <div className={cn(styles.navIconBase, styles.navIconVariants[state])}>
-                  <Icon size={14} />
-                </div>
-
-                <div className={styles.navText}>
-                  <div className={styles.navLabelRow}>
-                    <p className={styles.navLabelVariants[state]}>
-                      {item.label}
-                    </p>
-                    <ArrowRight
-                      size={13}
-                      className={styles.navArrowVariants[state]}
-                    />
+                  <div className={cn(styles.navIconBase, styles.navIconVariants[state])}>
+                    <Icon size={14} />
                   </div>
-                  <p className={styles.navDescription}>
-                    {item.description}
-                  </p>
-                </div>
-              </Link>
-            );
-          })}
-        </nav>
 
-        <div className={styles.brandFooter}>
-          <p className={cn(handwriting.className, styles.brandName)}>
-            Publio
-          </p>
-          <p className={styles.brandSlogan}>
-            Write once, publish everywhere.
-          </p>
-          <p className={styles.version}>v0.1.0</p>
+                  <div className={styles.navText}>
+                    <div className={styles.navLabelRow}>
+                      <p className={styles.navLabelVariants[state]}>
+                        {item.label}
+                      </p>
+                      <ArrowRight
+                        size={13}
+                        className={styles.navArrowVariants[state]}
+                      />
+                    </div>
+                    <p className={styles.navDescription}>
+                      {item.description}
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className={styles.brandFooter}>
+            <p className={cn(handwriting.className, styles.brandName)}>
+              Publio
+            </p>
+            <p className={styles.brandSlogan}>
+              Write once, publish everywhere.
+            </p>
+            <p className={styles.version}>v0.1.0</p>
+          </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+
+      <nav className={styles.mobileTabBar} aria-label="移动端导航">
+        {navItems.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            (item.href !== '/' && pathname.startsWith(item.href));
+          const Icon = item.icon;
+          const state = isActive ? 'active' : 'inactive';
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={styles.mobileTabItem[state]}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <Icon size={20} />
+              <span className={styles.mobileTabLabel[state]}>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Settings2,
   ArrowRight,
   Library,
+  Send,
 } from 'lucide-react';
 import { Dancing_Script } from 'next/font/google';
 import { cn } from '@/lib/cn';
@@ -33,6 +34,12 @@ const navItems = [
     label: '稿件库',
     description: '管理所有草稿，追踪从选题到分发的完整链路。',
     icon: Library,
+  },
+  {
+    href: '/sync-tasks',
+    label: '分发记录',
+    description: '查看各平台发布回执、失败原因与重试入口。',
+    icon: Send,
   },
   {
     href: '/settings',

--- a/src/components/news/AiNewsPageClient.tsx
+++ b/src/components/news/AiNewsPageClient.tsx
@@ -93,6 +93,8 @@ interface NewsState {
   totalCandidates: number;
 }
 let cachedNewsState: NewsState | null = null;
+// 模块级缓存：保持卡片底稿展开/折叠状态，tab 切换回来时不重置
+const cachedBriefOpenMap: Map<string, boolean> = new Map();
 
 export default function AiNewsPageClient() {
   const router = useRouter();
@@ -108,6 +110,7 @@ export default function AiNewsPageClient() {
   const [draftError, setDraftError] = useState('');
   // Maps clusterId → draftId for topics the user has sent to the writing desk
   const [topicDraftMap, setTopicDraftMap] = useState<Record<string, string>>({});
+  const [briefOpenMap, setBriefOpenMap] = useState<Map<string, boolean>>(cachedBriefOpenMap);
   const hasDeskDataRef = useRef(false);
 
   const allCandidates = [...todayCandidates, ...followCandidates];
@@ -306,6 +309,11 @@ export default function AiNewsPageClient() {
               items={todayCandidates}
               offset={0}
               topicDraftMap={topicDraftMap}
+              briefOpenMap={briefOpenMap}
+              onBriefToggle={(clusterId, open) => {
+                cachedBriefOpenMap.set(clusterId, open);
+                setBriefOpenMap(new Map(cachedBriefOpenMap));
+              }}
               onCreateDraft={createSingleNewsDraft}
             />
             <CandidateSection
@@ -313,6 +321,11 @@ export default function AiNewsPageClient() {
               items={followCandidates}
               offset={todayCandidates.length}
               topicDraftMap={topicDraftMap}
+              briefOpenMap={briefOpenMap}
+              onBriefToggle={(clusterId, open) => {
+                cachedBriefOpenMap.set(clusterId, open);
+                setBriefOpenMap(new Map(cachedBriefOpenMap));
+              }}
               onCreateDraft={createSingleNewsDraft}
             />
           </div>
@@ -331,12 +344,16 @@ function CandidateSection({
   items,
   offset,
   topicDraftMap,
+  briefOpenMap,
+  onBriefToggle,
   onCreateDraft,
 }: {
   title: string;
   items: AiNewsDeskCandidate[];
   offset: number;
   topicDraftMap: Record<string, string>;
+  briefOpenMap: Map<string, boolean>;
+  onBriefToggle: (clusterId: string, open: boolean) => void;
   onCreateDraft: (item: AiNewsDeskCandidate) => void;
 }) {
   if (items.length === 0) return null;
@@ -351,6 +368,8 @@ function CandidateSection({
           relativeLabel={formatRelativeHours(item.latestPublishedAt)}
           formattedDate={formatDateTime(item.latestPublishedAt)}
           draftId={topicDraftMap[item.clusterId]}
+          showBrief={briefOpenMap.get(item.clusterId) ?? false}
+          onBriefToggle={(open) => onBriefToggle(item.clusterId, open)}
           onCreateDraft={onCreateDraft}
         />
       ))}

--- a/src/components/news/ScoreBar.css.ts
+++ b/src/components/news/ScoreBar.css.ts
@@ -1,0 +1,41 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+export const row = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+export const label = style({
+  width: '48px',
+  flexShrink: 0,
+  fontSize: '12px',
+  color: vars.color.textMuted,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const track = style({
+  flex: 1,
+  height: '4px',
+  background: vars.color.canvasDeep,
+  borderRadius: '2px',
+  overflow: 'hidden',
+});
+
+export const fill = style({
+  height: '100%',
+  background: vars.color.accent,
+  borderRadius: '2px',
+  transition: 'width 400ms ease',
+});
+
+export const value = style({
+  width: '24px',
+  flexShrink: 0,
+  fontSize: '12px',
+  textAlign: 'right',
+  color: vars.color.textMuted,
+});

--- a/src/components/news/ScoreBar.tsx
+++ b/src/components/news/ScoreBar.tsx
@@ -1,0 +1,21 @@
+import * as styles from './ScoreBar.css';
+
+interface ScoreBarProps {
+  label: string;
+  value: number;
+  max?: number;
+}
+
+export default function ScoreBar({ label, value, max = 100 }: ScoreBarProps) {
+  const pct = Math.min(100, Math.max(0, (value / max) * 100));
+
+  return (
+    <div className={styles.row}>
+      <span className={styles.label} title={label}>{label}</span>
+      <div className={styles.track}>
+        <div className={styles.fill} style={{ width: `${pct}%` }} />
+      </div>
+      <span className={styles.value}>{Math.round(value)}</span>
+    </div>
+  );
+}

--- a/src/components/news/TopicSignalCard.tsx
+++ b/src/components/news/TopicSignalCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Clock3, ExternalLink, FileUp, ChevronDown, CheckCircle2 } from 'lucide-react';
 
 import SurfaceCard from '@/components/layout/SurfaceCard';
@@ -12,6 +11,8 @@ interface TopicSignalCardProps {
   relativeLabel: string;
   formattedDate: string;
   draftId?: string;
+  showBrief: boolean;
+  onBriefToggle: (open: boolean) => void;
   onCreateDraft: (item: AiNewsDeskCandidate) => void;
 }
 
@@ -32,9 +33,10 @@ export default function TopicSignalCard({
   relativeLabel,
   formattedDate,
   draftId,
+  showBrief,
+  onBriefToggle,
   onCreateDraft,
 }: TopicSignalCardProps) {
-  const [showBrief, setShowBrief] = useState(false);
   const brief = item.researchBrief;
   const metrics = formatArticleMetrics(
     item.primarySignal.articleWordCount,
@@ -129,7 +131,7 @@ export default function TopicSignalCard({
             </a>
             <button
               type="button"
-              onClick={() => setShowBrief((v) => !v)}
+              onClick={() => onBriefToggle(!showBrief)}
               className={styles.actionButton({ variant: 'secondary' })}
             >
               <ChevronDown

--- a/src/components/news/TopicSignalCard.tsx
+++ b/src/components/news/TopicSignalCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Clock3, ExternalLink, FileUp, ChevronDown, CheckCircle2 } from 'lucide-react';
 
 import SurfaceCard from '@/components/layout/SurfaceCard';
+import ScoreBar from '@/components/news/ScoreBar';
 import type { AiNewsDeskCandidate } from '@/lib/aiNews';
 import * as styles from './news.css';
 
@@ -103,16 +104,19 @@ export default function TopicSignalCard({
 
           {/* 操作按钮 */}
           <div className={styles.actionsRow}>
-            {/* 评分区 — 底部左侧 */}
-            <div className={styles.scoreRow}>
-              <span className={styles.scoreHighlight}>
+            {/* 评分区 — 六条进度条 + 总分，桌面端显示 */}
+            <div className={styles.scoreBarsBlock}>
+              <div className={styles.scoreBarsGrid}>
+                <ScoreBar label="新鲜度" value={item.scores.freshness} />
+                <ScoreBar label="影响力" value={item.scores.impact} />
+                <ScoreBar label="势　能" value={item.scores.momentum} />
+                <ScoreBar label="可信度" value={item.scores.credibility} />
+                <ScoreBar label="视觉力" value={item.scores.visualReadiness} />
+                <ScoreBar label="创作适" value={item.scores.creatorFit} />
+              </div>
+              <span className={styles.scoreHighlight} style={{ alignSelf: 'flex-end', flexShrink: 0 }}>
                 {item.totalScore.toFixed(0)} 分
               </span>
-              <span>·</span>
-              <span>新鲜度 {item.scores.freshness}</span>
-              <span>影响力 {item.scores.impact}</span>
-              <span>势能 {item.scores.momentum}</span>
-              <span>可信度 {item.scores.credibility}</span>
             </div>
             <a
               href={item.primarySignal.link}

--- a/src/components/news/news.css.ts
+++ b/src/components/news/news.css.ts
@@ -440,3 +440,24 @@ export const affectedList = style({
   fontSize: '14px',
   color: vars.color.text,
 });
+
+// 评分进度条区块
+export const scoreBarsBlock = style({
+  display: 'none',
+  marginRight: 'auto',
+  alignItems: 'flex-start',
+  gap: '12px',
+  '@media': {
+    'screen and (min-width: 640px)': {
+      display: 'flex',
+    },
+  },
+});
+
+export const scoreBarsGrid = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  flex: 1,
+  minWidth: '160px',
+});

--- a/src/components/publish/PlatformPreviewPanel.tsx
+++ b/src/components/publish/PlatformPreviewPanel.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import type { PlatformId } from '@/types';
 import type {
   PlatformContentDrafts,
@@ -54,75 +58,90 @@ export default function PlatformPreviewPanel({
   adaptations,
   selectedPlatforms,
 }: PlatformPreviewPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
   if (selectedPlatforms.length === 0) return null;
 
   return (
-    <section className={styles.previewPanel}>
-      <div className={styles.previewHeader}>
-        <p className={styles.panelKicker}>Platform config</p>
-        <h2 className={styles.previewTitle}>发布配置</h2>
-      </div>
+    <div className={styles.rightPanelSection}>
+      <button
+        type="button"
+        className={styles.collapseToggle}
+        onClick={() => setIsOpen((v) => !v)}
+        aria-expanded={isOpen}
+      >
+        <span className={styles.rightPanelSectionTitle}>内容配置</span>
+        <ChevronDown
+          size={14}
+          className={`${styles.collapseChevron}${isOpen ? ` ${styles.collapseChevronOpen}` : ''}`}
+        />
+      </button>
 
-      <div className={styles.previewGrid}>
-        {selectedPlatforms.map((platform) => {
-          const draft = adaptations[platform];
-          const firstImage = extractFirstImage(draft.body);
+      <div
+        className={styles.collapseContent}
+        style={{ maxHeight: isOpen ? '600px' : 0 }}
+      >
+        <div className={styles.previewGrid} style={{ marginTop: '8px' }}>
+          {selectedPlatforms.map((platform) => {
+            const draft = adaptations[platform];
+            const firstImage = extractFirstImage(draft.body);
 
-          return (
-            <article key={platform} className={styles.previewCard}>
-              {/* 平台名 + 状态 */}
-              <div className={styles.previewMeta}>
-                <p className={styles.previewPlatform}>{platformLabels[platform]}</p>
-                <span className={`${styles.previewState} ${draft.isReady ? '' : styles.previewStateNotReady}`}>
-                  {draft.isReady ? '可发布' : '待补全'} · {formatLabels[draft.format]}
-                </span>
-              </div>
-
-              {/* 首图预览（外部 URL，无法提前配置 next/image 域名白名单） */}
-              {firstImage ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={firstImage}
-                  alt=""
-                  className={styles.previewImage}
-                />
-              ) : null}
-
-              {/* 内容摘要 */}
-              {draft.body ? (
-                <p className={styles.previewBody}>{createExcerpt(draft.body)}</p>
-              ) : null}
-
-              {/* Warnings */}
-              {draft.warnings.length > 0 ? (
-                <ul className={styles.previewWarningList}>
-                  {draft.warnings.map((warning) => (
-                    <li key={warning}>{warning}</li>
-                  ))}
-                </ul>
-              ) : null}
-
-              {/* 小红书：话题标签 */}
-              {draft.suggestedTags.length > 0 ? (
-                <div className={styles.previewTagList}>
-                  {draft.suggestedTags.map((tag) => (
-                    <span key={tag}>#{tag}</span>
-                  ))}
+            return (
+              <article key={platform} className={styles.previewCard}>
+                {/* 平台名 + 状态 */}
+                <div className={styles.previewMeta}>
+                  <p className={styles.previewPlatform}>{platformLabels[platform]}</p>
+                  <span className={`${styles.previewState} ${draft.isReady ? '' : styles.previewStateNotReady}`}>
+                    {draft.isReady ? '可发布' : '待补全'} · {formatLabels[draft.format]}
+                  </span>
                 </div>
-              ) : null}
 
-              {/* X：Thread 分段预览 */}
-              {draft.threadParts.length > 1 ? (
-                <ol className={styles.previewThreadList}>
-                  {draft.threadParts.map((part, index) => (
-                    <li key={`${index}-${part.slice(0, 20)}`}>{`${index + 1}. ${part}`}</li>
-                  ))}
-                </ol>
-              ) : null}
-            </article>
-          );
-        })}
+                {/* 首图预览（外部 URL，无法提前配置 next/image 域名白名单） */}
+                {firstImage ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={firstImage}
+                    alt=""
+                    className={styles.previewImage}
+                  />
+                ) : null}
+
+                {/* 内容摘要 */}
+                {draft.body ? (
+                  <p className={styles.previewBody}>{createExcerpt(draft.body)}</p>
+                ) : null}
+
+                {/* Warnings */}
+                {draft.warnings.length > 0 ? (
+                  <ul className={styles.previewWarningList}>
+                    {draft.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                {/* 小红书：话题标签 */}
+                {draft.suggestedTags.length > 0 ? (
+                  <div className={styles.previewTagList}>
+                    {draft.suggestedTags.map((tag) => (
+                      <span key={tag}>#{tag}</span>
+                    ))}
+                  </div>
+                ) : null}
+
+                {/* X：Thread 分段预览 */}
+                {draft.threadParts.length > 1 ? (
+                  <ol className={styles.previewThreadList}>
+                    {draft.threadParts.map((part, index) => (
+                      <li key={`${index}-${part.slice(0, 20)}`}>{`${index + 1}. ${part}`}</li>
+                    ))}
+                  </ol>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/src/components/publish/PlatformSelector.tsx
+++ b/src/components/publish/PlatformSelector.tsx
@@ -8,7 +8,7 @@ import {
   ZhihuIcon,
   XIcon,
 } from '@/components/icons/PlatformIcons';
-import { selectorWrap, platformLabel, srOnly } from './publish.css';
+import { selectorWrap, platformLabel, srOnly, selectorFooter, selectorToggleAll } from './publish.css';
 
 const platformIconMap: Record<PlatformId, React.ComponentType<{ size?: number }>> = {
   wechat: WechatIcon,
@@ -18,30 +18,45 @@ const platformIconMap: Record<PlatformId, React.ComponentType<{ size?: number }>
 };
 
 export default function PlatformSelector() {
-  const { platforms, togglePlatform } = usePublishStore();
+  const { platforms, togglePlatform, setAllPlatforms } = usePublishStore();
+
+  const selectedCount = Object.values(platforms).filter(Boolean).length;
+  const allSelected = selectedCount === PLATFORMS.length;
 
   return (
-    <div className={selectorWrap}>
-      {PLATFORMS.map((platform) => {
-        const Icon = platformIconMap[platform.id as PlatformId];
-        const checked = platforms[platform.id as PlatformId];
+    <div>
+      <div className={selectorWrap}>
+        {PLATFORMS.map((platform) => {
+          const Icon = platformIconMap[platform.id as PlatformId];
+          const checked = platforms[platform.id as PlatformId];
 
-        return (
-          <label
-            key={platform.id}
-            className={platformLabel({ checked })}
-          >
-            <input
-              type="checkbox"
-              checked={checked}
-              onChange={() => togglePlatform(platform.id as PlatformId)}
-              className={srOnly}
-            />
-            <Icon size={16} />
-            {platform.name}
-          </label>
-        );
-      })}
+          return (
+            <label
+              key={platform.id}
+              className={platformLabel({ checked })}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => togglePlatform(platform.id as PlatformId)}
+                className={srOnly}
+              />
+              <Icon size={16} />
+              {platform.name}
+            </label>
+          );
+        })}
+      </div>
+      <div className={selectorFooter}>
+        <span>{selectedCount > 0 ? `已选 ${selectedCount} 个平台` : '请选择平台'}</span>
+        <button
+          type="button"
+          className={selectorToggleAll}
+          onClick={() => setAllPlatforms(!allSelected)}
+        >
+          {allSelected ? '全不选' : '全选'}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/publish/PublishButton.tsx
+++ b/src/components/publish/PublishButton.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { usePublishStore } from '@/stores/publishStore';
 import { PlatformId, PublishResponse } from '@/types';
 import { SendHorizonal, Loader2, AlertCircle } from 'lucide-react';
@@ -14,9 +13,17 @@ const platformLabels: Record<PlatformId, string> = {
 };
 
 export default function PublishButton() {
-  const router = useRouter();
-  const { title, content, platforms, platformDrafts, overallStatus, setPublishing, setResults } =
-    usePublishStore();
+  const {
+    title,
+    content,
+    platforms,
+    platformDrafts,
+    overallStatus,
+    setPublishing,
+    setResults,
+    setLastSyncTaskId,
+    openProgressOverlay,
+  } = usePublishStore();
 
   const selectedPlatforms = (
     Object.entries(platforms) as [PlatformId, boolean][]
@@ -68,8 +75,9 @@ export default function PublishButton() {
 
       if (!('syncTaskId' in data)) throw new Error('发布结果格式异常，请稍后重试');
 
-      // Immediately navigate to the sync task detail page
-      router.push(`/sync-tasks/${data.syncTaskId}`);
+      // 原地显示发布进度浮层，不跳转
+      setLastSyncTaskId(data.syncTaskId);
+      openProgressOverlay();
     } catch (error) {
       setResults(
         selectedPlatforms.map((p) => ({

--- a/src/components/publish/PublishProgressOverlay.css.ts
+++ b/src/components/publish/PublishProgressOverlay.css.ts
@@ -1,0 +1,115 @@
+import { style, keyframes } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+const slideUp = keyframes({
+  from: { transform: 'translateY(8px)', opacity: 0 },
+  to: { transform: 'translateY(0)', opacity: 1 },
+});
+
+export const overlay = style({
+  position: 'fixed',
+  bottom: '24px',
+  right: '24px',
+  width: '320px',
+  zIndex: 1000,
+  borderRadius: vars.radius.xl,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.surface,
+  boxShadow: '0 8px 32px rgba(0,0,0,0.12)',
+  animation: `${slideUp} 150ms ease-out`,
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '12px 14px',
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const headerTitle = style({
+  fontSize: '13px',
+  fontWeight: 600,
+  color: vars.color.text,
+});
+
+export const closeButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '24px',
+  height: '24px',
+  borderRadius: '6px',
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  color: vars.color.textMuted,
+  transition: 'background-color 150ms, color 150ms',
+  ':hover': {
+    background: vars.color.canvasDeep,
+    color: vars.color.text,
+  },
+});
+
+export const body = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2px',
+  padding: '8px 14px',
+});
+
+export const receiptRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+  padding: '8px 0',
+  borderBottom: `1px solid ${vars.color.border}`,
+  selectors: {
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+  },
+});
+
+export const platformName = style({
+  fontSize: '13px',
+  color: vars.color.text,
+  flex: 1,
+  minWidth: 0,
+});
+
+export const statusText = style({
+  fontSize: '12px',
+  color: vars.color.textMuted,
+  flexShrink: 0,
+});
+
+export const statusTextSuccess = style({
+  color: vars.color.successText,
+});
+
+export const statusTextError = style({
+  color: vars.color.errorText,
+});
+
+export const footer = style({
+  padding: '10px 14px',
+  borderTop: `1px solid ${vars.color.border}`,
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
+export const detailLink = style({
+  fontSize: '13px',
+  color: vars.color.accent,
+  textDecoration: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});

--- a/src/components/publish/PublishProgressOverlay.tsx
+++ b/src/components/publish/PublishProgressOverlay.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { X, Loader2, CheckCircle2, XCircle, ArrowUpRight } from 'lucide-react';
+import { usePublishStore } from '@/stores/publishStore';
+import type { SyncTask, SyncReceiptStatus } from '@/lib/sync/types';
+import type { PlatformId } from '@/types';
+import * as styles from './PublishProgressOverlay.css';
+
+const platformLabels: Record<PlatformId, string> = {
+  wechat: '微信公众号',
+  xiaohongshu: '小红书',
+  zhihu: '知乎',
+  x: 'X (Twitter)',
+};
+
+function isTerminalStatus(status: SyncReceiptStatus) {
+  return status !== 'pending' && status !== 'syncing';
+}
+
+function StatusIcon({ status }: { status: SyncReceiptStatus }) {
+  if (status === 'pending' || status === 'syncing') {
+    return <Loader2 size={14} className="animate-spin" />;
+  }
+  if (status === 'published' || status === 'draft-created') {
+    return <CheckCircle2 size={14} style={{ color: 'var(--success-text, #247a4b)' }} />;
+  }
+  return <XCircle size={14} style={{ color: 'var(--error-text, #bf4b4b)' }} />;
+}
+
+function statusLabel(status: SyncReceiptStatus): string {
+  switch (status) {
+    case 'pending': return '等待中';
+    case 'syncing': return '发布中…';
+    case 'draft-created': return '草稿已创建';
+    case 'published': return '已发布';
+    case 'failed': return '失败';
+    case 'needs-action': return '需要处理';
+    default: return status;
+  }
+}
+
+function statusClass(status: SyncReceiptStatus): string {
+  if (status === 'published' || status === 'draft-created') return styles.statusTextSuccess;
+  if (status === 'failed' || status === 'needs-action') return styles.statusTextError;
+  return styles.statusText;
+}
+
+export default function PublishProgressOverlay() {
+  const { isProgressOverlayOpen, lastSyncTaskId, closeProgressOverlay } = usePublishStore();
+  const [syncTask, setSyncTask] = useState<SyncTask | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const isDone = syncTask
+    ? syncTask.receipts.every((r) => isTerminalStatus(r.status))
+    : false;
+
+  useEffect(() => {
+    if (!isProgressOverlayOpen || !lastSyncTaskId) return;
+
+    // 立即拉一次
+    async function fetchTask() {
+      if (!lastSyncTaskId) return;
+      try {
+        const res = await fetch(`/api/sync-tasks/${lastSyncTaskId}`, { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = await res.json() as { syncTask: SyncTask };
+        setSyncTask(data.syncTask);
+        // 所有 receipt 都到终态时停止轮询
+        if (data.syncTask.receipts.every((r) => isTerminalStatus(r.status))) {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+        }
+      } catch {
+        // 网络错误时静默，继续等待下一次轮询
+      }
+    }
+
+    void fetchTask();
+    intervalRef.current = setInterval(() => { void fetchTask(); }, 2000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [isProgressOverlayOpen, lastSyncTaskId]);
+
+  // 关闭时清理状态
+  function handleClose() {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setSyncTask(null);
+    closeProgressOverlay();
+  }
+
+  if (!isProgressOverlayOpen || !lastSyncTaskId) return null;
+
+  return (
+    <div className={styles.overlay} role="status" aria-live="polite">
+      <div className={styles.header}>
+        <span className={styles.headerTitle}>分发进度</span>
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={handleClose}
+          aria-label="关闭"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        {syncTask ? (
+          syncTask.receipts.map((receipt) => (
+            <div key={receipt.platform} className={styles.receiptRow}>
+              <StatusIcon status={receipt.status} />
+              <span className={styles.platformName}>
+                {platformLabels[receipt.platform] ?? receipt.platform}
+              </span>
+              <span className={`${styles.statusText} ${statusClass(receipt.status)}`}>
+                {statusLabel(receipt.status)}
+              </span>
+            </div>
+          ))
+        ) : (
+          // 任务数据尚未加载时的骨架
+          <div className={styles.receiptRow}>
+            <Loader2 size={14} className="animate-spin" />
+            <span className={styles.platformName}>正在初始化…</span>
+          </div>
+        )}
+      </div>
+
+      {isDone && (
+        <div className={styles.footer}>
+          <Link
+            href={`/sync-tasks/${lastSyncTaskId}`}
+            className={styles.detailLink}
+            onClick={handleClose}
+          >
+            查看完整详情
+            <ArrowUpRight size={13} />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/publish/__tests__/PlatformPreviewPanel.test.tsx
+++ b/src/components/publish/__tests__/PlatformPreviewPanel.test.tsx
@@ -5,7 +5,33 @@ import { createElement } from 'react';
 import type { PlatformContentDrafts } from '@/lib/platformAdapters/types';
 
 vi.mock('@/components/publish/publish.css', () => ({
+  selectorWrap: 'selectorWrap',
+  selectorFooter: 'selectorFooter',
+  selectorToggleAll: 'selectorToggleAll',
+  platformLabel: 'platformLabel',
+  srOnly: 'srOnly',
+  publishButton: 'publishButton',
+  panel: 'panel',
+  panelHeader: 'panelHeader',
   panelKicker: 'panelKicker',
+  panelTitle: 'panelTitle',
+  panelStats: 'panelStats',
+  statBadge: 'statBadge',
+  resultList: 'resultList',
+  resultCardVariants: () => 'resultCardVariants',
+  resultPlatformRow: 'resultPlatformRow',
+  platformIconWrap: 'platformIconWrap',
+  platformName: 'platformName',
+  platformSubLabel: 'platformSubLabel',
+  resultMessage: 'resultMessage',
+  resultMessageTextVariants: () => 'resultMessageTextVariants',
+  resultActions: 'resultActions',
+  statusBadgeVariants: () => 'statusBadgeVariants',
+  externalLink: 'externalLink',
+  loadingWrap: 'loadingWrap',
+  loadingCard: 'loadingCard',
+  loadingText: 'loadingText',
+  loadingPlaceholder: 'loadingPlaceholder',
   previewPanel: 'previewPanel',
   previewHeader: 'previewHeader',
   previewTitle: 'previewTitle',
@@ -16,9 +42,16 @@ vi.mock('@/components/publish/publish.css', () => ({
   previewState: 'previewState',
   previewStateNotReady: 'previewStateNotReady',
   previewBody: 'previewBody',
+  previewImage: 'previewImage',
   previewWarningList: 'previewWarningList',
   previewTagList: 'previewTagList',
   previewThreadList: 'previewThreadList',
+  rightPanelSection: 'rightPanelSection',
+  rightPanelSectionTitle: 'rightPanelSectionTitle',
+  collapseToggle: 'collapseToggle',
+  collapseContent: 'collapseContent',
+  collapseChevron: 'collapseChevron',
+  collapseChevronOpen: 'collapseChevronOpen',
 }));
 
 describe('PlatformPreviewPanel', () => {
@@ -74,7 +107,7 @@ describe('PlatformPreviewPanel', () => {
       selectedPlatforms: ['xiaohongshu', 'x'],
     }));
 
-    expect(screen.getByText('发布配置')).toBeInTheDocument();
+    expect(screen.getByText('内容配置')).toBeInTheDocument();
     expect(screen.getByText('小红书')).toBeInTheDocument();
     expect(screen.getByText('小红书标题建议控制在 20 字以内')).toBeInTheDocument();
     expect(screen.getByText('X (Twitter)')).toBeInTheDocument();

--- a/src/components/publish/publish.css.ts
+++ b/src/components/publish/publish.css.ts
@@ -8,6 +8,28 @@ export const selectorWrap = style({
   gap: '8px',
 });
 
+export const selectorFooter = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginTop: '8px',
+  fontSize: '12px',
+  color: vars.color.textMuted,
+});
+
+export const selectorToggleAll = style({
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  fontSize: '12px',
+  color: vars.color.accent,
+  cursor: 'pointer',
+  transition: 'color 150ms',
+  ':hover': {
+    color: vars.color.signal,
+  },
+});
+
 export const platformLabel = recipe({
   base: {
     display: 'inline-flex',

--- a/src/components/publish/publish.css.ts
+++ b/src/components/publish/publish.css.ts
@@ -472,3 +472,50 @@ export const previewThreadList = style({
   overflowY: 'auto',
   overscrollBehavior: 'contain',
 });
+
+// 右侧面板区块容器
+export const rightPanelSection = style({
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.surface,
+  padding: '12px 14px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '10px',
+});
+
+export const rightPanelSectionTitle = style({
+  fontSize: '11px',
+  fontWeight: 500,
+  textTransform: 'uppercase',
+  letterSpacing: '0.32em',
+  color: vars.color.accent,
+});
+
+// 折叠区域：发布配置
+export const collapseToggle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  gap: '6px',
+});
+
+export const collapseContent = style({
+  overflow: 'hidden',
+  transition: 'max-height 220ms cubic-bezier(0.4, 0, 0.2, 1)',
+});
+
+export const collapseChevron = style({
+  transition: 'transform 220ms',
+  flexShrink: 0,
+  color: vars.color.textMuted,
+});
+
+export const collapseChevronOpen = style({
+  transform: 'rotate(180deg)',
+});

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { updateDraft, ensureDraft } from '@/lib/drafts/client';
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+interface UseAutoSaveOptions {
+  title: string;
+  content: string;
+  draftId: string | null;
+  onDraftCreated: (id: string) => void;
+  debounceMs?: number;
+}
+
+export function useAutoSave({
+  title,
+  content,
+  draftId,
+  onDraftCreated,
+  debounceMs = 1000,
+}: UseAutoSaveOptions): { saveStatus: SaveStatus } {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 使用 ref 追踪最新值，避免 stale closure
+  const draftIdRef = useRef(draftId);
+  const onDraftCreatedRef = useRef(onDraftCreated);
+
+  useEffect(() => {
+    draftIdRef.current = draftId;
+  }, [draftId]);
+
+  useEffect(() => {
+    onDraftCreatedRef.current = onDraftCreated;
+  }, [onDraftCreated]);
+
+  useEffect(() => {
+    // 标题和内容都为空时不触发
+    if (!title.trim() && !content.trim()) return;
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    timerRef.current = setTimeout(async () => {
+      // 标题为空时不创建新草稿，但若已有草稿则更新内容
+      if (!title.trim() && !draftIdRef.current) return;
+
+      setSaveStatus('saving');
+      try {
+        if (draftIdRef.current) {
+          await updateDraft(draftIdRef.current, { title, content });
+        } else {
+          const draft = await ensureDraft({ title, content, source: 'manual' });
+          onDraftCreatedRef.current(draft.id);
+        }
+        setSaveStatus('saved');
+      } catch {
+        setSaveStatus('error');
+      }
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [title, content, debounceMs]);
+
+  return { saveStatus };
+}

--- a/src/lib/drafts/client.ts
+++ b/src/lib/drafts/client.ts
@@ -39,3 +39,34 @@ export async function deleteDraft(id: string) {
     throw new Error(data.error || '稿件删除失败，请稍后重试。');
   }
 }
+
+export async function updateDraft(
+  id: string,
+  input: { title?: string; content?: string },
+): Promise<ContentDraft> {
+  const response = await fetch(`/api/drafts/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  const data = (await response.json()) as DraftResponse;
+  if (!response.ok || !data.draft) {
+    throw new Error(data.error || '草稿更新失败，请稍后重试。');
+  }
+  return data.draft;
+}
+
+export async function ensureDraft(
+  input: Pick<CreateDraftInput, 'title' | 'content' | 'source'>,
+): Promise<ContentDraft> {
+  const response = await fetch('/api/drafts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  const data = (await response.json()) as DraftResponse;
+  if (!response.ok || !data.draft) {
+    throw new Error(data.error || '草稿创建失败，请稍后重试。');
+  }
+  return data.draft;
+}

--- a/src/stores/publishStore.ts
+++ b/src/stores/publishStore.ts
@@ -12,6 +12,9 @@ interface PublishStore {
   setTitle: (title: string) => void;
   setContent: (content: string) => void;
 
+  currentDraftId: string | null;
+  setCurrentDraftId: (id: string | null) => void;
+
   platforms: Record<PlatformId, boolean>;
   togglePlatform: (id: PlatformId) => void;
 
@@ -37,6 +40,9 @@ export const usePublishStore = create<PublishStore>((set) => ({
   content: '',
   setTitle: (title) => set({ title }),
   setContent: (content) => set({ content }),
+
+  currentDraftId: null,
+  setCurrentDraftId: (id) => set({ currentDraftId: id }),
 
   platforms: {
     wechat: true,

--- a/src/stores/publishStore.ts
+++ b/src/stores/publishStore.ts
@@ -26,6 +26,12 @@ interface PublishStore {
   setPublishing: () => void;
   setResults: (results: PlatformPublishResult[]) => void;
   reset: () => void;
+
+  lastSyncTaskId: string | null;
+  isProgressOverlayOpen: boolean;
+  setLastSyncTaskId: (id: string | null) => void;
+  openProgressOverlay: () => void;
+  closeProgressOverlay: () => void;
 }
 
 const platformIds = PLATFORMS.map((platform) => platform.id);
@@ -73,5 +79,11 @@ export const usePublishStore = create<PublishStore>((set) => ({
       results,
       overallStatus: resolveOverallPublishStatus(results),
     }),
-  reset: () => set({ overallStatus: 'idle', results: [] }),
+  reset: () => set({ overallStatus: 'idle', results: [], lastSyncTaskId: null, isProgressOverlayOpen: false }),
+
+  lastSyncTaskId: null,
+  isProgressOverlayOpen: false,
+  setLastSyncTaskId: (id) => set({ lastSyncTaskId: id }),
+  openProgressOverlay: () => set({ isProgressOverlayOpen: true }),
+  closeProgressOverlay: () => set({ isProgressOverlayOpen: false }),
 }));

--- a/src/stores/publishStore.ts
+++ b/src/stores/publishStore.ts
@@ -17,6 +17,7 @@ interface PublishStore {
 
   platforms: Record<PlatformId, boolean>;
   togglePlatform: (id: PlatformId) => void;
+  setAllPlatforms: (checked: boolean) => void;
 
   platformDrafts: PlatformContentDrafts;
   syncPlatformDrafts: () => void;
@@ -59,6 +60,10 @@ export const usePublishStore = create<PublishStore>((set) => ({
   togglePlatform: (id) =>
     set((state) => ({
       platforms: { ...state.platforms, [id]: !state.platforms[id] },
+    })),
+  setAllPlatforms: (checked) =>
+    set(() => ({
+      platforms: Object.fromEntries(platformIds.map((id) => [id, checked])) as Record<PlatformId, boolean>,
     })),
 
   platformDrafts: emptyPlatformDrafts,

--- a/src/styles/globals.css.ts
+++ b/src/styles/globals.css.ts
@@ -43,12 +43,14 @@ globalStyle('::selection', {
 });
 
 globalStyle(':focus-visible:not(input):not(textarea):not(select)', {
-  outline: '2px solid rgba(217, 119, 87, 0.55)',
+  outline: `2px solid ${vars.color.accent}`,
   outlineOffset: '2px',
+  outlineColor: 'rgba(217, 119, 87, 0.6)',
 });
 
 globalStyle('input:focus-visible, textarea:focus-visible, select:focus-visible', {
   outline: 'none',
+  boxShadow: `0 0 0 2px rgba(217, 119, 87, 0.4)`,
 });
 
 globalStyle('button, input, textarea, select', {

--- a/src/styles/tokens.css.ts
+++ b/src/styles/tokens.css.ts
@@ -21,6 +21,9 @@ export const vars = createGlobalTheme(':root', {
     errorBg:       '#fff4f4',
     errorBorder:   '#f4c1c1',
     errorText:     '#bf4b4b',
+    warningBg:     '#fff8f0',
+    warningBorder: '#fcd9a0',
+    warningText:   '#b45309',
   },
   radius: {
     xl: '12px',


### PR DESCRIPTION
## Summary

- **编辑器**：两栏布局重构，右侧固定面板含平台选择、内容预览（手机框架）、稿件统计卡片；清除按钮两步确认防误操作；自动保存 hook（停止输入 1s 触发，首次保存自动创建草稿并更新 URL）
- **发布流程**：发布后原地展示进度浮层（轮询更新），替代原有跳转逻辑；平台选择器新增全选切换和已选数量提示
- **稿件库**：流水线视图增加彩色分发状态徽标；新增状态筛选栏
- **布局 & 导航**：移动端底部 Tab 栏替代顶部导航；侧边栏新增分发记录入口；AppShellHeader 增加底部边框
- **设置页**：保存凭证后自动验证平台连接；已连接账户名内联显示在折叠标题行
- **新闻工作台**：评分改用 ScoreBar 进度条展示；话题简报展开/折叠状态跨 Tab 保持
- **重构**：移除 localStorage 新闻草稿桥接层，统一走 createDraft API 流
- **a11y**：输入框和交互元素 focus-visible 样式优化

## Test plan

- [ ] 编辑器自动保存：输入后停止 1s，观察 URL 出现 `?draftId=`
- [ ] 发布流程：选平台 → 发布 → 右下角浮层出现并轮询更新状态
- [ ] 稿件库：状态筛选栏切换，彩色状态徽标正常显示
- [ ] 移动端：底部 Tab 栏导航正常
- [ ] 设置页：填写凭证保存后自动触发连接验证