### PR TITLE
feat: Agent integration — AI writing, adaptation, research, diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@uiw/react-md-editor": "^4.0.4",
     "@vanilla-extract/css": "^1.20.1",
     "@vanilla-extract/recipes": "^0.5.7",
+    "eventsource-parser": "^3.0.8",
     "lucide-react": "^0.468.0",
     "marked": "^15.0.0",
     "next": "15.5.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@vanilla-extract/recipes':
         specifier: ^0.5.7
         version: 0.5.7(@vanilla-extract/css@1.20.1)
+      eventsource-parser:
+        specifier: ^3.0.8
+        version: 3.0.8
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
@@ -2004,6 +2007,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -5561,6 +5568,8 @@ snapshots:
       require-like: 0.1.2
 
   events@3.3.0: {}
+
+  eventsource-parser@3.0.8: {}
 
   expect-type@1.3.0: {}
 

--- a/src/app/api/agent/adapt/route.ts
+++ b/src/app/api/agent/adapt/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+import { getAgentConfig } from '@/lib/agent/config';
+import { createOpenAIProvider } from '@/lib/agent/provider';
+import { createSSEResponse } from '@/lib/agent/stream';
+import { buildAdaptationMessages } from '@/lib/agent/prompts/adaptation';
+import type { AdaptAgentRequest } from '@/lib/agent/types';
+import { PLATFORMS } from '@/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const config = getAgentConfig();
+  if (!config) {
+    return Response.json(
+      { error: 'Agent 未配置' },
+      { status: 503 }
+    );
+  }
+
+  let body: AdaptAgentRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: '请求体解析失败' }, { status: 400 });
+  }
+
+  const { title, content, platform } = body;
+
+  if (!platform || !PLATFORMS.some((p) => p.id === platform)) {
+    return Response.json({ error: '无效的平台 ID' }, { status: 400 });
+  }
+
+  if (!content?.trim()) {
+    return Response.json({ error: '内容不能为空' }, { status: 400 });
+  }
+
+  const messages = buildAdaptationMessages(platform, title || '', content);
+  const provider = createOpenAIProvider(config);
+  const tokens = provider.stream({ messages });
+
+  return createSSEResponse(tokens, request.signal);
+}

--- a/src/app/api/agent/diagnose/route.ts
+++ b/src/app/api/agent/diagnose/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { getAgentConfig } from '@/lib/agent/config';
+import { createOpenAIProvider } from '@/lib/agent/provider';
+import { createSSEResponse } from '@/lib/agent/stream';
+import { buildDiagnoseMessages } from '@/lib/agent/prompts/diagnose';
+import type { DiagnoseAgentRequest } from '@/lib/agent/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const config = getAgentConfig();
+  if (!config) {
+    return Response.json(
+      { error: 'Agent 未配置' },
+      { status: 503 }
+    );
+  }
+
+  let body: DiagnoseAgentRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: '请求体解析失败' }, { status: 400 });
+  }
+
+  const { platform, errorMessage, statusCode, context } = body;
+
+  if (!platform || !errorMessage?.trim()) {
+    return Response.json({ error: '平台和错误信息不能为空' }, { status: 400 });
+  }
+
+  const messages = buildDiagnoseMessages(platform, errorMessage, statusCode, context);
+  const provider = createOpenAIProvider(config);
+  const tokens = provider.stream({ messages, maxTokens: 1000 });
+
+  return createSSEResponse(tokens, request.signal);
+}

--- a/src/app/api/agent/research/route.ts
+++ b/src/app/api/agent/research/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+import { getAgentConfig } from '@/lib/agent/config';
+import { createOpenAIProvider } from '@/lib/agent/provider';
+import { createSSEResponse } from '@/lib/agent/stream';
+import { buildResearchMessages } from '@/lib/agent/prompts/research';
+import type { ResearchAgentRequest } from '@/lib/agent/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const config = getAgentConfig();
+  if (!config) {
+    return Response.json(
+      { error: 'Agent 未配置' },
+      { status: 503 }
+    );
+  }
+
+  let body: ResearchAgentRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: '请求体解析失败' }, { status: 400 });
+  }
+
+  const { clusterTitle, signals } = body;
+
+  if (!clusterTitle?.trim()) {
+    return Response.json({ error: '话题标题不能为空' }, { status: 400 });
+  }
+
+  if (!signals || signals.length === 0) {
+    return Response.json({ error: '至少需要一条信号' }, { status: 400 });
+  }
+
+  const messages = buildResearchMessages(clusterTitle, signals);
+  const provider = createOpenAIProvider(config);
+  const tokens = provider.stream({ messages, maxTokens: 3000 });
+
+  return createSSEResponse(tokens, request.signal);
+}

--- a/src/app/api/agent/status/route.ts
+++ b/src/app/api/agent/status/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { isAgentConfigured } from '@/lib/agent/config';
+
+export const dynamic = 'force-dynamic';
+
+/** 客户端用于检查 Agent 是否已配置（不暴露密钥） */
+export async function GET() {
+  return NextResponse.json({ available: isAgentConfigured() });
+}

