### PR TITLE
Include draftId in publish requests

### DIFF
--- a/src/components/publish/PublishButton.tsx
+++ b/src/components/publish/PublishButton.tsx
@@ -16,6 +16,7 @@ export default function PublishButton() {
   const {
     title,
     content,
+    currentDraftId,
     platforms,
     platformDrafts,
     overallStatus,
@@ -52,6 +53,7 @@ export default function PublishButton() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          draftId: currentDraftId ?? undefined,
           title,
           content,
           platforms: selectedPlatforms,

--- a/src/components/publish/__tests__/PublishButton.test.tsx
+++ b/src/components/publish/__tests__/PublishButton.test.tsx
@@ -24,6 +24,7 @@ describe('PublishButton', () => {
 
   test('sends platform-level draft content in the publish request', async () => {
     const { default: PublishButton } = await import('@/components/publish/PublishButton');
+    usePublishStore.getState().setCurrentDraftId('draft-42');
     usePublishStore.getState().setTitle('通用标题');
     usePublishStore.getState().setContent('通用正文');
     usePublishStore.getState().syncPlatformDrafts();
@@ -45,6 +46,7 @@ describe('PublishButton', () => {
     const [, init] = fetch.mock.calls[0] as [string, RequestInit];
     const payload = JSON.parse(init.body as string);
 
+    expect(payload.draftId).toBe('draft-42');
     expect(payload.platformDrafts.wechat).toMatchObject({
       title: '通用标题',
       content: '通用正文',


### PR DESCRIPTION
## Summary
- include `currentDraftId` in the `/api/publish` request payload
- extend the existing `PublishButton` test to assert `draftId` is sent

## Testing
- `pnpm test src/components/publish/__tests__/PublishButton.test.tsx`

Fixes #16