### PR TITLE
feat: editor enhancements, scheduled publishing, and security hardening

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,32 @@ import type { NextConfig } from 'next';
 
 const withVanillaExtract = createVanillaExtractPlugin();
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-XSS-Protection', value: '1; mode=block' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob: https:",
+              "connect-src 'self'",
+              "font-src 'self'",
+            ].join('; '),
+          },
+        ],
+      },
+    ];
+  },
+};
 
 export default withVanillaExtract(nextConfig);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "15.5.15",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sanitize-html": "^2.17.3",
     "twitter-api-v2": "^1.18.0",
     "zustand": "^5.0.0"
   },
@@ -32,6 +33,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/sanitize-html": "^2.16.1",
     "@vanilla-extract/next-plugin": "^2.5.1",
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      sanitize-html:
+        specifier: ^2.17.3
+        version: 2.17.3
       twitter-api-v2:
         specifier: ^1.18.0
         version: 1.29.0
@@ -54,6 +57,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@vanilla-extract/next-plugin':
         specifier: ^2.5.1
         version: 2.5.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.21.0)(webpack@5.106.0(esbuild@0.28.0))
@@ -1111,6 +1117,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1751,6 +1760,19 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1769,8 +1791,16 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.24.1:
@@ -2176,6 +2206,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2285,6 +2318,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2820,6 +2857,9 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -3014,6 +3054,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  sanitize-html@2.17.3:
+    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -4318,6 +4361,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -5089,6 +5136,24 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5106,7 +5171,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -5779,6 +5848,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5885,6 +5961,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -6631,6 +6709,8 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
+  parse-srcset@1.0.2: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -6925,6 +7005,15 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  sanitize-html@2.17.3:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.9
 
   saxes@6.0.0:
     dependencies:

--- a/src/app/api/drafts/[id]/route.ts
+++ b/src/app/api/drafts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDraftRegistry } from '@/lib/drafts/registry';
 import type { DraftStatus } from '@/lib/drafts/types';
+import { validateTitle, validateContent } from '@/lib/validation';
 
 export const dynamic = 'force-dynamic';
 
