### PR TITLE
Sync publish state from progress overlay

### DIFF
--- a/src/components/publish/PublishProgressOverlay.tsx
+++ b/src/components/publish/PublishProgressOverlay.tsx
@@ -6,6 +6,7 @@ import { X, Loader2, CheckCircle2, XCircle, ArrowUpRight } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
 import type { SyncTask, SyncReceiptStatus } from '@/lib/sync/types';
 import type { PlatformId } from '@/types';
+import { syncTaskToPublishResults } from '@/lib/publishStatus';
 import * as styles from './PublishProgressOverlay.css';
 
 const platformLabels: Record<PlatformId, string> = {
@@ -48,7 +49,12 @@ function statusClass(status: SyncReceiptStatus): string {
 }
 
 export default function PublishProgressOverlay() {
-  const { isProgressOverlayOpen, lastSyncTaskId, closeProgressOverlay } = usePublishStore();
+  const {
+    isProgressOverlayOpen,
+    lastSyncTaskId,
+    closeProgressOverlay,
+    setResults,
+  } = usePublishStore();
   const [syncTask, setSyncTask] = useState<SyncTask | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -67,6 +73,7 @@ export default function PublishProgressOverlay() {
         if (!res.ok) return;
         const data = await res.json() as { syncTask: SyncTask };
         setSyncTask(data.syncTask);
+        setResults(syncTaskToPublishResults(data.syncTask));
         // 所有 receipt 都到终态时停止轮询
         if (data.syncTask.receipts.every((r) => isTerminalStatus(r.status))) {
           if (intervalRef.current) clearInterval(intervalRef.current);
@@ -82,7 +89,7 @@ export default function PublishProgressOverlay() {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [isProgressOverlayOpen, lastSyncTaskId]);
+  }, [isProgressOverlayOpen, lastSyncTaskId, setResults]);
 
   // 关闭时清理状态
   function handleClose() {

--- a/src/components/publish/__tests__/PublishProgressOverlay.test.tsx
+++ b/src/components/publish/__tests__/PublishProgressOverlay.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import type { AnchorHTMLAttributes } from 'react';
+
+import { usePublishStore } from '@/stores/publishStore';
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/publish/PublishProgressOverlay.css', () => ({
+  overlay: 'overlay',
+  header: 'header',
+  headerTitle: 'headerTitle',
+  closeButton: 'closeButton',
+  body: 'body',
+  receiptRow: 'receiptRow',
+  platformName: 'platformName',
+  statusText: 'statusText',
+  statusTextSuccess: 'statusTextSuccess',
+  statusTextError: 'statusTextError',
+  footer: 'footer',
+  detailLink: 'detailLink',
+}));
+
+describe('PublishProgressOverlay', () => {
+  beforeEach(() => {
+    usePublishStore.setState(usePublishStore.getInitialState(), true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test('settles global publish state when sync task reaches terminal receipts', async () => {
+    const { default: PublishProgressOverlay } = await import('@/components/publish/PublishProgressOverlay');
+    usePublishStore.setState({
+      overallStatus: 'publishing',
+      isProgressOverlayOpen: true,
+      lastSyncTaskId: 'sync-1',
+    });
+
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        syncTask: {
+          id: 'sync-1',
+          title: '稿件标题',
+          status: 'partial',
+          createdAt: '2026-04-23T09:00:00.000Z',
+          updatedAt: '2026-04-23T09:01:00.000Z',
+          events: [],
+          receipts: [
+            {
+              platform: 'wechat',
+              status: 'published',
+              message: '已发布',
+              attempts: 1,
+              updatedAt: '2026-04-23T09:01:00.000Z',
+            },
+            {
+              platform: 'zhihu',
+              status: 'failed',
+              message: '原始错误',
+              failureMessage: '发布失败',
+              attempts: 1,
+              updatedAt: '2026-04-23T09:01:00.000Z',
+            },
+          ],
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    render(createElement(PublishProgressOverlay));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/sync-tasks/sync-1', { cache: 'no-store' });
+    });
+
+    await waitFor(() => {
+      expect(usePublishStore.getState().overallStatus).toBe('error');
+    });
+
+    expect(usePublishStore.getState().results).toEqual([
+      { platform: 'wechat', status: 'published', message: '已发布', url: undefined },
+      { platform: 'zhihu', status: 'failed', message: '发布失败', url: undefined },
+    ]);
+  });
+});

--- a/src/lib/__tests__/publishStatus.test.ts
+++ b/src/lib/__tests__/publishStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import {
   resolveOverallPublishStatus,
+  syncTaskToPublishResults,
   toPublishResultDisplayState,
 } from '@/lib/publishStatus';
 import type { PlatformPublishResult } from '@/types';
@@ -34,5 +35,44 @@ describe('publish status helpers', () => {
     expect(toPublishResultDisplayState('failed')).toBe('error');
     expect(toPublishResultDisplayState('error')).toBe('error');
     expect(toPublishResultDisplayState('publishing')).toBe('publishing');
+  });
+
+  test('maps sync task receipts back into publish results', () => {
+    expect(syncTaskToPublishResults({
+      id: 'sync-1',
+      title: '稿件标题',
+      status: 'partial',
+      createdAt: '2026-04-23T09:00:00.000Z',
+      updatedAt: '2026-04-23T09:01:00.000Z',
+      events: [],
+      receipts: [
+        {
+          platform: 'wechat',
+          status: 'published',
+          message: '已发布',
+          attempts: 1,
+          updatedAt: '2026-04-23T09:01:00.000Z',
+        },
+        {
+          platform: 'zhihu',
+          status: 'syncing',
+          message: '正在发布',
+          attempts: 1,
+          updatedAt: '2026-04-23T09:01:00.000Z',
+        },
+        {
+          platform: 'x',
+          status: 'failed',
+          message: '原始错误',
+          failureMessage: '整理后的错误',
+          attempts: 1,
+          updatedAt: '2026-04-23T09:01:00.000Z',
+        },
+      ],
+    })).toEqual([
+      { platform: 'wechat', status: 'published', message: '已发布', url: undefined },
+      { platform: 'zhihu', status: 'publishing', message: '正在发布', url: undefined },
+      { platform: 'x', status: 'failed', message: '整理后的错误', url: undefined },
+    ]);
   });
 });

