### PR TITLE
fix: ESLint 9 lint-staged compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "prettier --write",
-      "eslint --fix"
+      "env ESLINT_USE_FLAT_CONFIG=false eslint --fix"
     ],
     "*.{css.ts,json}": [
       "prettier --write"


### PR DESCRIPTION
## Summary

ESLint 9 defaults to flat config format (`eslint.config.js`), but `eslint-config-next` v15 still uses legacy `.eslintrc.json`. The `lint-staged` `eslint --fix` command fails because ESLint 9 can't find the expected config file.

Set `ESLINT_USE_FLAT_CONFIG=false` in the lint-staged command to force ESLint 9 to use the legacy config.

## Test plan

- [x] `git commit` triggers lint-staged without ESLint config error
- [x] `pnpm lint` still passes