### PR TITLE
fix: restrict API routes to localhost-only access

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const LOCALHOST_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
+
+function isLocalhost(host: string): boolean {
+  try {
+    const { hostname } = new URL(`http://${host}`);
+    return LOCALHOST_HOSTS.includes(hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (!pathname.startsWith('/api/')) {
+    return NextResponse.next();
+  }
+
+  const host = request.headers.get('host');
+  if (!host || !isLocalhost(host)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const origin = request.headers.get('origin');
+  if (origin) {
+    try {
+      const originHost = new URL(origin).hostname;
+      if (!LOCALHOST_HOSTS.includes(originHost)) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    } catch {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+};


### PR DESCRIPTION
## Summary

- Add `src/middleware.ts` to enforce localhost-only access on all `/api/*` routes
- Check `Host` header to block non-localhost network access
- Check `Origin` header when present to block CSRF from external origins
- OAuth callback routes unaffected (browser redirects to localhost URL carry correct Host)

Closes #24

## Test plan

- [ ] `pnpm lint` passes
- [ ] Dev server: all existing API calls from the UI still work (localhost origin)
- [ ] `curl -H "Host: evil.com" http://localhost:3000/api/settings` returns 403
- [ ] `curl http://127.0.0.1:3000/api/settings` returns 200
- [ ] `curl -H "Origin: https://evil.com" http://localhost:3000/api/settings` returns 403