--- a/src/app/api/agent/write/route.ts
+++ b/src/app/api/agent/write/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server';
+import { getAgentConfig } from '@/lib/agent/config';
+import { createOpenAIProvider } from '@/lib/agent/provider';
+import { createSSEResponse } from '@/lib/agent/stream';
+import { buildWritingMessages } from '@/lib/agent/prompts/writing';
+import type { WritingAction, WritingAgentRequest } from '@/lib/agent/types';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_ACTIONS: WritingAction[] = [
+  'expand',
+  'condense',
+  'rewrite',
+  'polish',
+  'continue',
+];
+
+export async function POST(request: NextRequest) {
+  const config = getAgentConfig();
+  if (!config) {
+    return Response.json(
+      { error: 'Agent 未配置，请在设置中填写 AGENT_BASE_URL、AGENT_API_KEY、AGENT_MODEL' },
+      { status: 503 }
+    );
+  }
+
+  let body: WritingAgentRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: '请求体解析失败' }, { status: 400 });
+  }
+
+  const { action, content, title, selection } = body;
+
+  if (!action || !VALID_ACTIONS.includes(action)) {
+    return Response.json(
+      { error: `无效的 action，可选: ${VALID_ACTIONS.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  if (!content?.trim()) {
+    return Response.json({ error: '内容不能为空' }, { status: 400 });
+  }
+
+  const messages = buildWritingMessages(action, content, { title, selection });
+  const provider = createOpenAIProvider(config);
+  const tokens = provider.stream({ messages });
+
+  return createSSEResponse(tokens, request.signal);
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -12,6 +12,7 @@ const SECRET_KEYS = [
   'ZHIHU_COOKIE',
   'X_API_SECRET',
   'X_ACCESS_TOKEN_SECRET',
+  'AGENT_API_KEY',
 ];
 
 function maskValue(key: string, value: string): string {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Eye, Files, SquarePen, Eraser } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
+import { useAgentStore } from '@/stores/agentStore';
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import MarkdownEditor from '@/components/editor/MarkdownEditor';
 import RecentDraftBar from '@/components/editor/RecentDraftBar';
@@ -15,6 +16,7 @@ import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
 import PublishProgressOverlay from '@/components/publish/PublishProgressOverlay';
 import SchedulePicker from '@/components/publish/SchedulePicker';
 import EditorialContextCard from '@/components/editor/EditorialContextCard';
+import AgentPanel from '@/components/agent/AgentPanel';
 import * as publishStyles from '@/components/publish/publish.css';
 import { fetchDraftById } from '@/lib/drafts/client';
 import { useAutoSave } from '@/hooks/useAutoSave';
@@ -37,12 +39,22 @@ function HomePageContent() {
     activeTab,
     setActiveTab,
   } = usePublishStore();
+  const agentStatus = useAgentStore((s) => s.status);
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [draftLoadError, setDraftLoadError] = useState('');
   const [clearConfirming, setClearConfirming] = useState(false);
   const clearConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [agentEnabled, setAgentEnabled] = useState(false);
+
+  // 检查 Agent 是否已配置
+  useEffect(() => {
+    fetch('/api/agent/status')
+      .then((r) => r.json())
+      .then((data) => setAgentEnabled(data.available === true))
+      .catch(() => setAgentEnabled(false));
+  }, []);
   const selectedPlatforms = useMemo(
     () => Object.entries(platforms)
       .filter(([, selected]) => selected)
@@ -189,9 +201,11 @@ function HomePageContent() {
             </div>
 
             <div className={styles.editorCard}>
-              <MarkdownEditor activeTab={activeTab} onSave={triggerSave} />
+              <MarkdownEditor activeTab={activeTab} onSave={triggerSave} agentEnabled={agentEnabled} />
             </div>
           </div>
+
+          {agentStatus !== 'idle' && <AgentPanel />}
 
           <div className={styles.rightPanel}>
             <EditorialContextCard />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import PublishButton from '@/components/publish/PublishButton';
 import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
 import PlatformPreviewPanel from '@/components/publish/PlatformPreviewPanel';
 import PublishProgressOverlay from '@/components/publish/PublishProgressOverlay';
+import PublishTimingSuggestion from '@/components/publish/PublishTimingSuggestion';
 import SchedulePicker from '@/components/publish/SchedulePicker';
 import EditorialContextCard from '@/components/editor/EditorialContextCard';
 import AgentPanel from '@/components/agent/AgentPanel';
@@ -218,6 +219,8 @@ function HomePageContent() {
             <div className={publishStyles.rightPanelSection}>
               <SchedulePicker />
             </div>
+
+            <PublishTimingSuggestion />
 
             <PlatformPreviewPanel
               adaptations={platformDrafts}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -222,6 +222,7 @@ function HomePageContent() {
             <PlatformPreviewPanel
               adaptations={platformDrafts}
               selectedPlatforms={selectedPlatforms}
+              agentEnabled={agentEnabled}
             />
 
             <div className={publishStyles.rightPanelSection}>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -647,8 +647,14 @@ function SettingsContent() {
               </div>
             </div>
             <p className={styles.fieldHint}>
-              填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写后，编辑器中的 AI 写作命令自动激活。
+              填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写并保存后：
             </p>
+            <ul className={styles.fieldHint} style={{ margin: '4px 0 0 16px', padding: 0 }}>
+              <li>编辑器输入 <code className={styles.inlineCode}>/</code> 查看 AI 命令（扩写、缩写、改写、润色、续写）</li>
+              <li>AI 选题页话题卡出现「深度分析」按钮</li>
+              <li>发布预览面板出现「AI 适配」按钮</li>
+              <li>分发失败时出现「AI 诊断」按钮</li>
+            </ul>
           </div>
         </SurfaceCard>
       </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   RefreshCw,
   Unplug,
   Zap,
+  Sparkles,
 } from 'lucide-react';
 
 import AppShellHeader from '@/components/layout/AppShellHeader';
@@ -576,6 +577,80 @@ function SettingsContent() {
             </SurfaceCard>
           );
         })}
+      </div>
+      <div className={styles.platformList}>
+        <SurfaceCard tone="soft" className={styles.accordionCard}>
+          <div className={styles.accordionTrigger} style={{ cursor: 'default' }}>
+            <div className={styles.accordionIcon}>
+              <Sparkles size={20} />
+            </div>
+            <div className={styles.accordionBody}>
+              <p className={styles.accordionTitle}>AI 助手（Agent）</p>
+              <p className={styles.accordionSummary}>配置 LLM 接口，启用 AI 写作、适配、研究功能</p>
+            </div>
+          </div>
+
+          <div className={styles.accordionPanel}>
+            <div className={styles.fieldList}>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="AGENT_BASE_URL" className={styles.fieldLabel}>
+                  API Base URL
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="AGENT_BASE_URL"
+                    type="text"
+                    value={values['AGENT_BASE_URL'] || ''}
+                    onChange={(event) => handleChange('AGENT_BASE_URL', event.target.value)}
+                    placeholder="如 https://api.openai.com/v1 或 https://api.deepseek.com"
+                    className={styles.fieldInput}
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="AGENT_API_KEY" className={styles.fieldLabel}>
+                  API Key
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="AGENT_API_KEY"
+                    type={showSecrets['AGENT_API_KEY'] ? 'text' : 'password'}
+                    value={values['AGENT_API_KEY'] || ''}
+                    onChange={(event) => handleChange('AGENT_API_KEY', event.target.value)}
+                    placeholder="输入 API Key"
+                    className={styles.fieldInput}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleSecret('AGENT_API_KEY')}
+                    aria-label={`${showSecrets['AGENT_API_KEY'] ? '隐藏' : '显示'} API Key`}
+                    className={styles.eyeButton}
+                  >
+                    {showSecrets['AGENT_API_KEY'] ? <EyeOff size={16} /> : <Eye size={16} />}
+                  </button>
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="AGENT_MODEL" className={styles.fieldLabel}>
+                  模型名称
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="AGENT_MODEL"
+                    type="text"
+                    value={values['AGENT_MODEL'] || ''}
+                    onChange={(event) => handleChange('AGENT_MODEL', event.target.value)}
+                    placeholder="如 gpt-4o-mini、deepseek-chat、qwen-plus"
+                    className={styles.fieldInput}
+                  />
+                </div>
+              </div>
+            </div>
+            <p className={styles.fieldHint}>
+              填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写后，编辑器中的 AI 写作命令自动激活。
+            </p>
+          </div>
+        </SurfaceCard>
       </div>
     </div>
   );

--- a/src/components/agent/AgentPanel.css.ts
+++ b/src/components/agent/AgentPanel.css.ts
@@ -1,0 +1,154 @@
+import { style, keyframes } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+const blink = keyframes({
+  '0%, 100%': { opacity: 1 },
+  '50%': { opacity: 0 },
+});
+
+export const panelWrap = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '360px',
+  flexShrink: 0,
+  background: vars.color.surface,
+  borderRadius: vars.radius.xl,
+  border: `1px solid ${vars.color.border}`,
+  overflow: 'hidden',
+  maxHeight: 'calc(100vh - 140px)',
+  position: 'sticky',
+  top: '24px',
+  '@media': {
+    'screen and (max-width: 1279px)': {
+      width: '300px',
+    },
+  },
+});
+
+export const panelHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '12px 16px',
+  borderBottom: `1px solid ${vars.color.borderFaint}`,
+});
+
+export const panelTitle = style({
+  fontSize: '13px',
+  fontWeight: 600,
+  color: vars.color.text,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+});
+
+export const panelBadge = style({
+  fontSize: '11px',
+  fontWeight: 500,
+  color: vars.color.accent,
+  background: vars.color.accentSoft,
+  borderRadius: '4px',
+  padding: '1px 6px',
+});
+
+export const closeButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '24px',
+  height: '24px',
+  borderRadius: '4px',
+  border: 'none',
+  background: 'transparent',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  ':hover': {
+    background: vars.color.canvasDeep,
+    color: vars.color.text,
+  },
+});
+
+export const panelBody = style({
+  flex: 1,
+  overflow: 'auto',
+  padding: '16px',
+});
+
+export const outputArea = style({
+  fontSize: '14px',
+  lineHeight: 1.7,
+  color: vars.color.text,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+});
+
+export const cursor = style({
+  display: 'inline-block',
+  width: '2px',
+  height: '1em',
+  background: vars.color.accent,
+  marginLeft: '1px',
+  animation: `${blink} 1s step-end infinite`,
+  verticalAlign: 'text-bottom',
+});
+
+export const panelActions = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  padding: '12px 16px',
+  borderTop: `1px solid ${vars.color.borderFaint}`,
+});
+
+export const actionButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '5px',
+  borderRadius: '6px',
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '6px 10px',
+  fontSize: '13px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'all 150ms',
+  ':hover': {
+    background: vars.color.canvasDeep,
+    color: vars.color.text,
+    borderColor: vars.color.borderStrong,
+  },
+});
+
+export const actionButtonPrimary = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '5px',
+  borderRadius: '6px',
+  border: 'none',
+  background: vars.color.accent,
+  padding: '6px 12px',
+  fontSize: '13px',
+  fontWeight: 500,
+  color: '#ffffff',
+  cursor: 'pointer',
+  transition: 'opacity 150ms',
+  ':hover': {
+    opacity: 0.9,
+  },
+});
+
+export const errorBox = style({
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.errorBorder}`,
+  background: vars.color.errorBg,
+  padding: '10px 12px',
+  fontSize: '13px',
+  color: vars.color.errorText,
+});
+
+export const emptyState = style({
+  fontSize: '13px',
+  color: vars.color.textMuted,
+  textAlign: 'center',
+  padding: '32px 16px',
+});

--- a/src/components/agent/AgentPanel.tsx
+++ b/src/components/agent/AgentPanel.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCallback } from 'react';
+import { X, Copy, Replace, CornerDownLeft } from 'lucide-react';
+import { useAgentStore } from '@/stores/agentStore';
+import { usePublishStore } from '@/stores/publishStore';
+import * as styles from './AgentPanel.css';
+
+const ACTION_LABELS: Record<string, string> = {
+  expand: '扩写',
+  condense: '缩写',
+  rewrite: '改写',
+  polish: '润色',
+  continue: '续写',
+};
+
+export default function AgentPanel() {
+  const { status, output, error, activeAction, abort, reset } = useAgentStore();
+  const { content, setContent } = usePublishStore();
+
+  const handleInsert = useCallback(() => {
+    // 在当前内容末尾追加 agent 输出
+    const separator = content.endsWith('\n') ? '\n' : '\n\n';
+    setContent(content + separator + output);
+    reset();
+  }, [content, output, setContent, reset]);
+
+  const handleReplace = useCallback(() => {
+    // 替换全部内容
+    setContent(output);
+    reset();
+  }, [output, setContent, reset]);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(output);
+  }, [output]);
+
+  const handleClose = useCallback(() => {
+    if (status === 'streaming') {
+      abort();
+    }
+    reset();
+  }, [status, abort, reset]);
+
+  const actionLabel = activeAction ? ACTION_LABELS[activeAction] || activeAction : 'AI';
+
+  return (
+    <div className={styles.panelWrap}>
+      <div className={styles.panelHeader}>
+        <span className={styles.panelTitle}>
+          AI 助手
+          <span className={styles.panelBadge}>{actionLabel}</span>
+        </span>
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={handleClose}
+          title="关闭"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className={styles.panelBody}>
+        {error ? (
+          <div className={styles.errorBox}>{error}</div>
+        ) : output ? (
+          <div className={styles.outputArea}>
+            {output}
+            {status === 'streaming' && <span className={styles.cursor} />}
+          </div>
+        ) : status === 'streaming' ? (
+          <div className={styles.outputArea}>
+            <span className={styles.cursor} />
+          </div>
+        ) : (
+          <div className={styles.emptyState}>等待 AI 响应...</div>
+        )}
+      </div>
+
+      {(status === 'done' || (status === 'error' && output)) && (
+        <div className={styles.panelActions}>
+          <button
+            type="button"
+            className={styles.actionButtonPrimary}
+            onClick={handleInsert}
+            title="追加到文末"
+          >
+            <CornerDownLeft size={13} />
+            插入
+          </button>
+          <button
+            type="button"
+            className={styles.actionButton}
+            onClick={handleReplace}
+            title="替换全部内容"
+          >
+            <Replace size={13} />
+            替换
+          </button>
+          <button
+            type="button"
+            className={styles.actionButton}
+            onClick={handleCopy}
+            title="复制到剪贴板"
+          >
+            <Copy size={13} />
+            复制
+          </button>
+        </div>
+      )}
+
+      {status === 'streaming' && (
+        <div className={styles.panelActions}>
+          <button
+            type="button"
+            className={styles.actionButton}
+            onClick={abort}
+          >
+            停止生成
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -12,6 +12,7 @@ import {
   estimateReadTime,
 } from '@/lib/contentStats';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
+import { useAgentStream } from '@/hooks/useAgentStream';
 import SlashCommandMenu from './SlashCommandMenu';
 import * as styles from './editor.css';
 
@@ -20,15 +21,17 @@ const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false });
 interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';
   onSave?: () => Promise<void>;
+  agentEnabled?: boolean;
 }
 
-export default function MarkdownEditor({ activeTab, onSave }: MarkdownEditorProps) {
+export default function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEditorProps) {
   const { title, setTitle, content, setContent, setActiveTab } = usePublishStore();
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const editorWrapRef = useRef<HTMLDivElement>(null);
-  const slash = useSlashCommands(content, setContent);
+  const slash = useSlashCommands(content, setContent, { agentEnabled });
+  const agent = useAgentStream();
 
   useEffect(() => {
     function syncHeight() {
@@ -177,7 +180,16 @@ export default function MarkdownEditor({ activeTab, onSave }: MarkdownEditorProp
               <SlashCommandMenu
                 commands={slash.filteredCommands}
                 selectedIndex={slash.selectedIndex}
-                onSelect={(cmd) => slash.selectCommand(cmd)}
+                onSelect={(cmd) => {
+                  const result = slash.selectCommand(cmd);
+                  if (result?.type === 'ai') {
+                    agent.request({
+                      url: '/api/agent/write',
+                      body: { action: result.action, content, title },
+                      action: result.action,
+                    });
+                  }
+                }}
               />
             </div>
           )}

--- a/src/components/news/AiNewsPageClient.tsx
+++ b/src/components/news/AiNewsPageClient.tsx
@@ -266,6 +266,7 @@ export default function AiNewsPageClient() {
           })),
         },
       ],