--- a/src/lib/publishStatus.ts
+++ b/src/lib/publishStatus.ts
@@ -3,6 +3,7 @@ import type {
   PlatformPublishStatus,
   PublishStatus,
 } from '@/types';
+import type { SyncReceiptStatus, SyncTask } from '@/lib/sync/types';
 
 export type PublishResultDisplayState = 'success' | 'error' | 'publishing';
 
@@ -34,4 +35,18 @@ export function resolveOverallPublishStatus(
     (result) => toPublishResultDisplayState(result.status) === 'error',
   );
   return hasError ? 'error' : 'success';
+}
+
+function toPlatformPublishStatus(status: SyncReceiptStatus): PlatformPublishStatus {
+  if (status === 'syncing') return 'publishing';
+  return status;
+}
+
+export function syncTaskToPublishResults(syncTask: SyncTask): PlatformPublishResult[] {
+  return syncTask.receipts.map((receipt) => ({
+    platform: receipt.platform,
+    status: toPlatformPublishStatus(receipt.status),
+    message: receipt.failureMessage ?? receipt.message,
+    url: receipt.url,
+  }));
 }


### PR DESCRIPTION
## Summary
- map sync task receipts back into publish results during overlay polling
- keep the shared publish store in sync so the button and status panel settle after completion
- add regression coverage for receipt mapping and the overlay status transition

## Testing
- `pnpm test src/lib/__tests__/publishStatus.test.ts src/components/publish/__tests__/PublishProgressOverlay.test.tsx src/components/publish/__tests__/PublishButton.test.tsx`

Fixes #18