@@ -38,13 +39,22 @@ export async function PATCH(request: NextRequest | Request, { params }: DraftRou
   try {
     const { id } = await params;
     const body = await request.json();
-    const input = {
-      ...(typeof body.title === 'string' ? { title: body.title.trim() } : {}),
-      ...(typeof body.content === 'string' ? { content: body.content.trim() } : {}),
-      ...(isDraftStatus(body.status) ? { status: body.status } : {}),
-    };
+    const input: Record<string, unknown> = {};
+    if (typeof body.title === 'string') {
+      const err = validateTitle(body.title);
+      if (err) return NextResponse.json({ error: err }, { status: 400 });
+      input.title = body.title.trim();
+    }
+    if (typeof body.content === 'string') {
+      const err = validateContent(body.content);
+      if (err) return NextResponse.json({ error: err }, { status: 400 });
+      input.content = body.content.trim();
+    }
+    if (isDraftStatus(body.status)) {
+      input.status = body.status;
+    }
 
-    const draft = getDraftRegistry().updateDraft(id, input);
+    const draft = getDraftRegistry().updateDraft(id, input as any);
     if (!draft) return missingDraftResponse();
 
     return NextResponse.json({ draft });

--- a/src/app/api/drafts/route.ts
+++ b/src/app/api/drafts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDraftRegistry } from '@/lib/drafts/registry';
 import type { DraftSource } from '@/lib/drafts/types';
+import { validateTitle, validateContent } from '@/lib/validation';
 
 export const dynamic = 'force-dynamic';
 
@@ -25,16 +26,28 @@ export async function POST(request: NextRequest | Request) {
       typeof body.topicClusterId === 'string' && body.topicClusterId.trim()
         ? body.topicClusterId.trim()
         : undefined;
+    const scheduledAt =
+      typeof body.scheduledAt === 'string' && body.scheduledAt.trim()
+        ? body.scheduledAt.trim()
+        : undefined;
+    const platforms = Array.isArray(body.platforms) ? body.platforms : undefined;
 
     if (!title || !content) {
       return NextResponse.json({ error: '标题和内容不能为空' }, { status: 400 });
     }
+
+    const titleErr = validateTitle(title);
+    if (titleErr) return NextResponse.json({ error: titleErr }, { status: 400 });
+    const contentErr = validateContent(content);
+    if (contentErr) return NextResponse.json({ error: contentErr }, { status: 400 });
 
     const draft = getDraftRegistry().createDraft({
       title,
       content,
       source,
       topicClusterId,
+      scheduledAt,
+      platforms,
     });
 
     return NextResponse.json({ draft }, { status: 201 });

--- a/src/app/api/publish/route.ts
+++ b/src/app/api/publish/route.ts
@@ -11,6 +11,7 @@ import {
   toSyncReceiptStatus,
 } from '@/lib/publishers/executePublish';
 import { adaptContentForPlatforms } from '@/lib/platformAdapters/adaptContent';
+import { validateTitle, validateContent, validatePlatforms } from '@/lib/validation';
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,18 +23,12 @@ export async function POST(request: NextRequest) {
         : {};
 
     // Basic validation
-    if (!title?.trim()) {
-      return NextResponse.json({ error: '标题不能为空' }, { status: 400 });
-    }
-    if (!content?.trim()) {
-      return NextResponse.json({ error: '内容不能为空' }, { status: 400 });
-    }
-    if (!platforms?.length) {
-      return NextResponse.json(
-        { error: '请至少选择一个发布平台' },
-        { status: 400 }
-      );
-    }
+    const titleErr = validateTitle(title);
+    if (titleErr) return NextResponse.json({ error: titleErr }, { status: 400 });
+    const contentErr = validateContent(content);
+    if (contentErr) return NextResponse.json({ error: contentErr }, { status: 400 });
+    const platformErr = validatePlatforms(platforms);
+    if (platformErr) return NextResponse.json({ error: platformErr }, { status: 400 });
 
     // Platform-level draft validation
     const adaptations = adaptContentForPlatforms({

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { saveUploadedFile } from '@/lib/upload/saveFile';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file');
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json({ error: '请选择要上传的文件' }, { status: 400 });
+    }
+
+    const { url, filename } = await saveUploadedFile(file);
+    return NextResponse.json({ url, filename });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '上传失败';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/uploads/[filename]/route.ts
+++ b/src/app/api/uploads/[filename]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFileSync, existsSync } from 'node:fs';
+import { getUploadFilePath } from '@/lib/upload/saveFile';
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ filename: string }> },
+) {
+  try {
+    const { filename } = await params;
+    const filepath = getUploadFilePath(filename);
+
+    if (!existsSync(filepath)) {
+      return NextResponse.json({ error: '文件不存在' }, { status: 404 });
+    }
+
+    const ext = '.' + filename.split('.').pop()?.toLowerCase();
+    const contentType = CONTENT_TYPES[ext || ''] || 'application/octet-stream';
+    const buffer = readFileSync(filepath);
+
+    return new NextResponse(buffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '读取文件失败';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -81,6 +81,7 @@ export const editorCard = style({
   overflow: 'hidden',
   borderRadius: vars.radius.xl,
   background: vars.color.surface,
+  outline: 'none',
 });
 
 export const draftLoadError = style({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import PublishButton from '@/components/publish/PublishButton';
 import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
 import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
 import PublishProgressOverlay from '@/components/publish/PublishProgressOverlay';
+import SchedulePicker from '@/components/publish/SchedulePicker';
 import EditorialContextCard from '@/components/editor/EditorialContextCard';
 import * as publishStyles from '@/components/publish/publish.css';
 import { fetchDraftById } from '@/lib/drafts/client';
@@ -33,10 +34,11 @@ function HomePageContent() {
     overallStatus,
     currentDraftId,
     setCurrentDraftId,
+    activeTab,
+    setActiveTab,
   } = usePublishStore();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit');
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [draftLoadError, setDraftLoadError] = useState('');
   const [clearConfirming, setClearConfirming] = useState(false);
@@ -53,7 +55,7 @@ function HomePageContent() {
     router.replace(`/?draftId=${id}`);
   }, [setCurrentDraftId, router]);
 
-  const { saveStatus } = useAutoSave({
+  const { saveStatus, triggerSave } = useAutoSave({
     title,
     content,
     draftId: currentDraftId,
@@ -187,7 +189,7 @@ function HomePageContent() {
             </div>
 
             <div className={styles.editorCard}>
-              <MarkdownEditor activeTab={activeTab} />
+              <MarkdownEditor activeTab={activeTab} onSave={triggerSave} />
             </div>
           </div>
 
@@ -197,6 +199,10 @@ function HomePageContent() {
             <div className={publishStyles.rightPanelSection}>
               <span className={publishStyles.rightPanelSectionTitle}>发布到</span>
               <PlatformSelector />
+            </div>
+
+            <div className={publishStyles.rightPanelSection}>
+              <SchedulePicker />
             </div>
 
             <PlatformPreviewPanel

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import '@uiw/react-md-editor/markdown-editor.css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { usePublishStore } from '@/stores/publishStore';
 import { markdownToHtml } from '@/lib/markdown';
 import {
@@ -11,20 +11,24 @@ import {
   countHeadings,
   estimateReadTime,
 } from '@/lib/contentStats';
+import { useSlashCommands } from '@/hooks/useSlashCommands';
+import SlashCommandMenu from './SlashCommandMenu';
 import * as styles from './editor.css';
 
 const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false });
 
 interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';
+  onSave?: () => Promise<void>;
 }
 
-export default function MarkdownEditor({ activeTab }: MarkdownEditorProps) {
-  const { title, setTitle, content, setContent } = usePublishStore();
+export default function MarkdownEditor({ activeTab, onSave }: MarkdownEditorProps) {
+  const { title, setTitle, content, setContent, setActiveTab } = usePublishStore();
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const editorWrapRef = useRef<HTMLDivElement>(null);
+  const slash = useSlashCommands(content, setContent);
 
   useEffect(() => {
     function syncHeight() {
@@ -42,6 +46,92 @@ export default function MarkdownEditor({ activeTab }: MarkdownEditorProps) {
     window.addEventListener('resize', syncHeight);
     return () => window.removeEventListener('resize', syncHeight);
   }, []);
+
+  // 全局快捷键
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key === 's') {
+        e.preventDefault();
+        onSave?.();
+      }
+      if (mod && e.key === 'Enter') {
+        e.preventDefault();
+        document.dispatchEvent(new CustomEvent('publio:publish'));
+      }
+      if (mod && e.key === 'p') {
+        e.preventDefault();
+        setActiveTab(activeTab === 'edit' ? 'preview' : 'edit');
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [activeTab, onSave, setActiveTab]);
+
+  // 监听编辑器 keydown 以处理 slash commands 导航
+  useEffect(() => {
+    const wrap = editorWrapRef.current;
+    if (!wrap) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (slash.onKeyDown(e)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+
+    wrap.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      wrap.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [slash]);
+
+  const lastContentForSlashRef = useRef(content);
+  const handleContentChange = (val?: string) => {
+    const newValue = val || '';
+    setContent(newValue);
+    // 仅当内容确实由用户输入变化时检测 slash command
+    if (newValue !== lastContentForSlashRef.current) {
+      lastContentForSlashRef.current = newValue;
+      // 简单检测：如果新内容比旧内容多且包含 /，触发 slash 检测
+      slash.onTextChange(newValue, newValue.length);
+    }
+  };
+
+  const handleImageUpload = useCallback(async (file: File) => {
+    if (!file.type.startsWith('image/')) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await fetch('/api/upload', { method: 'POST', body: formData });
+      if (!res.ok) return;
+      const { url } = await res.json();
+      const insertion = `\n![${file.name}](${url})\n`;
+      setContent(content + insertion);
+    } catch {
+      // 上传失败静默处理
+    }
+  }, [content, setContent]);
+
+  const handlePaste = useCallback((e: React.ClipboardEvent) => {
+    const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith('image/'));
+    if (files.length > 0) {
+      e.preventDefault();
+      for (const file of files) {
+        void handleImageUpload(file);
+      }
+    }
+  }, [handleImageUpload]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith('image/'));
+    if (files.length > 0) {
+      e.preventDefault();
+      for (const file of files) {
+        void handleImageUpload(file);
+      }
+    }
+  }, [handleImageUpload]);
 
   const cleanContent = content.trim();
   const previewHtml = markdownToHtml(
@@ -67,9 +157,13 @@ export default function MarkdownEditor({ activeTab }: MarkdownEditorProps) {
         <div
           ref={editorWrapRef}
           className={styles.editorWrap}
+          onPaste={handlePaste}
+          onDrop={handleDrop}
+          onDragOver={(e) => e.preventDefault()}
           onClick={(e) => {
             const target = e.target as HTMLElement;
             if (target.closest('.w-md-editor-toolbar')) return;
+            if (target.closest('[data-slash-menu]')) return;
             if (isDesktop) {
               const textarea = editorWrapRef.current?.querySelector<HTMLTextAreaElement>('textarea.w-md-editor-text-input');
               textarea?.focus();
@@ -78,10 +172,19 @@ export default function MarkdownEditor({ activeTab }: MarkdownEditorProps) {
             }
           }}
         >
+          {slash.visible && (
+            <div data-slash-menu>
+              <SlashCommandMenu
+                commands={slash.filteredCommands}
+                selectedIndex={slash.selectedIndex}
+                onSelect={(cmd) => slash.selectCommand(cmd)}
+              />
+            </div>
+          )}
           {isDesktop ? (
             <MDEditor
               value={content}
-              onChange={(val) => setContent(val || '')}
+              onChange={handleContentChange}
               height={editorHeight}
               preview="edit"
               visibleDragbar={false}
@@ -90,7 +193,7 @@ export default function MarkdownEditor({ activeTab }: MarkdownEditorProps) {
             <textarea
               ref={textareaRef}
               value={content}
-              onChange={(e) => setContent(e.target.value)}
+              onChange={(e) => handleContentChange(e.target.value)}
               placeholder="开始写作，支持 Markdown 语法..."
               className={styles.mobileTextarea}
             />

--- a/src/components/editor/SlashCommandMenu.tsx
+++ b/src/components/editor/SlashCommandMenu.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { SlashCommand } from '@/hooks/useSlashCommands';
+import * as styles from './slashCommand.css';
+
+interface SlashCommandMenuProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  onSelect: (cmd: SlashCommand) => void;
+}
+
+export default function SlashCommandMenu({
+  commands,
+  selectedIndex,
+  onSelect,
+}: SlashCommandMenuProps) {
+  if (commands.length === 0) {
+    return (
+      <div className={styles.menuOverlay}>
+        <div className={styles.commandItem} style={{ opacity: 0.5 }}>
+          无匹配命令
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.menuOverlay}>
+      {commands.map((cmd, i) => (
+        <button
+          key={cmd.key}
+          className={styles.commandItem}
+          data-active={i === selectedIndex}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(cmd);
+          }}
+        >
+          <span className={styles.commandIcon}>{cmd.icon}</span>
+          <span className={styles.commandLabel}>{cmd.label}</span>
+          <span className={styles.commandHint}>{cmd.prefix.trim()}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/editor/editor.css.ts
+++ b/src/components/editor/editor.css.ts
@@ -9,12 +9,7 @@ export const editorRoot = style({
 
 // Title input area
 export const titleRow = style({
-  borderBottom: `1px solid ${vars.color.borderFaint}`,
   padding: '16px',
-  transition: 'border-color 150ms',
-  ':focus-within': {
-    borderColor: vars.color.accent,
-  },
   '@media': {
     'screen and (min-width: 640px)': {
       padding: '16px 20px',
@@ -31,6 +26,12 @@ export const titleInput = style({
   lineHeight: 1.3,
   color: vars.color.text,
   outline: 'none',
+  selectors: {
+    '&:focus, &:focus-visible': {
+      outline: 'none',
+      boxShadow: 'none',
+    },
+  },
   '::placeholder': {
     color: vars.color.textMuted,
   },
@@ -44,18 +45,24 @@ export const titleInput = style({
 // MDEditor wrapper — globalStyle overrides for third-party component
 export const editorWrap = style({
   background: vars.color.surface,
+  position: 'relative',
+  outline: 'none',
 });
 
 globalStyle(`${editorWrap} .w-md-editor`, {
   border: 'none',
   borderRadius: 0,
-  boxShadow: 'none',
+  boxShadow: 'none !important',
   background: 'transparent',
   color: vars.color.text,
 });
 
+globalStyle(`${editorWrap} .w-md-editor:focus-within`, {
+  boxShadow: 'none !important',
+});
+
 globalStyle(`${editorWrap} .w-md-editor-toolbar`, {
-  borderTop: 'none',
+  borderTop: `1px solid ${vars.color.borderFaint}`,
   borderBottom: `1px solid ${vars.color.borderFaint}`,
   background: vars.color.surface,
   padding: '6px 12px',
@@ -73,6 +80,12 @@ globalStyle(`${editorWrap} .w-md-editor-text-input`, {
   fontFamily: vars.font.sans,
   background: 'transparent',
   color: vars.color.text,
+  outline: 'none',
+});
+
+globalStyle(`${editorWrap} .w-md-editor-text-input:focus, ${editorWrap} .w-md-editor-text-input:focus-visible`, {
+  outline: 'none',
+  boxShadow: 'none',
 });
 
 globalStyle(`${editorWrap} .w-md-editor-text-input::placeholder`, {

--- a/src/components/editor/slashCommand.css.ts
+++ b/src/components/editor/slashCommand.css.ts
@@ -1,0 +1,58 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+export const menuOverlay = style({
+  position: 'absolute',
+  top: 80,
+  left: 16,
+  zIndex: 50,
+  minWidth: 220,
+  padding: 4,
+  borderRadius: vars.radius.lg,
+  background: vars.color.surface,
+  border: `1px solid ${vars.color.border}`,
+  boxShadow: '0 4px 24px rgba(0,0,0,0.12)',
+  maxHeight: 320,
+  overflowY: 'auto',
+});
+
+export const commandItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  width: '100%',
+  padding: '8px 12px',
+  borderRadius: vars.radius.lg,
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  fontSize: 14,
+  color: vars.color.text,
+  textAlign: 'left',
+  selectors: {
+    '&:hover, &[data-active="true"]': {
+      background: vars.color.bgElevated,
+    },
+  },
+});
+
+export const commandIcon = style({
+  width: 20,
+  height: 20,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 13,
+  fontWeight: 600,
+  color: vars.color.accent,
+  flexShrink: 0,
+});
+
+export const commandLabel = style({
+  flex: 1,
+});
+
+export const commandHint = style({
+  fontSize: 12,
+  color: vars.color.textMuted,
+});

--- a/src/components/publish/PublishButton.tsx
+++ b/src/components/publish/PublishButton.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { usePublishStore } from '@/stores/publishStore';
 import { PlatformId, PublishResponse } from '@/types';
-import { SendHorizonal, Loader2, AlertCircle } from 'lucide-react';
+import { SendHorizonal, Loader2, AlertCircle, Clock } from 'lucide-react';
 import { publishButton } from './publish.css';
 
 const platformLabels: Record<PlatformId, string> = {
@@ -20,11 +21,14 @@ export default function PublishButton() {
     platforms,
     platformDrafts,
     overallStatus,
+    scheduledAt,
     setPublishing,
     setResults,
     setLastSyncTaskId,
     openProgressOverlay,
   } = usePublishStore();
+
+  const handlePublishRef = useRef<typeof handlePublish>(null!);
 
   const selectedPlatforms = (
     Object.entries(platforms) as [PlatformId, boolean][]
@@ -46,6 +50,54 @@ export default function PublishButton() {
 
   async function handlePublish() {
     if (isDisabled) return;
+
+    // 定时发布：创建/更新草稿并设置 scheduledAt
+    if (scheduledAt) {
+      try {
+        const body = {
+          title,
+          content,
+          source: 'manual' as const,
+          scheduledAt,
+          platforms: selectedPlatforms,
+        };
+
+        if (currentDraftId) {
+          await fetch(`/api/drafts/${currentDraftId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+        } else {
+          const res = await fetch('/api/drafts', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+          const data = await res.json();
+          if (data.draft?.id) {
+            usePublishStore.getState().setCurrentDraftId(data.draft.id);
+          }
+        }
+        setResults(
+          selectedPlatforms.map((p) => ({
+            platform: p,
+            status: 'success' as const,
+            message: `已设定 ${new Date(scheduledAt).toLocaleString('zh-CN')} 定时发布`,
+          })),
+        );
+      } catch (error) {
+        setResults(
+          selectedPlatforms.map((p) => ({
+            platform: p,
+            status: 'error' as const,
+            message: error instanceof Error ? error.message : '设定定时发布失败',
+          })),
+        );
+      }
+      return;
+    }
+
     setPublishing();
 
     try {
@@ -91,6 +143,16 @@ export default function PublishButton() {
     }
   }
 
+  handlePublishRef.current = handlePublish;
+
+  useEffect(() => {
+    function onShortcut() {
+      handlePublishRef.current();
+    }
+    document.addEventListener('publio:publish', onShortcut);
+    return () => document.removeEventListener('publio:publish', onShortcut);
+  }, []);
+
   let label: string;
   if (overallStatus === 'publishing') {
     label = '提交中...';
@@ -98,6 +160,8 @@ export default function PublishButton() {
     label = '请先选择平台';
   } else if (notReadyPlatforms.length > 0) {
     label = `${notReadyPlatforms.map((p) => platformLabels[p]).join('、')} 内容待补全`;
+  } else if (scheduledAt) {
+    label = `定时 ${new Date(scheduledAt).toLocaleString('zh-CN', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })} 发布`;
   } else {
     label = `发布到 ${selectedPlatforms.length} 个平台`;
   }
@@ -110,6 +174,8 @@ export default function PublishButton() {
     >
       {overallStatus === 'publishing' ? (
         <Loader2 size={15} className="animate-spin" />
+      ) : scheduledAt ? (
+        <Clock size={15} />
       ) : notReadyPlatforms.length > 0 ? (
         <AlertCircle size={15} />
       ) : (

--- a/src/components/publish/SchedulePicker.tsx
+++ b/src/components/publish/SchedulePicker.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Clock } from 'lucide-react';
+import { usePublishStore } from '@/stores/publishStore';
+import * as styles from './schedulePicker.css';
+
+export default function SchedulePicker() {
+  const { scheduledAt, setScheduledAt } = usePublishStore();
+
+  const minDatetime = new Date().toISOString().slice(0, 16);
+
+  return (
+    <div className={styles.pickerWrap}>
+      <label className={styles.label}>
+        <Clock size={14} />
+        定时发布
+      </label>
+      <div className={styles.inputRow}>
+        <input
+          type="datetime-local"
+          value={scheduledAt ?? ''}
+          onChange={(e) => setScheduledAt(e.target.value || null)}
+          min={minDatetime}
+          className={styles.input}
+        />
+        {scheduledAt && (
+          <button
+            type="button"
+            onClick={() => setScheduledAt(null)}
+            className={styles.clearBtn}
+          >
+            取消
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/publish/schedulePicker.css.ts
+++ b/src/components/publish/schedulePicker.css.ts
@@ -1,0 +1,55 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+export const pickerWrap = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+});
+
+export const label = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: 13,
+  fontWeight: 500,
+  color: vars.color.text,
+});
+
+export const inputRow = style({
+  display: 'flex',
+  gap: 8,
+  alignItems: 'center',
+});
+
+export const input = style({
+  flex: 1,
+  padding: '6px 10px',
+  fontSize: 13,
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.surface,
+  color: vars.color.text,
+  outline: 'none',
+  selectors: {
+    '&:focus': {
+      borderColor: vars.color.accent,
+    },
+  },
+});
+
+export const clearBtn = style({
+  padding: '4px 10px',
+  fontSize: 12,
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  selectors: {
+    '&:hover': {
+      color: vars.color.accent,
+      borderColor: vars.color.accent,
+    },
+  },
+});

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -19,12 +19,13 @@ export function useAutoSave({
   draftId,
   onDraftCreated,
   debounceMs = 1000,
-}: UseAutoSaveOptions): { saveStatus: SaveStatus } {
+}: UseAutoSaveOptions): { saveStatus: SaveStatus; triggerSave: () => Promise<void> } {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // 使用 ref 追踪最新值，避免 stale closure
   const draftIdRef = useRef(draftId);
   const onDraftCreatedRef = useRef(onDraftCreated);
+  const titleRef = useRef(title);
+  const contentRef = useRef(content);
 
   useEffect(() => {
     draftIdRef.current = draftId;
@@ -35,27 +36,41 @@ export function useAutoSave({
   }, [onDraftCreated]);
 
   useEffect(() => {
-    // 标题和内容都为空时不触发
+    titleRef.current = title;
+  }, [title]);
+
+  useEffect(() => {
+    contentRef.current = content;
+  }, [content]);
+
+  async function performSave() {
+    const currentTitle = titleRef.current;
+    const currentContent = contentRef.current;
+
+    if (!currentTitle.trim() && !currentContent.trim()) return;
+    if (!currentTitle.trim() && !draftIdRef.current) return;
+
+    setSaveStatus('saving');
+    try {
+      if (draftIdRef.current) {
+        await updateDraft(draftIdRef.current, { title: currentTitle, content: currentContent });
+      } else {
+        const draft = await ensureDraft({ title: currentTitle, content: currentContent, source: 'manual' });
+        onDraftCreatedRef.current(draft.id);
+      }
+      setSaveStatus('saved');
+    } catch {
+      setSaveStatus('error');
+    }
+  }
+
+  useEffect(() => {
     if (!title.trim() && !content.trim()) return;
 
     if (timerRef.current) clearTimeout(timerRef.current);
 
-    timerRef.current = setTimeout(async () => {
-      // 标题为空时不创建新草稿，但若已有草稿则更新内容
-      if (!title.trim() && !draftIdRef.current) return;
-
-      setSaveStatus('saving');
-      try {
-        if (draftIdRef.current) {
-          await updateDraft(draftIdRef.current, { title, content });
-        } else {
-          const draft = await ensureDraft({ title, content, source: 'manual' });
-          onDraftCreatedRef.current(draft.id);
-        }
-        setSaveStatus('saved');
-      } catch {
-        setSaveStatus('error');
-      }
+    timerRef.current = setTimeout(() => {
+      void performSave();
     }, debounceMs);
 
     return () => {
@@ -63,5 +78,5 @@ export function useAutoSave({
     };
   }, [title, content, debounceMs]);
 
-  return { saveStatus };
+  return { saveStatus, triggerSave: performSave };
 }

--- a/src/hooks/useSlashCommands.ts
+++ b/src/hooks/useSlashCommands.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+
+export interface SlashCommand {
+  key: string;
+  label: string;
+  prefix: string;
+  suffix?: string;
+  placeholder?: string;
+  icon: string;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { key: 'heading1', label: '一级标题', prefix: '# ', icon: 'H1' },
+  { key: 'heading2', label: '二级标题', prefix: '## ', icon: 'H2' },
+  { key: 'heading3', label: '三级标题', prefix: '### ', icon: 'H3' },
+  { key: 'bold', label: '粗体', prefix: '**', suffix: '**', placeholder: '粗体文本', icon: 'B' },
+  { key: 'italic', label: '斜体', prefix: '*', suffix: '*', placeholder: '斜体文本', icon: 'I' },
+  { key: 'link', label: '链接', prefix: '[', suffix: '](url)', placeholder: '链接文本', icon: '🔗' },
+  { key: 'image', label: '图片', prefix: '![](', suffix: ')', placeholder: '图片 URL', icon: '🖼' },
+  { key: 'code', label: '行内代码', prefix: '`', suffix: '`', placeholder: '代码', icon: '</>' },
+  { key: 'quote', label: '引用', prefix: '> ', icon: '❝' },
+  { key: 'list', label: '无序列表', prefix: '- ', icon: '•' },
+  { key: 'divider', label: '分割线', prefix: '\n---\n', icon: '—' },
+];
+
+interface UseSlashCommandsReturn {
+  visible: boolean;
+  selectedIndex: number;
+  filterText: string;
+  filteredCommands: SlashCommand[];
+  onKeyDown: (e: KeyboardEvent) => boolean;
+  onTextChange: (text: string, cursorPos: number) => void;
+  selectCommand: (cmd: SlashCommand) => { newContent: string; insertionOffset: number } | null;
+  hide: () => void;
+}
+
+export function useSlashCommands(
+  content: string,
+  setContent: (val: string) => void,
+): UseSlashCommandsReturn {
+  const [visible, setVisible] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [filterText, setFilterText] = useState('');
+  const slashPosRef = useRef(-1);
+
+  const filteredCommands = SLASH_COMMANDS.filter((cmd) =>
+    cmd.label.toLowerCase().includes(filterText.toLowerCase()) ||
+    cmd.key.toLowerCase().includes(filterText.toLowerCase()),
+  );
+
+  const hide = useCallback(() => {
+    setVisible(false);
+    setSelectedIndex(0);
+    setFilterText('');
+    slashPosRef.current = -1;
+  }, []);
+
+  const onTextChange = useCallback((text: string, cursorPos: number) => {
+    // 使用 cursorPos 作为近似光标位置
+    // CodeMirror 不暴露精确位置，MDEditor onChange 传的是 text.length
+    // 查找最后一段文本中的 / 命令
+    const searchEnd = Math.min(cursorPos, text.length);
+    const lineStart = text.lastIndexOf('\n', searchEnd - 1) + 1;
+    const lineBeforeCursor = text.slice(lineStart, searchEnd);
+
+    const match = lineBeforeCursor.match(/^\/(.*)$/);
+    if (match) {
+      slashPosRef.current = lineStart;
+      setFilterText(match[1]);
+      setSelectedIndex(0);
+      setVisible(true);
+    } else {
+      hide();
+    }
+  }, [hide]);
+
+  const selectCommand = useCallback((cmd: SlashCommand) => {
+    if (slashPosRef.current < 0) return null;
+
+    const before = content.slice(0, slashPosRef.current);
+    const slashLineEnd = content.indexOf('\n', slashPosRef.current);
+    const after = slashLineEnd >= 0 ? content.slice(slashLineEnd) : '';
+
+    const placeholder = cmd.placeholder || '';
+    const insertion = cmd.prefix + placeholder + (cmd.suffix || '');
+    const newContent = before + insertion + after;
+
+    setContent(newContent);
+    hide();
+    return { newContent, insertionOffset: newContent.length };
+  }, [content, setContent, hide]);
+
+  const onKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!visible) return false;
+
+    if (e.key === 'Escape') {
+      hide();
+      return true;
+    }
+    if (e.key === 'ArrowUp') {
+      setSelectedIndex((i) => (i > 0 ? i - 1 : filteredCommands.length - 1));
+      return true;
+    }
+    if (e.key === 'ArrowDown') {
+      setSelectedIndex((i) => (i < filteredCommands.length - 1 ? i + 1 : 0));
+      return true;
+    }
+    if (e.key === 'Enter') {
+      if (filteredCommands[selectedIndex]) {
+        selectCommand(filteredCommands[selectedIndex]);
+      }
+      return true;
+    }
+    return false;
+  }, [visible, filteredCommands, selectedIndex, selectCommand, hide]);
+
+  return {
+    visible,
+    selectedIndex,
+    filterText,
+    filteredCommands,
+    onKeyDown,
+    onTextChange,
+    selectCommand,
+    hide,
+  };
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { startScheduler } = await import('@/lib/scheduler');
+    startScheduler();
+  }
+}

--- a/src/lib/drafts/store.ts
+++ b/src/lib/drafts/store.ts
@@ -54,6 +54,8 @@ export function createDraftStore(options: DraftStoreOptions = {}) {
         status: 'draft',
         source: input.source,
         ...(input.topicClusterId ? { topicClusterId: input.topicClusterId } : {}),
+        ...(input.scheduledAt ? { scheduledAt: input.scheduledAt } : {}),
+        ...(input.platforms ? { platforms: input.platforms } : {}),
         createdAt: timestamp,
         updatedAt: timestamp,
       };

--- a/src/lib/drafts/types.ts
+++ b/src/lib/drafts/types.ts
@@ -1,3 +1,5 @@
+import type { PlatformId } from '@/types';
+
 export type DraftStatus =
   | 'draft'
   | 'ready'
@@ -15,6 +17,8 @@ export interface ContentDraft {
   status: DraftStatus;
   source: DraftSource;
   topicClusterId?: string;
+  scheduledAt?: string;
+  platforms?: PlatformId[];
   createdAt: string;
   updatedAt: string;
 }
@@ -24,10 +28,12 @@ export interface CreateDraftInput {
   content: string;
   source: DraftSource;
   topicClusterId?: string;
+  scheduledAt?: string;
+  platforms?: PlatformId[];
 }
 
 export type UpdateDraftInput = Partial<
-  Pick<ContentDraft, 'title' | 'content' | 'status'>
+  Pick<ContentDraft, 'title' | 'content' | 'status' | 'scheduledAt' | 'platforms'>
 >;
 
 export interface ListDraftsOptions {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,4 +1,5 @@
 import { marked, Tokens } from 'marked';
+import sanitizeHtml from 'sanitize-html';
 
 type StyledPlatform = 'wechat' | 'zhihu';
 
@@ -233,8 +234,20 @@ function tokenize(markdown: string) {
   return marked.lexer(markdown) as unknown as TokensList;
 }
 
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'h1', 'h2', 'h3', 'section', 'article']),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    '*': ['style'],
+    img: ['src', 'alt', 'style'],
+    a: ['href', 'target', 'rel', 'style'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+};
+
 export function markdownToHtml(markdown: string): string {
-  return tokensToHtml(tokenize(markdown));
+  const raw = tokensToHtml(tokenize(markdown));
+  return sanitizeHtml(raw, SANITIZE_OPTIONS);
 }
 
 export function markdownToStyledHtml(
@@ -274,13 +287,13 @@ export function markdownToStyledHtml(
 
   const bodyHtml = tokensToHtml(bodyTokens, platform, { skipFirstH1: true });
 
-  return `
+  return sanitizeHtml(`
     <article style="${ARTICLE_THEME[platform].article}">
       ${hero}
       ${leadHtml}
       ${bodyHtml}
     </article>
-  `;
+  `, SANITIZE_OPTIONS);
 }
 
 export function markdownToPlainText(markdown: string): string {

--- a/src/lib/platformConnections/checkers.ts
+++ b/src/lib/platformConnections/checkers.ts
@@ -4,7 +4,6 @@
  */
 import { TwitterApi } from 'twitter-api-v2';
 import { getWechatConfig, getXhsConfig, getZhihuConfig, getXConfig } from '@/lib/config';
-import { getXhsAccessToken } from '@/lib/publishers/xiaohongshu';
 
 export interface CheckResult {
   ok: boolean;
@@ -42,7 +41,22 @@ export async function checkXiaohongshu(): Promise<CheckResult> {
   }
 
   try {
-    await getXhsAccessToken(appId, appSecret);
+    const tokenRes = await fetch(
+      'https://open.xiaohongshu.com/api/oauth/token',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          app_id: appId,
+          app_secret: appSecret,
+          grant_type: 'client_credentials',
+        }),
+      }
+    );
+    const tokenData = await tokenRes.json();
+    if (tokenData.code !== 0 && tokenData.code !== 200) {
+      return { ok: false, failureReason: `小红书凭证无效: ${tokenData.msg || tokenData.message || '未知错误'}` };
+    }
     const expiresAt = new Date(Date.now() + 7200 * 1000).toISOString();
     return { ok: true, expiresAt };
   } catch (error) {

--- a/src/lib/publishers/base.ts
+++ b/src/lib/publishers/base.ts
@@ -1,0 +1,67 @@
+import type { PlatformId } from '@/types';
+import type { Publisher, PublishInput, PublishOutput } from './types';
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export abstract class BasePublisher implements Publisher {
+  abstract platform: PlatformId;
+  abstract validateConfig(): boolean;
+  protected abstract publishToPlatform(input: PublishInput): Promise<PublishOutput>;
+
+  private static tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+  protected getCachedToken(key: string): string | null {
+    const entry = BasePublisher.tokenCache.get(key);
+    if (entry && Date.now() < entry.expiresAt) return entry.token;
+    BasePublisher.tokenCache.delete(key);
+    return null;
+  }
+
+  protected setCachedToken(key: string, token: string, expiresInSec: number): void {
+    BasePublisher.tokenCache.set(key, {
+      token,
+      expiresAt: Date.now() + (expiresInSec - 300) * 1000,
+    });
+  }
+
+  protected clearCachedToken(key: string): void {
+    BasePublisher.tokenCache.delete(key);
+  }
+
+  private async retryWithBackoff<T>(fn: () => Promise<T>): Promise<T> {
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt < MAX_RETRIES) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  async publish(input: PublishInput): Promise<PublishOutput> {
+    if (!this.validateConfig()) {
+      return {
+        success: false,
+        platform: this.platform,
+        message: `${this.platform} 凭证未配置`,
+      };
+    }
+
+    try {
+      return await this.retryWithBackoff(() => this.publishToPlatform(input));
+    } catch (error) {
+      return {
+        success: false,
+        platform: this.platform,
+        message: error instanceof Error ? error.message : `${this.platform} 发布失败`,
+      };
+    }
+  }
+}

--- a/src/lib/publishers/wechat.ts
+++ b/src/lib/publishers/wechat.ts
@@ -1,31 +1,6 @@
-import { Publisher, PublishInput, PublishOutput } from './types';
+import type { PublishInput, PublishOutput } from './types';
+import { BasePublisher } from './base';
 import { getWechatConfig } from '@/lib/config';
-
-let cachedToken: { token: string; expiresAt: number } | null = null;
-
-async function getAccessToken(): Promise<string> {
-  const { appId, appSecret } = getWechatConfig();
-
-  if (cachedToken && Date.now() < cachedToken.expiresAt) {
-    return cachedToken.token;
-  }
-
-  const res = await fetch(
-    `https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${appId}&secret=${appSecret}`
-  );
-  const data = await res.json();
-
-  if (data.errcode) {
-    throw new Error(`微信获取 access_token 失败: ${data.errmsg} (${data.errcode})`);
-  }
-
-  cachedToken = {
-    token: data.access_token,
-    expiresAt: Date.now() + (data.expires_in - 300) * 1000,
-  };
-
-  return cachedToken.token;
-}
 
 async function uploadDefaultThumb(token: string): Promise<string> {
   // Create a minimal 1x1 JPEG as placeholder thumbnail
@@ -98,7 +73,7 @@ async function uploadDefaultThumb(token: string): Promise<string> {
   return data.media_id;
 }
 
-export class WechatPublisher implements Publisher {
+export class WechatPublisher extends BasePublisher {
   platform = 'wechat' as const;
 
   validateConfig(): boolean {
@@ -106,95 +81,94 @@ export class WechatPublisher implements Publisher {
     return !!(appId && appSecret);
   }
 
-  async publish(input: PublishInput): Promise<PublishOutput> {
+  protected async publishToPlatform(input: PublishInput): Promise<PublishOutput> {
+    // Step 1: Get access token
+    const token = await this.getAccessToken();
+
+    // Step 2: Upload thumb image
+    let thumbMediaId: string;
     try {
-      if (!this.validateConfig()) {
-        return {
-          success: false,
-          platform: 'wechat',
-          message: '微信公众号凭证未配置，请在设置中配置 App ID 和 App Secret',
-        };
+      thumbMediaId = await uploadDefaultThumb(token);
+    } catch {
+      thumbMediaId = '';
+    }
+
+    // Step 3: Create draft
+    const digest =
+      input.markdownContent.replace(/[#*`>\-\[\]()!]/g, '').slice(0, 120);
+
+    const draftRes = await fetch(
+      `https://api.weixin.qq.com/cgi-bin/draft/add?access_token=${token}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          articles: [
+            {
+              title: input.title,
+              author: '',
+              content: input.htmlContent,
+              thumb_media_id: thumbMediaId,
+              digest,
+              content_source_url: '',
+              need_open_comment: 0,
+              only_fans_can_comment: 0,
+            },
+          ],
+        }),
       }
+    );
 
-      // Step 1: Get access token
-      const token = await getAccessToken();
+    const draftData = await draftRes.json();
+    if (draftData.errcode) {
+      this.handleAuthError(draftData.errcode);
+      throw new Error(`创建草稿失败: ${draftData.errmsg}`);
+    }
 
-      // Step 2: Upload thumb image
-      let thumbMediaId: string;
-      try {
-        thumbMediaId = await uploadDefaultThumb(token);
-      } catch {
-        // If thumb upload fails, try without it
-        thumbMediaId = '';
+    // Step 4: Submit for publish
+    const publishRes = await fetch(
+      `https://api.weixin.qq.com/cgi-bin/freepublish/submit?access_token=${token}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ media_id: draftData.media_id }),
       }
+    );
 
-      // Step 3: Create draft
-      const digest =
-        input.markdownContent.replace(/[#*`>\-\[\]()!]/g, '').slice(0, 120);
+    const publishData = await publishRes.json();
+    if (publishData.errcode) {
+      throw new Error(`提交发布失败: ${publishData.errmsg}`);
+    }
 
-      const draftRes = await fetch(
-        `https://api.weixin.qq.com/cgi-bin/draft/add?access_token=${token}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            articles: [
-              {
-                title: input.title,
-                author: '',
-                content: input.htmlContent,
-                thumb_media_id: thumbMediaId,
-                digest,
-                content_source_url: '',
-                need_open_comment: 0,
-                only_fans_can_comment: 0,
-              },
-            ],
-          }),
-        }
-      );
+    return {
+      success: true,
+      platform: 'wechat',
+      message: '已提交发布（文章审核后将自动发布）',
+      url: 'https://mp.weixin.qq.com',
+    };
+  }
 
-      const draftData = await draftRes.json();
-      if (draftData.errcode) {
-        throw new Error(`创建草稿失败: ${draftData.errmsg}`);
-      }
+  private async getAccessToken(): Promise<string> {
+    const cached = this.getCachedToken('wechat');
+    if (cached) return cached;
 
-      // Step 4: Submit for publish
-      const publishRes = await fetch(
-        `https://api.weixin.qq.com/cgi-bin/freepublish/submit?access_token=${token}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ media_id: draftData.media_id }),
-        }
-      );
+    const { appId, appSecret } = getWechatConfig();
+    const res = await fetch(
+      `https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${appId}&secret=${appSecret}`
+    );
+    const data = await res.json();
 
-      const publishData = await publishRes.json();
-      if (publishData.errcode) {
-        throw new Error(`提交发布失败: ${publishData.errmsg}`);
-      }
+    if (data.errcode) {
+      throw new Error(`微信获取 access_token 失败: ${data.errmsg} (${data.errcode})`);
+    }
 
-      return {
-        success: true,
-        platform: 'wechat',
-        message: '已提交发布（文章审核后将自动发布）',
-        url: 'https://mp.weixin.qq.com',
-      };
-    } catch (error) {
-      // Clear token cache on auth errors
-      if (
-        error instanceof Error &&
-        (error.message.includes('40001') || error.message.includes('42001'))
-      ) {
-        cachedToken = null;
-      }
+    this.setCachedToken('wechat', data.access_token, data.expires_in);
+    return data.access_token;
+  }
 
-      return {
-        success: false,
-        platform: 'wechat',
-        message:
-          error instanceof Error ? error.message : '微信公众号发布失败',
-      };
+  private handleAuthError(errcode: number): void {
+    if (errcode === 40001 || errcode === 42001) {
+      this.clearCachedToken('wechat');
     }
   }
 }

--- a/src/lib/publishers/x.ts
+++ b/src/lib/publishers/x.ts
@@ -1,5 +1,6 @@
 import { TwitterApi } from 'twitter-api-v2';
-import { Publisher, PublishInput, PublishOutput } from './types';
+import type { PublishInput, PublishOutput } from './types';
+import { BasePublisher } from './base';
 import { getXConfig } from '@/lib/config';
 import { markdownToPlainText } from '@/lib/markdown';
 
@@ -17,7 +18,6 @@ function splitIntoThread(title: string, content: string): string[] {
   let current = '';
   for (const para of paragraphs) {
     if (para.length > 270) {
-      // Paragraph too long, split by sentences
       if (current.trim()) {
         chunks.push(current.trim());
         current = '';
@@ -40,7 +40,6 @@ function splitIntoThread(title: string, content: string): string[] {
   }
   if (current.trim()) chunks.push(current.trim());
 
-  // Add thread numbering
   if (chunks.length > 1) {
     return chunks.map((chunk, i) => `${chunk}\n\n[${i + 1}/${chunks.length}]`);
   }
@@ -48,7 +47,7 @@ function splitIntoThread(title: string, content: string): string[] {
   return chunks;
 }
 
-export class XPublisher implements Publisher {
+export class XPublisher extends BasePublisher {
   platform = 'x' as const;
 
   validateConfig(): boolean {
@@ -56,56 +55,40 @@ export class XPublisher implements Publisher {
     return !!(apiKey && apiSecret && accessToken && accessTokenSecret);
   }
 
-  async publish(input: PublishInput): Promise<PublishOutput> {
-    try {
-      if (!this.validateConfig()) {
-        return {
-          success: false,
-          platform: 'x',
-          message: 'X (Twitter) 凭证未配置，请在设置中配置 API Keys 和 Access Tokens',
-        };
+  protected async publishToPlatform(input: PublishInput): Promise<PublishOutput> {
+    const { apiKey, apiSecret, accessToken, accessTokenSecret } = getXConfig();
+
+    const client = new TwitterApi({
+      appKey: apiKey,
+      appSecret: apiSecret,
+      accessToken: accessToken,
+      accessSecret: accessTokenSecret,
+    });
+
+    const chunks = splitIntoThread(input.title, input.markdownContent);
+
+    let firstTweetId: string | undefined;
+    let previousTweetId: string | undefined;
+
+    for (const chunk of chunks) {
+      const payload: { text: string; reply?: { in_reply_to_tweet_id: string } } = {
+        text: chunk,
+      };
+
+      if (previousTweetId) {
+        payload.reply = { in_reply_to_tweet_id: previousTweetId };
       }
 
-      const { apiKey, apiSecret, accessToken, accessTokenSecret } = getXConfig();
-
-      const client = new TwitterApi({
-        appKey: apiKey,
-        appSecret: apiSecret,
-        accessToken: accessToken,
-        accessSecret: accessTokenSecret,
-      });
-
-      const chunks = splitIntoThread(input.title, input.markdownContent);
-
-      let firstTweetId: string | undefined;
-      let previousTweetId: string | undefined;
-
-      for (const chunk of chunks) {
-        const payload: { text: string; reply?: { in_reply_to_tweet_id: string } } = {
-          text: chunk,
-        };
-
-        if (previousTweetId) {
-          payload.reply = { in_reply_to_tweet_id: previousTweetId };
-        }
-
-        const result = await client.v2.tweet(payload);
-        if (!firstTweetId) firstTweetId = result.data.id;
-        previousTweetId = result.data.id;
-      }
-
-      return {
-        success: true,
-        platform: 'x',
-        message: chunks.length > 1 ? `发布成功（${chunks.length} 条推文串）` : '发布成功',
-        url: `https://x.com/i/status/${firstTweetId}`,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        platform: 'x',
-        message: error instanceof Error ? error.message : 'X 发布失败',
-      };
+      const result = await client.v2.tweet(payload);
+      if (!firstTweetId) firstTweetId = result.data.id;
+      previousTweetId = result.data.id;
     }
+
+    return {
+      success: true,
+      platform: 'x',
+      message: chunks.length > 1 ? `发布成功（${chunks.length} 条推文串）` : '发布成功',
+      url: `https://x.com/i/status/${firstTweetId}`,
+    };
   }
 }

--- a/src/lib/publishers/xiaohongshu.ts
+++ b/src/lib/publishers/xiaohongshu.ts
@@ -1,52 +1,9 @@
-import { Publisher, PublishInput, PublishOutput } from './types';
+import type { PublishInput, PublishOutput } from './types';
+import { BasePublisher } from './base';
 import { getXhsConfig } from '@/lib/config';
 import { markdownToPlainText } from '@/lib/markdown';
 
-// 模块级 token 缓存（参照 wechat.ts 的 cachedToken 模式）
-let cachedXhsToken: { token: string; expiresAt: number } | null = null;
-
-export async function getXhsAccessToken(appId: string, appSecret: string): Promise<string> {
-  // 优先使用手动配置的 access token
-  const { accessToken } = getXhsConfig();
-  if (accessToken) return accessToken;
-
-  // 检查内存缓存是否有效
-  if (cachedXhsToken && Date.now() < cachedXhsToken.expiresAt) {
-    return cachedXhsToken.token;
-  }
-
-  const tokenRes = await fetch(
-    'https://open.xiaohongshu.com/api/oauth/token',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        app_id: appId,
-        app_secret: appSecret,
-        grant_type: 'client_credentials',
-      }),
-    }
-  );
-  const tokenData = await tokenRes.json();
-
-  if (tokenData.code !== 0 && tokenData.code !== 200) {
-    throw new Error(
-      `小红书获取 access_token 失败: ${tokenData.msg || tokenData.message || '未知错误'}`
-    );
-  }
-
-  const token = tokenData.data?.access_token || tokenData.access_token;
-  const expiresIn = tokenData.data?.expires_in || tokenData.expires_in || 7200;
-
-  cachedXhsToken = {
-    token,
-    expiresAt: Date.now() + (expiresIn - 300) * 1000,
-  };
-
-  return token;
-}
-
-export class XiaohongshuPublisher implements Publisher {
+export class XiaohongshuPublisher extends BasePublisher {
   platform = 'xiaohongshu' as const;
 
   validateConfig(): boolean {
@@ -54,66 +11,80 @@ export class XiaohongshuPublisher implements Publisher {
     return !!(appId && appSecret);
   }
 
-  async publish(input: PublishInput): Promise<PublishOutput> {
-    try {
-      if (!this.validateConfig()) {
-        return {
-          success: false,
-          platform: 'xiaohongshu',
-          message: '小红书凭证未配置，请在设置中配置 App ID 和 App Secret',
-        };
+  protected async publishToPlatform(input: PublishInput): Promise<PublishOutput> {
+    const { appId, appSecret } = getXhsConfig();
+    const accessToken = await this.getAccessToken(appId, appSecret);
+
+    const plainText = markdownToPlainText(input.markdownContent);
+    const truncatedContent =
+      plainText.length > 1000
+        ? plainText.slice(0, 997) + '...'
+        : plainText;
+
+    const noteRes = await fetch(
+      'https://open.xiaohongshu.com/api/note/publish',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: input.title.slice(0, 20),
+          content: truncatedContent,
+          note_type: 'normal',
+          image_ids: [],
+        }),
       }
+    );
 
-      const { appId, appSecret } = getXhsConfig();
-      const accessToken = await getXhsAccessToken(appId, appSecret);
+    const noteData = await noteRes.json();
 
-      // 转换为纯文本（小红书不支持富文本）
-      const plainText = markdownToPlainText(input.markdownContent);
-      const truncatedContent =
-        plainText.length > 1000
-          ? plainText.slice(0, 997) + '...'
-          : plainText;
-
-      const noteRes = await fetch(
-        'https://open.xiaohongshu.com/api/note/publish',
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            title: input.title.slice(0, 20),
-            content: truncatedContent,
-            note_type: 'normal',
-            image_ids: [],
-          }),
-        }
+    if (noteData.code !== 0 && noteData.code !== 200) {
+      throw new Error(
+        `小红书发布失败: ${noteData.msg || noteData.message || '未知错误'}`
       );
-
-      const noteData = await noteRes.json();
-
-      if (noteData.code !== 0 && noteData.code !== 200) {
-        throw new Error(
-          `小红书发布失败: ${noteData.msg || noteData.message || '未知错误'}`
-        );
-      }
-
-      return {
-        success: true,
-        platform: 'xiaohongshu',
-        message: '发布成功',
-        url: noteData.data?.note_url || 'https://www.xiaohongshu.com',
-      };
-    } catch (error) {
-      return {
-        success: false,
-        platform: 'xiaohongshu',
-        message:
-          error instanceof Error
-            ? error.message
-            : '小红书发布失败',
-      };
     }
+
+    return {
+      success: true,
+      platform: 'xiaohongshu',
+      message: '发布成功',
+      url: noteData.data?.note_url || 'https://www.xiaohongshu.com',
+    };
+  }
+
+  private async getAccessToken(appId: string, appSecret: string): Promise<string> {
+    const { accessToken } = getXhsConfig();
+    if (accessToken) return accessToken;
+
+    const cached = this.getCachedToken('xiaohongshu');
+    if (cached) return cached;
+
+    const tokenRes = await fetch(
+      'https://open.xiaohongshu.com/api/oauth/token',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          app_id: appId,
+          app_secret: appSecret,
+          grant_type: 'client_credentials',
+        }),
+      }
+    );
+    const tokenData = await tokenRes.json();
+
+    if (tokenData.code !== 0 && tokenData.code !== 200) {
+      throw new Error(
+        `小红书获取 access_token 失败: ${tokenData.msg || tokenData.message || '未知错误'}`
+      );
+    }
+
+    const token = tokenData.data?.access_token || tokenData.access_token;
+    const expiresIn = tokenData.data?.expires_in || tokenData.expires_in || 7200;
+
+    this.setCachedToken('xiaohongshu', token, expiresIn);
+    return token;
   }
 }

--- a/src/lib/publishers/zhihu.ts
+++ b/src/lib/publishers/zhihu.ts
@@ -1,7 +1,8 @@
-import { Publisher, PublishInput, PublishOutput } from './types';
+import type { PublishInput, PublishOutput } from './types';
+import { BasePublisher } from './base';
 import { getZhihuConfig } from '@/lib/config';
 
-export class ZhihuPublisher implements Publisher {
+export class ZhihuPublisher extends BasePublisher {
   platform = 'zhihu' as const;
 
   validateConfig(): boolean {
@@ -9,72 +10,55 @@ export class ZhihuPublisher implements Publisher {
     return !!cookie;
   }
 
-  async publish(input: PublishInput): Promise<PublishOutput> {
-    try {
-      if (!this.validateConfig()) {
-        return {
-          success: false,
-          platform: 'zhihu',
-          message: '知乎凭证未配置，请在设置中配置 Cookie',
-        };
+  protected async publishToPlatform(input: PublishInput): Promise<PublishOutput> {
+    const { cookie } = getZhihuConfig();
+    const headers = {
+      Cookie: cookie,
+      'Content-Type': 'application/json',
+      'x-requested-with': 'fetch',
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    };
+
+    // Step 1: Create draft
+    const draftRes = await fetch(
+      'https://zhuanlan.zhihu.com/api/articles/drafts',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({}),
       }
+    );
 
-      const { cookie } = getZhihuConfig();
-      const headers = {
-        Cookie: cookie,
-        'Content-Type': 'application/json',
-        'x-requested-with': 'fetch',
-        'User-Agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-      };
-
-      // Step 1: Create draft
-      const draftRes = await fetch(
-        'https://zhuanlan.zhihu.com/api/articles/drafts',
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({}),
-        }
-      );
-
-      if (draftRes.status === 401) {
-        throw new Error('知乎 Cookie 已过期，请在设置中更新 Cookie');
-      }
-
-      if (draftRes.status === 429) {
-        // Rate limited, wait and retry once
-        await new Promise((r) => setTimeout(r, 3000));
-        const retryRes = await fetch(
-          'https://zhuanlan.zhihu.com/api/articles/drafts',
-          { method: 'POST', headers, body: JSON.stringify({}) }
-        );
-        if (!retryRes.ok) {
-          throw new Error('知乎请求频率过高，请稍后再试');
-        }
-        const retryData = await retryRes.json();
-        return this.continuePublish(retryData.id, input, headers);
-      }
-
-      if (!draftRes.ok) {
-        throw new Error(`知乎创建草稿失败 (${draftRes.status})`);
-      }
-
-      const draftData = await draftRes.json();
-      return this.continuePublish(draftData.id, input, headers);
-    } catch (error) {
-      return {
-        success: false,
-        platform: 'zhihu',
-        message: error instanceof Error ? error.message : '知乎发布失败',
-      };
+    if (draftRes.status === 401) {
+      throw new Error('知乎 Cookie 已过期，请在设置中更新 Cookie');
     }
+
+    if (draftRes.status === 429) {
+      await new Promise((r) => setTimeout(r, 3000));
+      const retryRes = await fetch(
+        'https://zhuanlan.zhihu.com/api/articles/drafts',
+        { method: 'POST', headers, body: JSON.stringify({}) }
+      );
+      if (!retryRes.ok) {
+        throw new Error('知乎请求频率过高，请稍后再试');
+      }
+      const retryData = await retryRes.json();
+      return this.continuePublish(retryData.id, input, headers);
+    }
+
+    if (!draftRes.ok) {
+      throw new Error(`知乎创建草稿失败 (${draftRes.status})`);
+    }
+
+    const draftData = await draftRes.json();
+    return this.continuePublish(draftData.id, input, headers);
   }
 
   private async continuePublish(
     draftId: string,
     input: PublishInput,
-    headers: Record<string, string>
+    headers: Record<string, string>,
   ): Promise<PublishOutput> {
     // Step 2: Update draft content
     const updateRes = await fetch(

--- a/src/lib/scheduler/checkDueDrafts.ts
+++ b/src/lib/scheduler/checkDueDrafts.ts
@@ -1,0 +1,68 @@
+import { getDraftRegistry } from '@/lib/drafts/registry';
+import { getSyncHistoryStore } from '@/lib/sync/registry';
+import {
+  publishToPlatforms,
+  toSyncReceiptStatus,
+  inferFailureCode,
+  toNextAction,
+  toDraftStatus,
+} from '@/lib/publishers/executePublish';
+import type { PlatformId } from '@/types';
+
+export async function checkDueDrafts() {
+  const drafts = getDraftRegistry().listDrafts({ includeArchived: true });
+  const now = new Date();
+
+  const dueDrafts = drafts.filter(
+    (d) =>
+      d.scheduledAt &&
+      new Date(d.scheduledAt) <= now &&
+      d.status === 'draft' &&
+      d.platforms &&
+      d.platforms.length > 0,
+  );
+
+  for (const draft of dueDrafts) {
+    // Mark as syncing to prevent duplicate execution
+    getDraftRegistry().updateDraft(draft.id, { status: 'syncing' });
+
+    const platforms = draft.platforms as PlatformId[];
+    const syncStore = getSyncHistoryStore();
+    let syncTask = syncStore.createTask({
+      draftId: draft.id,
+      title: draft.title,
+      platforms,
+    });
+
+    try {
+      const publishResults = await publishToPlatforms(
+        platforms,
+        draft.title,
+        draft.content,
+      );
+
+      for (const result of publishResults) {
+        const receiptStatus = toSyncReceiptStatus(result);
+        const isFailed = receiptStatus === 'failed';
+        const failureCode = isFailed ? inferFailureCode(result.message) : undefined;
+        const nextAction = isFailed && failureCode ? toNextAction(failureCode) : undefined;
+
+        syncTask = syncStore.updateReceipt(syncTask.id, result.platform, {
+          status: receiptStatus,
+          message: result.message,
+          url: result.url,
+          failureCode,
+          failureMessage: isFailed ? (result.message ?? '未知错误') : undefined,
+          nextAction,
+        }) ?? syncTask;
+      }
+
+      getDraftRegistry().updateDraft(draft.id, {
+        status: toDraftStatus(syncTask.status),
+        scheduledAt: undefined,
+      });
+    } catch {
+      getDraftRegistry().updateDraft(draft.id, { status: 'failed' });
+    }
+  }
+}

--- a/src/lib/scheduler/index.ts
+++ b/src/lib/scheduler/index.ts
@@ -1,0 +1,2 @@
+export { startScheduler, stopScheduler } from './startScheduler';
+export { checkDueDrafts } from './checkDueDrafts';

--- a/src/lib/scheduler/startScheduler.ts
+++ b/src/lib/scheduler/startScheduler.ts
@@ -1,0 +1,20 @@
+import { checkDueDrafts } from './checkDueDrafts';
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+export function startScheduler() {
+  if (intervalId) return;
+  intervalId = setInterval(() => {
+    void checkDueDrafts();
+  }, 60_000);
+
+  // 立即执行一次检查
+  void checkDueDrafts();
+}
+
+export function stopScheduler() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}

--- a/src/lib/upload/saveFile.ts
+++ b/src/lib/upload/saveFile.ts
@@ -1,0 +1,44 @@
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { createLocalDataPath } from '@/lib/storage/localDataPath';
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
+const EXT_MAP: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+export async function saveUploadedFile(file: File): Promise<{ url: string; filename: string }> {
+  if (!ALLOWED_TYPES.has(file.type)) {
+    throw new Error(`不支持的文件类型: ${file.type}`);
+  }
+  if (file.size > MAX_SIZE) {
+    throw new Error('文件大小不能超过 5MB');
+  }
+
+  const ext = EXT_MAP[file.type] || 'png';
+  const filename = `${randomUUID()}.${ext}`;
+  const dir = createLocalDataPath('uploads');
+  mkdirSync(dir, { recursive: true });
+  const filepath = join(dir, filename);
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  writeFileSync(filepath, buffer);
+
+  return { url: `/api/uploads/${filename}`, filename };
+}
+
+export function getUploadFilePath(filename: string): string {
+  // 防止路径遍历
+  const safe = filename.replace(/[^a-zA-Z0-9._-]/g, '');
+  if (!safe || safe !== filename) {
+    throw new Error('无效文件名');
+  }
+  return createLocalDataPath(`uploads/${safe}`);
+}

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -1,0 +1,26 @@
+import type { PlatformId } from '@/types';
+
+export const MAX_CONTENT_LENGTH = 100 * 1024; // 100KB
+export const MAX_TITLE_LENGTH = 200;
+
+const VALID_PLATFORMS: PlatformId[] = ['wechat', 'xiaohongshu', 'zhihu', 'x'];
+
+export function validateTitle(title: unknown): string | null {
+  if (typeof title !== 'string' || !title.trim()) return '标题不能为空';
+  if (title.length > MAX_TITLE_LENGTH) return `标题不能超过 ${MAX_TITLE_LENGTH} 个字符`;
+  return null;
+}
+
+export function validateContent(content: unknown): string | null {
+  if (typeof content !== 'string' || !content.trim()) return '内容不能为空';
+  if (Buffer.byteLength(content, 'utf-8') > MAX_CONTENT_LENGTH) return '内容不能超过 100KB';
+  return null;
+}
+
+export function validatePlatforms(platforms: unknown): string | null {
+  if (!Array.isArray(platforms) || platforms.length === 0) return '请至少选择一个发布平台';
+  for (const p of platforms) {
+    if (!VALID_PLATFORMS.includes(p)) return `不支持的平台: ${p}`;
+  }
+  return null;
+}

--- a/src/stores/publishStore.ts
+++ b/src/stores/publishStore.ts
@@ -15,6 +15,9 @@ interface PublishStore {
   currentDraftId: string | null;
   setCurrentDraftId: (id: string | null) => void;
 
+  activeTab: 'edit' | 'preview';
+  setActiveTab: (tab: 'edit' | 'preview') => void;
+
   platforms: Record<PlatformId, boolean>;
   togglePlatform: (id: PlatformId) => void;
   setAllPlatforms: (checked: boolean) => void;
@@ -33,6 +36,9 @@ interface PublishStore {
   setLastSyncTaskId: (id: string | null) => void;
   openProgressOverlay: () => void;
   closeProgressOverlay: () => void;
+
+  scheduledAt: string | null;
+  setScheduledAt: (value: string | null) => void;
 }
 
 const platformIds = PLATFORMS.map((platform) => platform.id);
@@ -50,6 +56,9 @@ export const usePublishStore = create<PublishStore>((set) => ({
 
   currentDraftId: null,
   setCurrentDraftId: (id) => set({ currentDraftId: id }),
+
+  activeTab: 'edit',
+  setActiveTab: (tab) => set({ activeTab: tab }),
 
   platforms: {
     wechat: true,
@@ -91,4 +100,7 @@ export const usePublishStore = create<PublishStore>((set) => ({
   setLastSyncTaskId: (id) => set({ lastSyncTaskId: id }),
   openProgressOverlay: () => set({ isProgressOverlayOpen: true }),
   closeProgressOverlay: () => set({ isProgressOverlayOpen: false }),
+
+  scheduledAt: null,
+  setScheduledAt: (value) => set({ scheduledAt: value }),
 }));


### PR DESCRIPTION
## Summary

- **Security**: CSP headers, HTML sanitization via `sanitize-html`, centralized input validation
- **Publisher refactor**: `BasePublisher` base class eliminates duplicated token cache and error handling across all 4 platform publishers
- **Scheduled publishing**: server-side scheduler polls due drafts; `SchedulePicker` UI lets users set a publish time; `PublishButton` handles the scheduled flow
- **Slash commands**: `/` trigger in editor opens command menu with keyboard navigation
- **Image upload**: paste or drag-and-drop images into editor — auto-uploads and inserts markdown syntax
- **Keyboard shortcuts**: `Cmd+S` manual save, `Cmd+Enter` publish, `Cmd+P` toggle preview
- **Auto-save**: exposed `triggerSave` for manual invocation; fixed stale closure bug via refs
- **Editor CSS**: removed Safari focus ring artifacts (outline bleed through `overflow:hidden` + `border-radius` ancestor)

## Commits

| # | Scope | Description |
|---|-------|-------------|
| 1 | security | CSP headers, sanitize-html, BasePublisher, validation module |
| 2 | api | Draft model `scheduledAt`/`platforms` fields + API validation |
| 3 | feature | Scheduled publishing (scheduler, SchedulePicker, PublishButton) |
| 4 | feature | Slash commands and image upload |
| 5 | feature | Keyboard shortcuts and auto-save improvements |
| 6 | fix | Safari focus ring artifacts and editor CSS cleanup |

## Test plan

- [ ] Publish to each platform still works
- [ ] Set a scheduled time → PublishButton shows clock + formatted time, clicking saves draft with `scheduledAt`
- [ ] Type `/` in editor → slash command menu appears, navigable with arrow keys
- [ ] Paste / drag an image → uploads and inserts `![name](url)`
- [ ] `Cmd+S` triggers save indicator, `Cmd+Enter` triggers publish flow
- [ ] No focus ring visible on title input or editor content area in Safari