+      llmAnalysis: deepResearchContent[item.clusterId] || undefined,
     });
     void writeDraftAndOpenEditor(item.title, content, item.clusterId);
   };

--- a/src/components/news/AiNewsPageClient.tsx
+++ b/src/components/news/AiNewsPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import TopicDeskHeader from '@/components/news/TopicDeskHeader';
@@ -10,6 +10,8 @@ import {
   buildResearchDraftMarkdown,
 } from '@/lib/newsDraft';
 import { createDraft } from '@/lib/drafts/client';
+import { useAgentStore } from '@/stores/agentStore';
+import type { AgentStreamEvent } from '@/lib/agent/types';
 import * as styles from './news.css';
 
 // localStorage key for tracking which topic clusters have drafts in this session
@@ -113,7 +115,109 @@ export default function AiNewsPageClient() {
   const [briefOpenMap, setBriefOpenMap] = useState<Map<string, boolean>>(cachedBriefOpenMap);
   const hasDeskDataRef = useRef(false);
 
+  // Deep research state
+  const [agentEnabled, setAgentEnabled] = useState(false);
+  const [deepResearchLoading, setDeepResearchLoading] = useState<Record<string, boolean>>({});
+  const [deepResearchContent, setDeepResearchContent] = useState<Record<string, string>>({});
+  const researchCache = useAgentStore((s) => s.researchCache);
+  const cacheResearch = useAgentStore((s) => s.cacheResearch);
+
   const allCandidates = [...todayCandidates, ...followCandidates];
+
+  // Check agent availability on mount
+  useEffect(() => {
+    fetch('/api/agent/status')
+      .then((r) => r.json())
+      .then((d) => setAgentEnabled(d.available === true))
+      .catch(() => setAgentEnabled(false));
+  }, []);
+
+  // Restore cached research results
+  useEffect(() => {
+    const restored: Record<string, string> = {};
+    for (const [title, analysis] of Object.entries(researchCache)) {
+      // Find matching candidate by title
+      const match = allCandidates.find((c) => c.title === title);
+      if (match) restored[match.clusterId] = analysis.raw;
+    }
+    if (Object.keys(restored).length > 0) {
+      setDeepResearchContent((prev) => ({ ...prev, ...restored }));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allCandidates.length]);
+
+  const handleDeepResearch = useCallback(async (item: AiNewsDeskCandidate) => {
+    const clusterId = item.clusterId;
+    setDeepResearchLoading((prev) => ({ ...prev, [clusterId]: true }));
+
+    try {
+      const response = await fetch('/api/agent/research', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clusterTitle: item.title,
+          signals: item.signals?.map((s) => ({
+            title: s.title,
+            summary: s.summary || '',
+            source: s.sourceName,
+            publishedAt: s.publishedAt,
+          })) ?? [{
+            title: item.title,
+            summary: item.whyNow,
+            source: item.primarySignal.sourceName,
+            publishedAt: item.primarySignal.publishedAt,
+          }],
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error('深度分析请求失败');
+      }
+
+      const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+      let buffer = '';
+      let accumulated = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += value;
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const event: AgentStreamEvent = JSON.parse(line.slice(6));
+            if (event.type === 'delta') {
+              accumulated += event.content;
+              setDeepResearchContent((prev) => ({ ...prev, [clusterId]: accumulated }));
+            } else if (event.type === 'error') {
+              throw new Error(event.error);
+            }
+          } catch (e) {
+            if (e instanceof Error && e.message !== '深度分析请求失败') {
+              // skip parse errors
+            } else {
+              throw e;
+            }
+          }
+        }
+      }
+
+      // Cache result
+      cacheResearch({
+        raw: accumulated,
+        clusterTitle: item.title,
+        generatedAt: new Date().toISOString(),
+      });
+    } catch {
+      // On error, clear loading but keep any partial content
+    } finally {
+      setDeepResearchLoading((prev) => ({ ...prev, [clusterId]: false }));
+    }
+  }, [cacheResearch]);
 
   const writeDraftAndOpenEditor = async (title: string, content: string, clusterId: string) => {
     try {
@@ -315,6 +419,10 @@ export default function AiNewsPageClient() {
                 setBriefOpenMap(new Map(cachedBriefOpenMap));
               }}
               onCreateDraft={createSingleNewsDraft}
+              agentEnabled={agentEnabled}
+              onDeepResearch={handleDeepResearch}
+              deepResearchContent={deepResearchContent}
+              deepResearchLoading={deepResearchLoading}
             />
             <CandidateSection
               title="还能追"
@@ -327,6 +435,10 @@ export default function AiNewsPageClient() {
                 setBriefOpenMap(new Map(cachedBriefOpenMap));
               }}
               onCreateDraft={createSingleNewsDraft}
+              agentEnabled={agentEnabled}
+              onDeepResearch={handleDeepResearch}
+              deepResearchContent={deepResearchContent}
+              deepResearchLoading={deepResearchLoading}
             />
           </div>
         )}
@@ -347,6 +459,10 @@ function CandidateSection({
   briefOpenMap,
   onBriefToggle,
   onCreateDraft,
+  agentEnabled,
+  onDeepResearch,
+  deepResearchContent,
+  deepResearchLoading,
 }: {
   title: string;
   items: AiNewsDeskCandidate[];
@@ -355,6 +471,10 @@ function CandidateSection({
   briefOpenMap: Map<string, boolean>;
   onBriefToggle: (clusterId: string, open: boolean) => void;
   onCreateDraft: (item: AiNewsDeskCandidate) => void;
+  agentEnabled: boolean;
+  onDeepResearch: (item: AiNewsDeskCandidate) => void;
+  deepResearchContent: Record<string, string>;
+  deepResearchLoading: Record<string, boolean>;
 }) {
   if (items.length === 0) return null;
 
@@ -371,6 +491,10 @@ function CandidateSection({
           showBrief={briefOpenMap.get(item.clusterId) ?? false}
           onBriefToggle={(open) => onBriefToggle(item.clusterId, open)}
           onCreateDraft={onCreateDraft}
+          agentEnabled={agentEnabled}
+          onDeepResearch={onDeepResearch}
+          deepResearchContent={deepResearchContent[item.clusterId]}
+          deepResearchLoading={deepResearchLoading[item.clusterId] ?? false}
         />
       ))}
     </section>

--- a/src/components/news/TopicSignalCard.tsx
+++ b/src/components/news/TopicSignalCard.tsx
@@ -1,4 +1,4 @@
-import { Clock3, ExternalLink, FileUp, ChevronDown, CheckCircle2 } from 'lucide-react';
+import { Clock3, ExternalLink, FileUp, ChevronDown, CheckCircle2, Sparkles } from 'lucide-react';
 
 import SurfaceCard from '@/components/layout/SurfaceCard';
 import ScoreBar from '@/components/news/ScoreBar';
@@ -14,6 +14,10 @@ interface TopicSignalCardProps {
   showBrief: boolean;
   onBriefToggle: (open: boolean) => void;
   onCreateDraft: (item: AiNewsDeskCandidate) => void;
+  onDeepResearch?: (item: AiNewsDeskCandidate) => void;
+  deepResearchContent?: string;
+  deepResearchLoading?: boolean;
+  agentEnabled?: boolean;
 }
 
 function formatArticleMetrics(wordCount?: number, imageCount?: number) {
@@ -36,6 +40,10 @@ export default function TopicSignalCard({
   showBrief,
   onBriefToggle,
   onCreateDraft,
+  onDeepResearch,
+  deepResearchContent,
+  deepResearchLoading,
+  agentEnabled,
 }: TopicSignalCardProps) {
   const brief = item.researchBrief;
   const metrics = formatArticleMetrics(
@@ -143,6 +151,17 @@ export default function TopicSignalCard({
               />
               {showBrief ? '收起底稿' : '查看底稿'}
             </button>
+            {agentEnabled && onDeepResearch && (
+              <button
+                type="button"
+                onClick={() => onDeepResearch(item)}
+                disabled={deepResearchLoading}
+                className={styles.actionButton({ variant: 'secondary' })}
+              >
+                <Sparkles size={15} />
+                {deepResearchLoading ? '分析中…' : deepResearchContent ? '重新分析' : '深度分析'}
+              </button>
+            )}
             {draftId ? (
               <a
                 href={`/?draftId=${draftId}`}
@@ -196,6 +215,21 @@ export default function TopicSignalCard({
                       <p className={styles.angleReason}>{angle.reason}</p>
                     </div>
                   ))}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {/* AI 深度分析结果 */}
+          {deepResearchContent ? (
+            <div className={styles.briefSection}>
+              <div className={styles.briefBlockAccent}>
+                <p className={styles.briefKickerAccent}>✨ AI 深度分析</p>
+                <div
+                  className={styles.briefText}
+                  style={{ whiteSpace: 'pre-wrap' }}
+                >
+                  {deepResearchContent}
                 </div>
               </div>
             </div>

--- a/src/components/publish/PlatformAdaptButton.tsx
+++ b/src/components/publish/PlatformAdaptButton.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { Sparkles, Undo2, Loader2 } from 'lucide-react';
+import { usePublishStore } from '@/stores/publishStore';
+import type { PlatformId } from '@/types';
+import type { AgentStreamEvent } from '@/lib/agent/types';
+import * as styles from './publish.css';
+
+interface PlatformAdaptButtonProps {
+  platform: PlatformId;
+  agentEnabled: boolean;
+}
+
+export default function PlatformAdaptButton({ platform, agentEnabled }: PlatformAdaptButtonProps) {
+  const { title, content, platformDrafts, setAIAdaptedContent, revertAIDraft } = usePublishStore();
+  const [adapting, setAdapting] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const draft = platformDrafts[platform];
+  const isAdapted = draft?.aiAdapted === true;
+
+  const handleAdapt = useCallback(async () => {
+    if (!content.trim()) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setAdapting(true);
+
+    let accumulated = '';
+
+    try {
+      const response = await fetch('/api/agent/adapt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, content, platform }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        setAdapting(false);
+        return;
+      }
+
+      const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += value;
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const event: AgentStreamEvent = JSON.parse(line.slice(6));
+            if (event.type === 'delta') {
+              accumulated += event.content;
+            } else if (event.type === 'done') {
+              break;
+            }
+          } catch { /* skip */ }
+        }
+      }
+
+      if (accumulated) {
+        setAIAdaptedContent(platform, accumulated);
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+    } finally {
+      setAdapting(false);
+      abortRef.current = null;
+    }
+  }, [title, content, platform, setAIAdaptedContent]);
+
+  const handleRevert = useCallback(() => {
+    revertAIDraft(platform);
+  }, [platform, revertAIDraft]);
+
+  if (!agentEnabled) return null;
+
+  if (isAdapted) {
+    return (
+      <button
+        type="button"
+        className={styles.adaptButtonRevert}
+        onClick={handleRevert}
+        title="恢复原始内容"
+      >
+        <Undo2 size={11} />
+        回退
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={styles.adaptButton}
+      onClick={handleAdapt}
+      disabled={adapting || !content.trim()}
+      title="用 AI 优化此平台内容"
+    >
+      {adapting ? <Loader2 size={11} className={styles.spinIcon} /> : <Sparkles size={11} />}
+      {adapting ? '适配中…' : 'AI 适配'}
+    </button>
+  );
+}

--- a/src/components/publish/PlatformPreviewPanel.tsx
+++ b/src/components/publish/PlatformPreviewPanel.tsx
@@ -6,6 +6,7 @@ import type { PlatformId } from '@/types';
 import type {
   PlatformContentDrafts,
 } from '@/lib/platformAdapters/types';
+import PlatformAdaptButton from './PlatformAdaptButton';
 import * as styles from './publish.css';
 
 const platformLabels: Record<PlatformId, string> = {
@@ -24,6 +25,7 @@ const formatLabels = {
 interface PlatformPreviewPanelProps {
   adaptations: PlatformContentDrafts;
   selectedPlatforms: PlatformId[];
+  agentEnabled?: boolean;
 }
 
 // 去除常见 Markdown 语法，返回纯文本
@@ -57,6 +59,7 @@ function extractFirstImage(content: string): string | null {
 export default function PlatformPreviewPanel({
   adaptations,
   selectedPlatforms,
+  agentEnabled = false,
 }: PlatformPreviewPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -84,15 +87,17 @@ export default function PlatformPreviewPanel({
         <div className={styles.previewGrid} style={{ marginTop: '8px' }}>
           {selectedPlatforms.map((platform) => {
             const draft = adaptations[platform];
-            const firstImage = extractFirstImage(draft.body);
+            const displayBody = draft.aiAdapted && draft.aiBody ? draft.aiBody : draft.body;
+            const firstImage = extractFirstImage(displayBody);
 
             return (
               <article key={platform} className={styles.previewCard}>
-                {/* 平台名 + 状态 */}
+                {/* 平台名 + 状态 + AI 适配按钮 */}
                 <div className={styles.previewMeta}>
                   <p className={styles.previewPlatform}>{platformLabels[platform]}</p>
+                  <PlatformAdaptButton platform={platform} agentEnabled={agentEnabled} />
                   <span className={`${styles.previewState} ${draft.isReady ? '' : styles.previewStateNotReady}`}>
-                    {draft.isReady ? '可发布' : '待补全'} · {formatLabels[draft.format]}
+                    {draft.aiAdapted ? '✨ AI' : ''} {draft.isReady ? '可发布' : '待补全'} · {formatLabels[draft.format]}
                   </span>
                 </div>
 
@@ -107,8 +112,8 @@ export default function PlatformPreviewPanel({
                 ) : null}
 
                 {/* 内容摘要 */}
-                {draft.body ? (
-                  <p className={styles.previewBody}>{createExcerpt(draft.body)}</p>
+                {displayBody ? (
+                  <p className={styles.previewBody}>{createExcerpt(displayBody)}</p>
                 ) : null}
 
                 {/* Warnings */}

--- a/src/components/publish/PublishButton.tsx
+++ b/src/components/publish/PublishButton.tsx
@@ -114,7 +114,9 @@ export default function PublishButton() {
               platform,
               {
                 title: platformDrafts[platform].title,
-                content: platformDrafts[platform].body,
+                content: (platformDrafts[platform].aiAdapted && platformDrafts[platform].aiBody)
+                  ? platformDrafts[platform].aiBody
+                  : platformDrafts[platform].body,
               },
             ]),
           ),

--- a/src/components/publish/PublishTimingSuggestion.tsx
+++ b/src/components/publish/PublishTimingSuggestion.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Clock3 } from 'lucide-react';
+import { aggregatePublishHistory, suggestPublishTiming } from '@/lib/agent/publishOps';
+import type { SyncTask } from '@/lib/sync/types';
+import * as publishStyles from './publish.css';
+
+export default function PublishTimingSuggestion() {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch('/api/sync-tasks')
+      .then((r) => r.json())
+      .then((data: { syncTasks?: SyncTask[] }) => {
+        if (!data.syncTasks || data.syncTasks.length === 0) return;
+        const stats = aggregatePublishHistory(data.syncTasks);
+        setSuggestions(suggestPublishTiming(stats));
+      })
+      .catch(() => {
+        // silently fail — timing suggestions are non-critical
+      });
+  }, []);
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className={publishStyles.rightPanelSection}>
+      <span className={publishStyles.rightPanelSectionTitle}>
+        <Clock3 size={11} style={{ marginRight: 4, verticalAlign: '-1px' }} />
+        发布时机
+      </span>
+      <ul style={{ margin: 0, padding: '4px 0 0 16px', fontSize: '12px', color: '#6b5b4f' }}>
+        {suggestions.map((s) => (
+          <li key={s} style={{ marginBottom: 2 }}>{s}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/publish/publish.css.ts
+++ b/src/components/publish/publish.css.ts
@@ -1,6 +1,11 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style, styleVariants, keyframes } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/styles/tokens.css';
+
+const spin = keyframes({
+  from: { transform: 'rotate(0deg)' },
+  to: { transform: 'rotate(360deg)' },
+});
 
 export const selectorWrap = style({
   display: 'flex',
@@ -540,4 +545,49 @@ export const collapseChevron = style({
 
 export const collapseChevronOpen = style({
   transform: 'rotate(180deg)',
+});
+
+// AI 适配按钮
+export const adaptButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  borderRadius: '4px',
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '2px 7px',
+  fontSize: '11px',
+  color: vars.color.accent,
+  cursor: 'pointer',
+  transition: 'all 150ms',
+  ':hover': {
+    background: vars.color.accentSoft,
+    borderColor: vars.color.accent,
+  },
+  ':disabled': {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+});
+
+export const adaptButtonRevert = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  borderRadius: '4px',
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.canvasDeep,
+  padding: '2px 7px',
+  fontSize: '11px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'all 150ms',
+  ':hover': {
+    borderColor: vars.color.borderStrong,
+    color: vars.color.text,
+  },
+});
+
+export const spinIcon = style({
+  animation: `${spin} 1s linear infinite`,
 });

--- a/src/components/sync/SyncTaskDetail.tsx
+++ b/src/components/sync/SyncTaskDetail.tsx
@@ -93,9 +93,31 @@ interface SyncTaskDetailProps {
   agentEnabled?: boolean;
 }
 
-function DiagnoseButton({ receipt }: { receipt: PlatformSyncReceipt }) {
+function DiagnoseButton({ receipt, taskId }: { receipt: PlatformSyncReceipt; taskId: string }) {
   const [loading, setLoading] = useState(false);
   const [diagnosis, setDiagnosis] = useState(receipt.diagnosis || '');
+  const [retrying, setRetrying] = useState(false);
+  const [retryMessage, setRetryMessage] = useState('');
+
+  const canRetry = diagnosis.includes('可重试：是');
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    setRetryMessage('');
+    try {
+      const response = await fetch(`/api/sync-tasks/${taskId}/retry`, { method: 'POST' });
+      const data = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setRetryMessage(data.error ?? '重试失败');
+      } else {
+        setRetryMessage('重试已完成');
+      }
+    } catch {
+      setRetryMessage('重试失败');
+    } finally {
+      setRetrying(false);
+    }
+  };
 
   const handleDiagnose = async () => {
     setLoading(true);
@@ -163,6 +185,20 @@ function DiagnoseButton({ receipt }: { receipt: PlatformSyncReceipt }) {
       {diagnosis && (
         <div style={{ fontSize: '12px', color: '#5c4a3f', whiteSpace: 'pre-wrap', marginTop: 4, padding: '8px', background: '#faf6f2', borderRadius: 6 }}>
           {diagnosis}
+          {canRetry && (
+            <div style={{ marginTop: 8 }}>
+              <button
+                type="button"
+                onClick={handleRetry}
+                disabled={retrying}
+                className={styles.receiptLink}
+                style={{ cursor: 'pointer', border: 'none', background: 'none', padding: 0, fontWeight: 500 }}
+              >
+                {retrying ? '重试中…' : '🔄 智能重试'}
+              </button>
+              {retryMessage && <span style={{ marginLeft: 8, fontSize: '11px' }}>{retryMessage}</span>}
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -228,7 +264,7 @@ export default function SyncTaskDetail({ syncTask, agentEnabled: agentEnabledPro
               />
             ) : null}
             {receipt.status === 'failed' && agentEnabled ? (
-              <DiagnoseButton receipt={receipt} />
+              <DiagnoseButton receipt={receipt} taskId={syncTask.id} />
             ) : null}
           </article>
         ))}

--- a/src/components/sync/SyncTaskDetail.tsx
+++ b/src/components/sync/SyncTaskDetail.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Sparkles } from 'lucide-react';
 import type { PlatformId } from '@/types';
 import type {
   SyncEvent,
@@ -7,7 +11,9 @@ import type {
   SyncReceiptStatus,
   SyncTask,
   SyncTaskStatus,
+  PlatformSyncReceipt,
 } from '@/lib/sync/types';
+import type { AgentStreamEvent } from '@/lib/agent/types';
 import SyncTaskMarkDoneButton from '@/components/sync/SyncTaskMarkDoneButton';
 import SyncTaskRetryButton from '@/components/sync/SyncTaskRetryButton';
 import * as styles from './sync.css';
@@ -84,10 +90,98 @@ function formatTime(value: string) {
 
 interface SyncTaskDetailProps {
   syncTask: SyncTask;
+  agentEnabled?: boolean;
 }
 
-export default function SyncTaskDetail({ syncTask }: SyncTaskDetailProps) {
+function DiagnoseButton({ receipt }: { receipt: PlatformSyncReceipt }) {
+  const [loading, setLoading] = useState(false);
+  const [diagnosis, setDiagnosis] = useState(receipt.diagnosis || '');
+
+  const handleDiagnose = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/agent/diagnose', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          platform: receipt.platform,
+          errorMessage: receipt.failureMessage || receipt.message || '未知错误',
+          statusCode: undefined,
+          context: receipt.failureCode ? `failureCode: ${receipt.failureCode}` : undefined,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        setDiagnosis('诊断请求失败');
+        return;
+      }
+
+      const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+      let buffer = '';
+      let accumulated = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += value;
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const event: AgentStreamEvent = JSON.parse(line.slice(6));
+            if (event.type === 'delta') {
+              accumulated += event.content;
+              setDiagnosis(accumulated);
+            }
+          } catch {
+            // skip
+          }
+        }
+      }
+    } catch {
+      setDiagnosis('诊断失败，请稍后重试');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      {!diagnosis && (
+        <button
+          type="button"
+          onClick={handleDiagnose}
+          disabled={loading}
+          className={styles.receiptLink}
+          style={{ cursor: 'pointer', border: 'none', background: 'none', padding: 0 }}
+        >
+          <Sparkles size={12} style={{ marginRight: 4, verticalAlign: '-1px' }} />
+          {loading ? '诊断中…' : 'AI 诊断'}
+        </button>
+      )}
+      {diagnosis && (
+        <div style={{ fontSize: '12px', color: '#5c4a3f', whiteSpace: 'pre-wrap', marginTop: 4, padding: '8px', background: '#faf6f2', borderRadius: 6 }}>
+          {diagnosis}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SyncTaskDetail({ syncTask, agentEnabled: agentEnabledProp }: SyncTaskDetailProps) {
   const hasFailedReceipt = syncTask.receipts.some((receipt) => receipt.status === 'failed');
+  const [agentChecked, setAgentChecked] = useState(agentEnabledProp ?? false);
+
+  useEffect(() => {
+    if (agentEnabledProp !== undefined) return;
+    fetch('/api/agent/status')
+      .then((r) => r.json())
+      .then((d) => setAgentChecked(d.available === true))
+      .catch(() => setAgentChecked(false));
+  }, [agentEnabledProp]);
+
+  const agentEnabled = agentEnabledProp ?? agentChecked;
 
   return (
     <section className={styles.detailPanel}>
@@ -132,6 +226,9 @@ export default function SyncTaskDetail({ syncTask }: SyncTaskDetailProps) {
                 taskId={syncTask.id}
                 platform={receipt.platform}
               />
+            ) : null}
+            {receipt.status === 'failed' && agentEnabled ? (
+              <DiagnoseButton receipt={receipt} />
             ) : null}
           </article>
         ))}

--- a/src/hooks/useAgentStream.ts
+++ b/src/hooks/useAgentStream.ts
@@ -1,0 +1,107 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useAgentStore } from '@/stores/agentStore';
+import type { AgentAction, AgentStreamEvent } from '@/lib/agent/types';
+
+interface StreamRequestOptions {
+  url: string;
+  body: Record<string, unknown>;
+  action: AgentAction;
+}
+
+/**
+ * Hook：发起 Agent SSE 请求并消费流式输出。
+ * 自动管理 agentStore 的状态更新和 AbortController 生命周期。
+ */
+export function useAgentStream() {
+  const { status, output, error, activeAction, startStream, appendOutput, finishStream, setError, abort, reset } =
+    useAgentStore();
+
+  const request = useCallback(
+    async ({ url, body, action }: StreamRequestOptions) => {
+      const controller = startStream(action);
+
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({}));
+          setError(errData.error || `请求失败 (${response.status})`);
+          return;
+        }
+
+        if (!response.body) {
+          setError('响应为空');
+          return;
+        }
+
+        const reader = response.body
+          .pipeThrough(new TextDecoderStream())
+          .getReader();
+
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += value;
+
+          // 解析 SSE 行
+          const lines = buffer.split('\n');
+          // 保留最后一个不完整的行
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+
+            const data = line.slice(6);
+            try {
+              const event: AgentStreamEvent = JSON.parse(data);
+
+              switch (event.type) {
+                case 'delta':
+                  appendOutput(event.content);
+                  break;
+                case 'done':
+                  finishStream();
+                  return;
+                case 'error':
+                  setError(event.error);
+                  return;
+              }
+            } catch {
+              // 跳过无法解析的行
+            }
+          }
+        }
+
+        // 如果 stream 结束但没收到 done event
+        finishStream();
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          // 用户主动取消，不报错
+          return;
+        }
+        setError(err instanceof Error ? err.message : '未知错误');
+      }
+    },
+    [startStream, appendOutput, finishStream, setError]
+  );
+
+  return {
+    status,
+    output,
+    error,
+    activeAction,
+    request,
+    abort,
+    reset,
+  };
+}

--- a/src/hooks/useSlashCommands.ts
+++ b/src/hooks/useSlashCommands.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
+import type { WritingAction } from '@/lib/agent/types';
 
 export interface SlashCommand {
   key: string;
@@ -9,21 +10,48 @@ export interface SlashCommand {
   suffix?: string;
   placeholder?: string;
   icon: string;
+  type: 'format' | 'ai';
+  /** AI commands 对应的 action */
+  aiAction?: WritingAction;
 }
 
-export const SLASH_COMMANDS: SlashCommand[] = [
-  { key: 'heading1', label: '一级标题', prefix: '# ', icon: 'H1' },
-  { key: 'heading2', label: '二级标题', prefix: '## ', icon: 'H2' },
-  { key: 'heading3', label: '三级标题', prefix: '### ', icon: 'H3' },
-  { key: 'bold', label: '粗体', prefix: '**', suffix: '**', placeholder: '粗体文本', icon: 'B' },
-  { key: 'italic', label: '斜体', prefix: '*', suffix: '*', placeholder: '斜体文本', icon: 'I' },
-  { key: 'link', label: '链接', prefix: '[', suffix: '](url)', placeholder: '链接文本', icon: '🔗' },
-  { key: 'image', label: '图片', prefix: '![](', suffix: ')', placeholder: '图片 URL', icon: '🖼' },
-  { key: 'code', label: '行内代码', prefix: '`', suffix: '`', placeholder: '代码', icon: '</>' },
-  { key: 'quote', label: '引用', prefix: '> ', icon: '❝' },
-  { key: 'list', label: '无序列表', prefix: '- ', icon: '•' },
-  { key: 'divider', label: '分割线', prefix: '\n---\n', icon: '—' },
+export const FORMAT_COMMANDS: SlashCommand[] = [
+  { key: 'heading1', label: '一级标题', prefix: '# ', icon: 'H1', type: 'format' },
+  { key: 'heading2', label: '二级标题', prefix: '## ', icon: 'H2', type: 'format' },
+  { key: 'heading3', label: '三级标题', prefix: '### ', icon: 'H3', type: 'format' },
+  { key: 'bold', label: '粗体', prefix: '**', suffix: '**', placeholder: '粗体文本', icon: 'B', type: 'format' },
+  { key: 'italic', label: '斜体', prefix: '*', suffix: '*', placeholder: '斜体文本', icon: 'I', type: 'format' },
+  { key: 'link', label: '链接', prefix: '[', suffix: '](url)', placeholder: '链接文本', icon: '🔗', type: 'format' },
+  { key: 'image', label: '图片', prefix: '![](', suffix: ')', placeholder: '图片 URL', icon: '🖼', type: 'format' },
+  { key: 'code', label: '行内代码', prefix: '`', suffix: '`', placeholder: '代码', icon: '</>', type: 'format' },
+  { key: 'quote', label: '引用', prefix: '> ', icon: '❝', type: 'format' },
+  { key: 'list', label: '无序列表', prefix: '- ', icon: '•', type: 'format' },
+  { key: 'divider', label: '分割线', prefix: '\n---\n', icon: '—', type: 'format' },
 ];
+
+export const AI_COMMANDS: SlashCommand[] = [
+  { key: 'ai-expand', label: 'AI 扩写', prefix: '', icon: '✨', type: 'ai', aiAction: 'expand' },
+  { key: 'ai-condense', label: 'AI 缩写', prefix: '', icon: '📐', type: 'ai', aiAction: 'condense' },
+  { key: 'ai-rewrite', label: 'AI 改写', prefix: '', icon: '🔄', type: 'ai', aiAction: 'rewrite' },
+  { key: 'ai-polish', label: 'AI 润色', prefix: '', icon: '💎', type: 'ai', aiAction: 'polish' },
+  { key: 'ai-continue', label: 'AI 续写', prefix: '', icon: '➡️', type: 'ai', aiAction: 'continue' },
+];
+
+/** 兼容旧代码的导出 */
+export const SLASH_COMMANDS: SlashCommand[] = [...FORMAT_COMMANDS, ...AI_COMMANDS];
+
+interface SlashCommandResult {
+  type: 'format';
+  newContent: string;
+  insertionOffset: number;
+}
+
+interface SlashCommandAIResult {
+  type: 'ai';
+  action: WritingAction;
+}
+
+export type SelectCommandResult = SlashCommandResult | SlashCommandAIResult | null;
 
 interface UseSlashCommandsReturn {
   visible: boolean;
@@ -32,20 +60,26 @@ interface UseSlashCommandsReturn {
   filteredCommands: SlashCommand[];
   onKeyDown: (e: KeyboardEvent) => boolean;
   onTextChange: (text: string, cursorPos: number) => void;
-  selectCommand: (cmd: SlashCommand) => { newContent: string; insertionOffset: number } | null;
+  selectCommand: (cmd: SlashCommand) => SelectCommandResult;
   hide: () => void;
 }
 
 export function useSlashCommands(
   content: string,
   setContent: (val: string) => void,
+  options?: { agentEnabled?: boolean },
 ): UseSlashCommandsReturn {
   const [visible, setVisible] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [filterText, setFilterText] = useState('');
   const slashPosRef = useRef(-1);
 
-  const filteredCommands = SLASH_COMMANDS.filter((cmd) =>
+  const agentEnabled = options?.agentEnabled ?? false;
+
+  // 根据 agentEnabled 过滤可用命令
+  const availableCommands = agentEnabled ? SLASH_COMMANDS : FORMAT_COMMANDS;
+
+  const filteredCommands = availableCommands.filter((cmd) =>
     cmd.label.toLowerCase().includes(filterText.toLowerCase()) ||
     cmd.key.toLowerCase().includes(filterText.toLowerCase()),
   );
@@ -58,9 +92,6 @@ export function useSlashCommands(
   }, []);
 
   const onTextChange = useCallback((text: string, cursorPos: number) => {
-    // 使用 cursorPos 作为近似光标位置
-    // CodeMirror 不暴露精确位置，MDEditor onChange 传的是 text.length
-    // 查找最后一段文本中的 / 命令
     const searchEnd = Math.min(cursorPos, text.length);
     const lineStart = text.lastIndexOf('\n', searchEnd - 1) + 1;
     const lineBeforeCursor = text.slice(lineStart, searchEnd);
@@ -76,9 +107,21 @@ export function useSlashCommands(
     }
   }, [hide]);
 
-  const selectCommand = useCallback((cmd: SlashCommand) => {
+  const selectCommand = useCallback((cmd: SlashCommand): SelectCommandResult => {
     if (slashPosRef.current < 0) return null;
 
+    // AI 命令：清除斜杠行，触发 agent
+    if (cmd.type === 'ai' && cmd.aiAction) {
+      const before = content.slice(0, slashPosRef.current);
+      const slashLineEnd = content.indexOf('\n', slashPosRef.current);
+      const after = slashLineEnd >= 0 ? content.slice(slashLineEnd) : '';
+      const newContent = before + after;
+      setContent(newContent);
+      hide();
+      return { type: 'ai', action: cmd.aiAction };
+    }
+
+    // 格式命令：插入 prefix/suffix
     const before = content.slice(0, slashPosRef.current);
     const slashLineEnd = content.indexOf('\n', slashPosRef.current);
     const after = slashLineEnd >= 0 ? content.slice(slashLineEnd) : '';
@@ -89,7 +132,7 @@ export function useSlashCommands(
 
     setContent(newContent);
     hide();
-    return { newContent, insertionOffset: newContent.length };
+    return { type: 'format', newContent, insertionOffset: newContent.length };
   }, [content, setContent, hide]);
 
   const onKeyDown = useCallback((e: KeyboardEvent) => {

--- a/src/lib/agent/config.ts
+++ b/src/lib/agent/config.ts
@@ -1,24 +1,36 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseEnvFile } from '@/lib/storage/envFile';
 import type { AgentConfig } from './types';
 
 /**
- * 从环境变量读取 Agent 配置。
+ * 从 .env.local 文件实时读取 Agent 配置（绕过 process.env 缓存）。
  * 所有必填字段（baseUrl / apiKey / model）为空时返回 null。
  */
 export function getAgentConfig(): AgentConfig | null {
-  const baseUrl = process.env.AGENT_BASE_URL?.trim();
-  const apiKey = process.env.AGENT_API_KEY?.trim();
-  const model = process.env.AGENT_MODEL?.trim();
+  // 优先从文件实时读取，支持热更新（settings 页面保存后立即生效）
+  let envValues: Record<string, string> = {};
+  try {
+    const content = readFileSync(join(process.cwd(), '.env.local'), 'utf-8');
+    envValues = parseEnvFile(content);
+  } catch {
+    // 文件不存在，fallback 到 process.env
+  }
+
+  const baseUrl = (envValues.AGENT_BASE_URL || process.env.AGENT_BASE_URL || '').trim();
+  const apiKey = (envValues.AGENT_API_KEY || process.env.AGENT_API_KEY || '').trim();
+  const model = (envValues.AGENT_MODEL || process.env.AGENT_MODEL || '').trim();
 
   if (!baseUrl || !apiKey || !model) {
     return null;
   }
 
   return {
-    baseUrl: baseUrl.replace(/\/$/, ''), // 去掉尾部斜杠
+    baseUrl: baseUrl.replace(/\/$/, ''),
     apiKey,
     model,
-    maxTokens: parseInt(process.env.AGENT_MAX_TOKENS || '2048', 10),
-    temperature: parseFloat(process.env.AGENT_TEMPERATURE || '0.7'),
+    maxTokens: parseInt(envValues.AGENT_MAX_TOKENS || process.env.AGENT_MAX_TOKENS || '2048', 10),
+    temperature: parseFloat(envValues.AGENT_TEMPERATURE || process.env.AGENT_TEMPERATURE || '0.7'),
   };
 }
 

--- a/src/lib/agent/config.ts
+++ b/src/lib/agent/config.ts
@@ -1,0 +1,30 @@
+import type { AgentConfig } from './types';
+
+/**
+ * 从环境变量读取 Agent 配置。
+ * 所有必填字段（baseUrl / apiKey / model）为空时返回 null。
+ */
+export function getAgentConfig(): AgentConfig | null {
+  const baseUrl = process.env.AGENT_BASE_URL?.trim();
+  const apiKey = process.env.AGENT_API_KEY?.trim();
+  const model = process.env.AGENT_MODEL?.trim();
+
+  if (!baseUrl || !apiKey || !model) {
+    return null;
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''), // 去掉尾部斜杠
+    apiKey,
+    model,
+    maxTokens: parseInt(process.env.AGENT_MAX_TOKENS || '2048', 10),
+    temperature: parseFloat(process.env.AGENT_TEMPERATURE || '0.7'),
+  };
+}
+
+/**
+ * 检查 Agent 功能是否可用（配置完整）
+ */
+export function isAgentConfigured(): boolean {
+  return getAgentConfig() !== null;
+}

--- a/src/lib/agent/index.ts
+++ b/src/lib/agent/index.ts
@@ -1,0 +1,19 @@
+export { getAgentConfig, isAgentConfigured } from './config';
+export { createOpenAIProvider } from './provider';
+export type {
+  AgentConfig,
+  AgentAction,
+  WritingAction,
+  WritingAgentRequest,
+  AdaptAgentRequest,
+  ResearchAgentRequest,
+  DiagnoseAgentRequest,
+  AgentStreamEvent,
+  AgentStreamDelta,
+  AgentStreamDone,
+  AgentStreamError,
+  AgentStreamStatus,
+  ChatMessage,
+  LLMProvider,
+  LLMStreamParams,
+} from './types';

--- a/src/lib/agent/prompts/adaptation.ts
+++ b/src/lib/agent/prompts/adaptation.ts
@@ -1,0 +1,76 @@
+import type { PlatformId } from '@/types';
+import type { ChatMessage } from '../types';
+
+const SYSTEM_BASE = `你是一个专业的社交媒体内容适配专家。你需要将用户的文章改写为适合目标平台的风格。
+要求：
+- 直接输出适配后的内容，不要添加解释
+- 保留核心信息和观点
+- 输出纯文本或 Markdown（根据平台需要）`;
+
+const PLATFORM_PROMPTS: Record<PlatformId, string> = {
+  wechat: `${SYSTEM_BASE}
+
+目标平台：微信公众号
+风格要求：
+- 长文形式，保留完整的论述结构
+- 可使用小标题（## 二级标题）增强阅读体验
+- 适当使用加粗和引用来突出重点
+- 开头需要一段引人入胜的导语
+- 结尾可以添加互动引导（如"你怎么看？"）
+- 语气专业但不冷淡，适当口语化
+- 输出 Markdown 格式`,
+
+  xiaohongshu: `${SYSTEM_BASE}
+
+目标平台：小红书
+风格要求：
+- 笔记风格，轻松活泼
+- 标题控制在 20 字以内，用 emoji 吸引眼球
+- 正文不超过 1000 字
+- 多用 emoji 表情穿插（每 2-3 句一个）
+- 分段简短，每段 2-3 句话
+- 末尾添加 3-5 个话题标签（#标签名#）
+- 使用口语化、有感染力的表达
+- 输出纯文本`,
+
+  zhihu: `${SYSTEM_BASE}
+
+目标平台：知乎
+风格要求：
+- 回答/文章风格，逻辑清晰、有深度
+- 可以引用数据和来源（用 > 引用格式）
+- 使用编号列表梳理论点
+- 语气客观理性，展示专业度
+- 适当加入个人见解和分析
+- 可以比原文更详细，补充论证
+- 输出 Markdown 格式`,
+
+  x: `${SYSTEM_BASE}
+
+目标平台：X (Twitter)
+风格要求：
+- 单条推文不超过 280 字符（中文约 140 字）
+- 如果内容较长，拆分为 thread（多条推文）
+- 每条以换行分隔，用 "1/" "2/" 等编号标记
+- 语言精炼有力，有观点和态度
+- 可以使用 hashtag（#话题）
+- 第一条推文要足够抓人
+- 输出纯文本，每条推文间用空行分隔`,
+};
+
+/**
+ * 构建 adaptation agent 的 messages 数组
+ */
+export function buildAdaptationMessages(
+  platform: PlatformId,
+  title: string,
+  content: string,
+): ChatMessage[] {
+  return [
+    { role: 'system', content: PLATFORM_PROMPTS[platform] },
+    {
+      role: 'user',
+      content: `请将以下文章适配为目标平台风格：\n\n标题：${title}\n\n正文：\n${content}`,
+    },
+  ];
+}

--- a/src/lib/agent/prompts/diagnose.ts
+++ b/src/lib/agent/prompts/diagnose.ts
@@ -1,0 +1,47 @@
+import type { ChatMessage } from '../types';
+import type { PlatformId } from '@/types';
+
+const DIAGNOSE_SYSTEM_PROMPT = `你是一个平台发布故障诊断专家。用户正在使用内容分发工具向多个社交平台发布内容。
+
+当发布失败时，你需要基于错误信息、平台类型和上下文，给出：
+1. **原因分析**（1-2句话）：最可能的失败原因
+2. **修复建议**（具体步骤）：用户可以采取的修复操作
+3. **是否可重试**：判断这个错误是否值得自动重试
+
+输出格式（纯文本，不要 Markdown 标题）：
+
+原因：[简明原因]
+
+建议：
+- [步骤1]
+- [步骤2]
+
+可重试：[是/否] — [原因]
+
+要求：
+- 针对具体平台给出针对性建议（微信有审核、小红书有内容规范、知乎有反爬、X有 rate limit）
+- 不要给笼统的"请稍后重试"建议
+- 如果错误码明确指向授权过期，直接建议重新连接`;
+
+const PLATFORM_LABELS: Record<PlatformId, string> = {
+  wechat: '微信公众号',
+  xiaohongshu: '小红书',
+  zhihu: '知乎',
+  x: 'X (Twitter)',
+};
+
+export function buildDiagnoseMessages(
+  platform: PlatformId,
+  errorMessage: string,
+  statusCode?: number,
+  context?: string,
+): ChatMessage[] {
+  let userContent = `平台：${PLATFORM_LABELS[platform] || platform}\n错误信息：${errorMessage}`;
+  if (statusCode) userContent += `\nHTTP 状态码：${statusCode}`;
+  if (context) userContent += `\n补充上下文：${context}`;
+
+  return [
+    { role: 'system', content: DIAGNOSE_SYSTEM_PROMPT },
+    { role: 'user', content: userContent },
+  ];
+}

--- a/src/lib/agent/prompts/research.ts
+++ b/src/lib/agent/prompts/research.ts
@@ -1,0 +1,54 @@
+import type { ChatMessage } from '../types';
+
+const RESEARCH_SYSTEM_PROMPT = `你是一个专业的科技新闻分析师，擅长从多个新闻源中提炼深度洞察。
+
+任务：基于提供的话题聚类数据（多篇相关报道的标题和摘要），生成结构化的深度分析。
+
+输出格式（Markdown）：
+
+## 核心事件
+用 2-3 句话概括这个话题的核心事件。
+
+## 多角度解读
+从不同维度分析这个事件：
+- **技术维度**：技术层面的意义和影响
+- **商业维度**：对行业格局和商业模式的影响
+- **用户维度**：对普通用户的实际影响
+
+## 趋势判断
+- 这个事件反映了什么长期趋势？
+- 未来 3-6 个月可能的发展方向？
+
+## 写作建议
+针对内容创作者的建议：
+- 推荐的写作角度（2-3 个）
+- 目标受众定位
+- 适合的发布平台和内容形式
+
+## 关键引用
+从原始报道中提取 2-3 条最有价值的信息点，可直接用于文章引用。
+
+要求：
+- 分析要有深度，不要停留在新闻表面
+- 趋势判断要基于事实推断，不要空泛
+- 写作建议要具体可执行`;
+
+/**
+ * 构建 research agent 的 messages 数组
+ */
+export function buildResearchMessages(
+  clusterTitle: string,
+  signals: Array<{ title: string; summary: string; source: string; publishedAt?: string }>,
+): ChatMessage[] {
+  const signalList = signals
+    .map((s, i) => `${i + 1}. [${s.source}] ${s.title}\n   ${s.summary}${s.publishedAt ? `\n   发布时间: ${s.publishedAt}` : ''}`)
+    .join('\n\n');
+
+  return [
+    { role: 'system', content: RESEARCH_SYSTEM_PROMPT },
+    {
+      role: 'user',
+      content: `话题：${clusterTitle}\n\n相关报道：\n\n${signalList}`,
+    },
+  ];
+}

--- a/src/lib/agent/prompts/writing.ts
+++ b/src/lib/agent/prompts/writing.ts
@@ -1,0 +1,74 @@
+import type { WritingAction, ChatMessage } from '../types';
+
+const SYSTEM_BASE = `你是一个专业的中文内容写作助手。你的输出直接用于 Markdown 文档。
+要求：
+- 输出纯 Markdown 格式，不要包裹在代码块中
+- 保持作者原有的语气和风格
+- 不要添加多余的解释性文字，直接输出结果`;
+
+const ACTION_PROMPTS: Record<WritingAction, string> = {
+  expand: `${SYSTEM_BASE}
+
+任务：扩写用户提供的内容。
+- 保持核心观点不变，补充论据、细节、案例
+- 扩写后篇幅约为原文的 2-3 倍
+- 保持段落结构清晰`,
+
+  condense: `${SYSTEM_BASE}
+
+任务：缩写用户提供的内容。
+- 提炼核心观点，删除冗余表述
+- 缩写后篇幅约为原文的 1/3 到 1/2
+- 确保关键信息不丢失`,
+
+  rewrite: `${SYSTEM_BASE}
+
+任务：改写用户提供的内容。
+- 用不同的表述方式传达相同观点
+- 可以调整段落结构和句式
+- 保持信息量一致`,
+
+  polish: `${SYSTEM_BASE}
+
+任务：润色用户提供的内容。
+- 修正语法和用词问题
+- 提升可读性和表达流畅度
+- 最小化改动，保持原意不变`,
+
+  continue: `${SYSTEM_BASE}
+
+任务：续写用户提供的内容。
+- 根据已有内容的主题和方向继续撰写
+- 保持连贯的叙事或论述逻辑
+- 续写约 200-400 字`,
+};
+
+/**
+ * 构建 writing agent 的 messages 数组
+ */
+export function buildWritingMessages(
+  action: WritingAction,
+  content: string,
+  options?: { title?: string; selection?: string }
+): ChatMessage[] {
+  const messages: ChatMessage[] = [
+    { role: 'system', content: ACTION_PROMPTS[action] },
+  ];
+
+  let userContent = '';
+
+  if (options?.title) {
+    userContent += `标题：${options.title}\n\n`;
+  }
+
+  if (options?.selection) {
+    userContent += `以下是需要处理的选中片段：\n\n${options.selection}\n\n`;
+    userContent += `完整文章上下文：\n\n${content}`;
+  } else {
+    userContent += content;
+  }
+
+  messages.push({ role: 'user', content: userContent });
+
+  return messages;
+}

--- a/src/lib/agent/provider.ts
+++ b/src/lib/agent/provider.ts
@@ -1,0 +1,75 @@
+import { EventSourceParserStream } from 'eventsource-parser/stream';
+import type { AgentConfig, ChatMessage, LLMProvider, LLMStreamParams } from './types';
+
+/**
+ * OpenAI-compatible LLM provider。
+ * 支持任何兼容 /v1/chat/completions 的 API（OpenAI、DeepSeek、Ollama 等）。
+ */
+export function createOpenAIProvider(config: AgentConfig): LLMProvider {
+  return {
+    async *stream(params: LLMStreamParams): AsyncIterable<string> {
+      const url = `${config.baseUrl}/chat/completions`;
+
+      const body = {
+        model: params.model || config.model,
+        messages: params.messages.map((m: ChatMessage) => ({
+          role: m.role,
+          content: m.content,
+        })),
+        max_tokens: params.maxTokens ?? config.maxTokens,
+        temperature: params.temperature ?? config.temperature,
+        stream: true,
+      };
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(
+          `LLM API error ${response.status}: ${errorText || response.statusText}`
+        );
+      }
+
+      if (!response.body) {
+        throw new Error('LLM API returned empty body');
+      }
+
+      // 解析 SSE 流
+      const eventStream = response.body
+        .pipeThrough(new TextDecoderStream())
+        .pipeThrough(new EventSourceParserStream());
+
+      const reader = eventStream.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          // OpenAI SSE 格式：data 字段为 JSON 或 [DONE]
+          const data = value.data;
+          if (data === '[DONE]') break;
+
+          try {
+            const parsed = JSON.parse(data);
+            const content = parsed.choices?.[0]?.delta?.content;
+            if (content) {
+              yield content;
+            }
+          } catch {
+            // 跳过无法解析的 event（如心跳）
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    },
+  };
+}

--- a/src/lib/agent/publishOps.ts
+++ b/src/lib/agent/publishOps.ts
@@ -1,0 +1,97 @@
+import type { PlatformId } from '@/types';
+import type { SyncTask } from '@/lib/sync/types';
+
+export interface PublishHistoryStats {
+  totalPublished: number;
+  byPlatform: Record<string, number>;
+  byHour: Record<number, number>;
+  byDayOfWeek: Record<number, number>;
+  recentFailures: Array<{
+    platform: PlatformId;
+    failureCode?: string;
+    failureMessage?: string;
+    timestamp: string;
+  }>;
+}
+
+/**
+ * Aggregate publish history from sync tasks for timing suggestions and diagnostics.
+ */
+export function aggregatePublishHistory(tasks: SyncTask[]): PublishHistoryStats {
+  const stats: PublishHistoryStats = {
+    totalPublished: 0,
+    byPlatform: {},
+    byHour: {},
+    byDayOfWeek: {},
+    recentFailures: [],
+  };
+
+  for (const task of tasks) {
+    for (const receipt of task.receipts) {
+      if (receipt.status === 'published' && receipt.publishedAt) {
+        stats.totalPublished++;
+        stats.byPlatform[receipt.platform] = (stats.byPlatform[receipt.platform] || 0) + 1;
+
+        const date = new Date(receipt.publishedAt);
+        if (!Number.isNaN(date.getTime())) {
+          const hour = date.getHours();
+          const day = date.getDay();
+          stats.byHour[hour] = (stats.byHour[hour] || 0) + 1;
+          stats.byDayOfWeek[day] = (stats.byDayOfWeek[day] || 0) + 1;
+        }
+      }
+
+      if (receipt.status === 'failed') {
+        stats.recentFailures.push({
+          platform: receipt.platform,
+          failureCode: receipt.failureCode,
+          failureMessage: receipt.failureMessage,
+          timestamp: receipt.updatedAt,
+        });
+      }
+    }
+  }
+
+  // Keep only recent failures (last 20)
+  stats.recentFailures.sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
+  stats.recentFailures = stats.recentFailures.slice(0, 20);
+
+  return stats;
+}
+
+/**
+ * Generate simple timing suggestions based on publish history.
+ * Returns top 3 recommended hours to publish.
+ */
+export function suggestPublishTiming(stats: PublishHistoryStats): string[] {
+  const suggestions: string[] = [];
+
+  if (stats.totalPublished < 3) {
+    suggestions.push('发布记录较少，建议工作日 9:00-10:00 或 20:00-21:00 发布');
+    return suggestions;
+  }
+
+  // Find peak hours
+  const hourEntries = Object.entries(stats.byHour)
+    .map(([hour, count]) => ({ hour: Number(hour), count }))
+    .sort((a, b) => b.count - a.count);
+
+  if (hourEntries.length > 0) {
+    const top = hourEntries.slice(0, 3);
+    const hours = top.map((h) => `${h.hour}:00`).join('、');
+    suggestions.push(`历史高频发布时段：${hours}`);
+  }
+
+  // Day of week pattern
+  const dayNames = ['周日', '周一', '周二', '周三', '周四', '周五', '周六'];
+  const dayEntries = Object.entries(stats.byDayOfWeek)
+    .map(([day, count]) => ({ day: Number(day), count }))
+    .sort((a, b) => b.count - a.count);
+
+  if (dayEntries.length > 0) {
+    const topDays = dayEntries.slice(0, 3).map((d) => dayNames[d.day]).join('、');
+    suggestions.push(`活跃日：${topDays}`);
+  }
+
+  return suggestions;
+}

--- a/src/lib/agent/stream.ts
+++ b/src/lib/agent/stream.ts
@@ -1,0 +1,53 @@
+import type { AgentStreamEvent } from './types';
+
+/**
+ * 将 async iterable of tokens 封装为 SSE Response。
+ * 客户端通过 fetch + ReadableStream 消费。
+ *
+ * SSE 格式: `data: {"type":"delta","content":"..."}\n\n`
+ */
+export function createSSEResponse(
+  tokens: AsyncIterable<string>,
+  signal?: AbortSignal
+): Response {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const token of tokens) {
+          if (signal?.aborted) break;
+
+          const event: AgentStreamEvent = { type: 'delta', content: token };
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
+          );
+        }
+
+        // 发送 done 事件
+        const doneEvent: AgentStreamEvent = { type: 'done' };
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(doneEvent)}\n\n`)
+        );
+      } catch (err) {
+        const errorEvent: AgentStreamEvent = {
+          type: 'error',
+          error: err instanceof Error ? err.message : 'Unknown error',
+        };
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`)
+        );
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -1,0 +1,95 @@
+import type { PlatformId } from '@/types';
+
+// --- LLM Provider ---
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface LLMStreamParams {
+  messages: ChatMessage[];
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface LLMProvider {
+  /** 返回 async iterable，逐 token yield 文本 */
+  stream(params: LLMStreamParams): AsyncIterable<string>;
+}
+
+// --- Agent Config ---
+
+export interface AgentConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  maxTokens: number;
+  temperature: number;
+}
+
+// --- Agent Actions ---
+
+export type WritingAction =
+  | 'expand'    // 扩写
+  | 'condense'  // 缩写
+  | 'rewrite'   // 改写
+  | 'polish'    // 润色
+  | 'continue'; // 续写
+
+export type AgentAction = WritingAction | 'adapt' | 'research' | 'diagnose';
+
+// --- Agent Request/Response ---
+
+export interface WritingAgentRequest {
+  action: WritingAction;
+  content: string;
+  title?: string;
+  selection?: string; // 选中的文本片段（如有）
+}
+
+export interface AdaptAgentRequest {
+  title: string;
+  content: string;
+  platform: PlatformId;
+}
+
+export interface ResearchAgentRequest {
+  clusterTitle: string;
+  signals: Array<{
+    title: string;
+    summary: string;
+    source: string;
+    publishedAt?: string;
+  }>;
+}
+
+export interface DiagnoseAgentRequest {
+  platform: PlatformId;
+  errorMessage: string;
+  statusCode?: number;
+  context?: string;
+}
+
+// --- SSE Events ---
+
+export interface AgentStreamDelta {
+  type: 'delta';
+  content: string;
+}
+
+export interface AgentStreamDone {
+  type: 'done';
+}
+
+export interface AgentStreamError {
+  type: 'error';
+  error: string;
+}
+
+export type AgentStreamEvent = AgentStreamDelta | AgentStreamDone | AgentStreamError;
+
+// --- Agent Store ---
+
+export type AgentStreamStatus = 'idle' | 'streaming' | 'done' | 'error';

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -93,3 +93,14 @@ export type AgentStreamEvent = AgentStreamDelta | AgentStreamDone | AgentStreamE
 // --- Agent Store ---
 
 export type AgentStreamStatus = 'idle' | 'streaming' | 'done' | 'error';
+
+// --- Research Analysis ---
+
+export interface LLMResearchAnalysis {
+  /** 原始 markdown 输出 */
+  raw: string;
+  /** 话题标题 */
+  clusterTitle: string;
+  /** 生成时间 */
+  generatedAt: string;
+}

--- a/src/lib/newsDraft.ts
+++ b/src/lib/newsDraft.ts
@@ -38,6 +38,7 @@ export function buildResearchDraftMarkdown(params: {
   headline: string;
   intro: string;
   sections: ResearchDraftSection[];
+  llmAnalysis?: string;
 }) {
   const lines = [
     params.intro,
@@ -118,6 +119,15 @@ export function buildResearchDraftMarkdown(params: {
     lines.push('---');
     lines.push('');
   });
+
+  if (params.llmAnalysis) {
+    lines.push('## AI 深度分析');
+    lines.push('');
+    lines.push(params.llmAnalysis);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
 
   lines.push('## 写作提示');
   lines.push('');

--- a/src/lib/platformAdapters/types.ts
+++ b/src/lib/platformAdapters/types.ts
@@ -11,6 +11,12 @@ export interface PlatformContentDraft {
   warnings: string[];
   threadParts: string[];
   suggestedTags: string[];
+  /** AI 适配后的内容（优先于 body 使用） */
+  aiBody?: string;
+  /** 是否已经过 AI 适配 */
+  aiAdapted?: boolean;
+  /** AI 适配前的原始 body（用于回退） */
+  originalBody?: string;
 }
 
 export type PlatformContentDrafts = Record<PlatformId, PlatformContentDraft>;

--- a/src/lib/storage/envFile.ts
+++ b/src/lib/storage/envFile.ts
@@ -36,6 +36,13 @@ export function serializeEnvFile(values: Record<string, string>): string {
     `X_API_SECRET=${values.X_API_SECRET || ''}`,
     `X_ACCESS_TOKEN=${values.X_ACCESS_TOKEN || ''}`,
     `X_ACCESS_TOKEN_SECRET=${values.X_ACCESS_TOKEN_SECRET || ''}`,
+    '',
+    '# AI Agent',
+    `AGENT_BASE_URL=${values.AGENT_BASE_URL || ''}`,
+    `AGENT_API_KEY=${values.AGENT_API_KEY || ''}`,
+    `AGENT_MODEL=${values.AGENT_MODEL || ''}`,
+    `AGENT_MAX_TOKENS=${values.AGENT_MAX_TOKENS || ''}`,
+    `AGENT_TEMPERATURE=${values.AGENT_TEMPERATURE || ''}`,
   ];
   return lines.join('\n') + '\n';
 }

--- a/src/lib/sync/store.ts
+++ b/src/lib/sync/store.ts
@@ -117,6 +117,9 @@ export function createSyncHistoryStore(options: SyncHistoryStoreOptions = {}) {
           ...input,
           attempts: receipt.attempts + 1,
           updatedAt: timestamp,
+          ...(input.status === 'published' || input.status === 'draft-created'
+            ? { publishedAt: timestamp }
+            : {}),
         };
       });
 

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -55,9 +55,11 @@ export interface PlatformSyncReceipt {
   url?: string;
   attempts: number;
   updatedAt: string;
+  publishedAt?: string;
   failureCode?: SyncFailureCode;
   failureMessage?: string;
   nextAction?: SyncNextAction;
+  diagnosis?: string;
 }
 
 export interface SyncTask {

--- a/src/stores/agentStore.ts
+++ b/src/stores/agentStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { AgentAction, AgentStreamStatus } from '@/lib/agent/types';
+import type { AgentAction, AgentStreamStatus, LLMResearchAnalysis } from '@/lib/agent/types';
 
 interface AgentStore {
   // 流式输出状态
@@ -11,6 +11,9 @@ interface AgentStore {
   // AbortController 用于取消正在进行的请求
   abortController: AbortController | null;
 
+  // Research 结果缓存（按 clusterTitle 索引）
+  researchCache: Record<string, LLMResearchAnalysis>;
+
   // Actions
   startStream: (action: AgentAction) => AbortController;
   appendOutput: (delta: string) => void;
@@ -18,6 +21,7 @@ interface AgentStore {
   setError: (error: string) => void;
   abort: () => void;
   reset: () => void;
+  cacheResearch: (analysis: LLMResearchAnalysis) => void;
 }
 
 export const useAgentStore = create<AgentStore>((set, get) => ({
@@ -26,6 +30,7 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
   error: null,
   activeAction: null,
   abortController: null,
+  researchCache: {},
 
   startStream: (action) => {
     // 取消之前的请求（如有）
@@ -71,5 +76,14 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
       activeAction: null,
       abortController: null,
     });
+  },
+
+  cacheResearch: (analysis) => {
+    set((state) => ({
+      researchCache: {
+        ...state.researchCache,
+        [analysis.clusterTitle]: analysis,
+      },
+    }));
   },
 }));

--- a/src/stores/agentStore.ts
+++ b/src/stores/agentStore.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand';
+import type { AgentAction, AgentStreamStatus } from '@/lib/agent/types';
+
+interface AgentStore {
+  // 流式输出状态
+  status: AgentStreamStatus;
+  output: string;
+  error: string | null;
+  activeAction: AgentAction | null;
+
+  // AbortController 用于取消正在进行的请求
+  abortController: AbortController | null;
+
+  // Actions
+  startStream: (action: AgentAction) => AbortController;
+  appendOutput: (delta: string) => void;
+  finishStream: () => void;
+  setError: (error: string) => void;
+  abort: () => void;
+  reset: () => void;
+}
+
+export const useAgentStore = create<AgentStore>((set, get) => ({
+  status: 'idle',
+  output: '',
+  error: null,
+  activeAction: null,
+  abortController: null,
+
+  startStream: (action) => {
+    // 取消之前的请求（如有）
+    get().abortController?.abort();
+
+    const controller = new AbortController();
+    set({
+      status: 'streaming',
+      output: '',
+      error: null,
+      activeAction: action,
+      abortController: controller,
+    });
+    return controller;
+  },
+
+  appendOutput: (delta) => {
+    set((state) => ({ output: state.output + delta }));
+  },
+
+  finishStream: () => {
+    set({ status: 'done', abortController: null });
+  },
+
+  setError: (error) => {
+    set({ status: 'error', error, abortController: null });
+  },
+
+  abort: () => {
+    const { abortController } = get();
+    if (abortController) {
+      abortController.abort();
+      set({ status: 'idle', abortController: null });
+    }
+  },
+
+  reset: () => {
+    get().abortController?.abort();
+    set({
+      status: 'idle',
+      output: '',
+      error: null,
+      activeAction: null,
+      abortController: null,
+    });
+  },
+}));

--- a/src/stores/publishStore.ts
+++ b/src/stores/publishStore.ts
@@ -24,6 +24,8 @@ interface PublishStore {
 
   platformDrafts: PlatformContentDrafts;
   syncPlatformDrafts: () => void;
+  setAIAdaptedContent: (platform: PlatformId, aiBody: string) => void;
+  revertAIDraft: (platform: PlatformId) => void;
 
   overallStatus: PublishStatus;
   results: PlatformPublishResult[];
@@ -84,6 +86,38 @@ export const usePublishStore = create<PublishStore>((set) => ({
         platforms: platformIds,
       }),
     })),
+
+  setAIAdaptedContent: (platform, aiBody) =>
+    set((state) => {
+      const draft = state.platformDrafts[platform];
+      return {
+        platformDrafts: {
+          ...state.platformDrafts,
+          [platform]: {
+            ...draft,
+            aiBody,
+            aiAdapted: true,
+            originalBody: draft.originalBody || draft.body,
+          },
+        },
+      };
+    }),
+
+  revertAIDraft: (platform) =>
+    set((state) => {
+      const draft = state.platformDrafts[platform];
+      return {
+        platformDrafts: {
+          ...state.platformDrafts,
+          [platform]: {
+            ...draft,
+            aiBody: undefined,
+            aiAdapted: false,
+            originalBody: undefined,
+          },
+        },
+      };
+    }),
 
   overallStatus: 'idle',
   results: [],


### PR DESCRIPTION
## Summary

- Phase 1: Writing Agent — slash commands (/ai-expand, /ai-condense, /ai-rewrite, /ai-polish, /ai-continue) with streaming panel
- Phase 2: Content Adaptation Agent — per-platform AI rewriting before publish (wechat/xiaohongshu/zhihu/x)
- Phase 3: Topic Research Agent — deep analysis on AI news topic cards with result caching
- Phase 4: Publishing Ops Agent — timing suggestions, failure diagnosis, smart retry

## Key design decisions

- OpenAI-compatible provider (covers GLM/DeepSeek/Qwen/OpenAI/Ollama)
- Graceful degradation: all AI features hidden when AGENT_* env vars not configured
- SSE streaming for all agent responses
- Independent agentStore (Zustand), decoupled from publishStore
- Only dependency added: eventsource-parser (~3KB)
- Config reads .env.local at runtime (no server restart needed after settings save)

## Test plan

- [ ] No AGENT_* vars → all AI buttons hidden, existing features work
- [ ] Configure via Settings → save → AI commands appear in editor
- [ ] /ai-polish with content → streaming panel → insert/replace/copy
- [ ] AI News → deep research → streaming analysis displayed
- [ ] Platform preview → AI adapt → content replaced, revertable
- [ ] Publish failure → AI diagnose → retry if suggested
- [ ] pnpm build passes
- [ ] pnpm lint passes