### PR TITLE
docs: add Chinese README with language switch links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,162 +3,244 @@
 [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](./package.json)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)
+[![Next.js](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
+[![Tests](https://img.shields.io/badge/tests-115%20passing-brightgreen.svg)](#testing)
 
-> Write once, publish everywhere.
+> AI-native content operations platform. Write once, publish everywhere.
 
-多平台内容分发工具——在一个界面里完成 Markdown 写作、AI 选题、一键分发到微信公众号、小红书、知乎、X (Twitter)。
+Publio is a multi-platform content distribution tool that consolidates Markdown editing, AI-powered topic discovery, content adaptation, and one-click publishing into a unified workspace. It supports WeChat Official Account, Xiaohongshu, Zhihu, and X (Twitter).
 
 ---
 
-## 功能概览
+## Features
 
-**写作台**
-- Markdown 编辑器（桌面富编辑 / 移动端降级 textarea），实时字符数、段落、标题层级、预计阅读时长
-- 成稿预览（接近公众号排版效果）
-- 自动保存（停止输入 1s 触发，首次保存自动创建草稿并更新 URL）
-- Editorial context 卡片：标题状态、结构统计、可发布建议
+### Writing Desk
 
-**AI 写作助手**（可选，需配置 LLM）
-- 编辑器 Slash 命令：`/ai-expand`（扩写）、`/ai-condense`（缩写）、`/ai-rewrite`（改写）、`/ai-polish`（润色）、`/ai-continue`（续写）
-- 右侧流式输出面板，支持插入、替换、复制
-- 支持任意 OpenAI 兼容 API（智谱GLM、DeepSeek、通义千问、OpenAI、Ollama 等）
+- **Rich Markdown editor** with desktop live-preview and mobile fallback
+- **WYSIWYG mode** — toggle between source editing and side-by-side live preview
+- **Immersive writing mode** — full-screen distraction-free editing with centered 720px layout
+- **Auto-save** with 1-second debounce and automatic draft creation
+- **Editorial context panel** — title status, structural statistics, publishability signals
+- **Slash commands** — `/ai-expand`, `/ai-condense`, `/ai-rewrite`, `/ai-polish`, `/ai-continue`
+- **Version history** — auto-snapshot on title/content changes with restore capability
+- **Content templates** — 6 built-in templates for rapid drafting
 
-**AI 选题工作台**
-- 从 9 个 RSS 数据源抓取 24h AI 行业动态 → 话题聚类 → 五维评分 → 最多 10 条候选题
-- 每条附带研究底稿（事件经过、重要性、影响方、写作切口、多方视角、配图）
-- AI 深度分析（可选，需配置 LLM）：多角度解读、趋势判断、写作建议
-- 一键转稿到写作台（含 LLM 分析融入）
+### AI Agent System
 
-**稿件库**
-- 持久化草稿管理（手动创建 / AI 选题转稿），支持状态跟踪（draft → ready → synced）
-- Pipeline 视图按「来源 → 写作台 → 分发」展示全部稿件，支持批量删除
+All AI features require an OpenAI-compatible API (Zhipu GLM, DeepSeek, Qwen, OpenAI, Ollama, etc.). Gracefully degrades when unconfigured.
 
-**多平台发布**
-- 并发发布（Promise.allSettled），支持微信公众号、小红书、知乎、X (Twitter)
-- AI 平台适配（可选）：一键生成各平台风格内容（小红书 emoji/tag、X 精炼、微信长文润色）
-- 发布进度浮层（右下角轮询更新各平台状态）
-- 同步任务追踪：各平台回执、失败原因、AI 诊断、重试 / 手动标记完成
-- 发布时机建议（基于历史发布数据）
-- 各平台内容格式适配（字数校验、样式转换）
+| Capability | Description |
+|-----------|-------------|
+| **Writing Assistant** | Expand, condense, rewrite, polish, continue — via slash commands with streaming output |
+| **Platform Adaptation** | Per-platform content rewrite with rule injection (word count, format constraints) |
+| **Topic Research** | Deep analysis of news clusters with multi-angle insights |
+| **Publish Diagnose** | Failure analysis with actionable retry suggestions |
+| **Content Copilot** | Brand profile-driven topic recommendations based on current news trends |
+| **Style Learning** | Extracts writing style from historical drafts and injects into prompts |
+| **Multi-turn Chat** | Conversational AI panel with session-persistent history |
 
-**平台连接管理**
-- 设置页统一管理 API 凭证，OAuth 平台支持一键授权
-- 微信 / X 支持凭证验证，连接状态持久化并展示已连接账号名
+### AI News Desk
 
-**响应式导航**
-- 桌面端侧边栏，移动端底部 Tab 栏
+- Aggregates RSS feeds from 9+ built-in sources plus custom user-defined sources
+- Topic clustering, 6-dimension scoring (freshness, impact, momentum, credibility, visual-readiness, coverage)
+- Research brief per cluster with what happened, why it matters, who is affected, recommended angles
+- One-click conversion to editor draft with research context embedded
 
-## 快速开始
+### Multi-Platform Publishing
 
-### 环境要求
+- Concurrent publish via `Promise.allSettled` across all selected platforms
+- **Content moderation** — sensitive word detection with pre-publish warning dialog
+- **Platform validation** — automatic rule checking (title length, content limits, format constraints)
+- **Publish progress overlay** — real-time status polling with per-platform receipts
+- **Sync task tracking** — failure diagnosis, smart retry, manual mark-done
+- **Scheduled publish** — backend cron-based execution with persistent task queue
+- **Post-publish metrics** — views, likes, comments, shares aggregated in analytics dashboard
+
+### Content Calendar
+
+- Monthly view with event display for drafts, scheduled, published, and failed items
+- Click-through navigation to editor or sync task detail
+
+### Settings & Configuration
+
+- Platform credential management with OAuth flow and connection verification
+- AI Agent configuration (base URL, API key, model) with hot-reload
+- Custom RSS feed source management
+- Custom AI prompt editor (per-platform and global)
+- Brand profile configuration for content copilot
+- Writing style profile with auto-analysis from historical drafts
+
+### Design System
+
+- **Theme toggle** — light / dark / system preference with localStorage persistence
+- **Design tokens** — spacing, typography, color, radius with WCAG AA compliant contrast
+- **Responsive layout** — desktop sidebar navigation, adaptive content areas
+
+---
+
+## Quick Start
+
+### Prerequisites
 
 - Node.js >= 18
 - pnpm
 
-### 安装与启动
+### Installation
 
 ```bash
 git clone https://github.com/rogerdigital/publio.git
 cd publio
 pnpm install
-cp .env.example .env.local   # 填入平台凭据（也可启动后在设置页配置）
-pnpm dev                      # 自动清理残留进程和缓存
+cp .env.example .env.local   # configure platform credentials (or set up later in Settings)
+pnpm dev                      # starts with port cleanup and cache clearing
 ```
 
-`pnpm dev` 会先清理残留的 Next.js 开发进程并清空 `.next/cache`。跳过清理用 `pnpm run dev:raw`。
+`pnpm dev` automatically kills残留 Next.js processes and clears `.next/cache`. Use `pnpm run dev:raw` to skip cleanup.
 
-访问 http://localhost:3000 即可使用。
+Open http://localhost:3000.
 
-### 常用命令
+### Commands
 
 ```bash
-pnpm dev          # 开发模式（含端口清理）
-pnpm build        # 生产构建
-pnpm start        # 启动生产服务
-pnpm preview      # 构建 + 启动
-pnpm test         # 运行测试（Vitest）
-pnpm lint         # ESLint 检查
-pnpm verify       # 完整验证（lint + test + build）
+pnpm dev              # development mode (with port cleanup)
+pnpm build            # production build
+pnpm start            # production server
+pnpm preview           # build + start
+pnpm test             # run tests (Vitest)
+pnpm lint             # ESLint
+pnpm format           # Prettier format all files
+pnpm verify           # lint + test + build
 ```
 
-## 架构
+---
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                      Next.js 15 App Router              │
-│                                                         │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌─────────┐ │
-│  │  写作台   │  │ 稿件库   │  │ AI 选题  │  │  设置   │ │
-│  │  /        │  │ /drafts  │  │ /ai-news │  │/settings│ │
-│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └────┬────┘ │
-│       │              │              │              │      │
-│  ┌────▼──────────────▼──────────────▼──────────────▼───┐ │
-│  │                   Zustand Store                     │ │
-│  │     (content / platforms / draftId / publishState)  │ │
-│  └─────────────────────┬──────────────────────────────┘ │
-│                        │                                 │
-│  ┌─────────────────────▼──────────────────────────────┐ │
-│  │                 API Routes                          │ │
-│  │  drafts · publish · ai-news · sync-tasks · settings │ │
-│  └───┬──────────┬──────────┬──────────┬───────────────┘ │
-│      │          │          │          │                  │
-│  ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐              │
-│  │ WeChat│ │  XHS  │ │ Zhihu │ │   X   │  各平台发布器  │
-│  └───────┘ └───────┘ └───────┘ └───────┘              │
-└─────────────────────────────────────────────────────────┘
+## Configuration
 
-数据存储：JSON 文件（.publio-data/），原子写（.tmp + rename）
-```
+### Platform Credentials
 
-完整目录结构和文件说明见 [CLAUDE.md](./CLAUDE.md)。
+Managed via `.env.local` or the Settings page at runtime:
 
-## 开发
-
-### 技术栈
-
-Next.js 15 (App Router) · React 19 · TypeScript 5 (strict) · vanilla-extract · Zustand 5 · marked 15 · eventsource-parser · Vitest + Testing Library
-
-### 代码规范
-
-- 路径别名 `@/*` → `./src/*`，类型定义集中在 `src/types/index.ts`
-- 客户端组件标注 `'use client'`，重组件用 `dynamic()` 按需加载
-- 每个组件对应同目录 `.css.ts` 文件，设计 token 集中在 `src/styles/tokens.css.ts`
-- 第一方源码统一 TypeScript，不新增 JS 源文件（生成产物和第三方代码除外）
-
-### 平台凭据
-
-各平台 API 密钥通过 `.env.local` 配置，启动后在设置页也可管理：
-
-| 平台 | 变量 | 获取方式 |
-|------|------|----------|
-| 微信公众号 | `WECHAT_APP_ID`, `WECHAT_APP_SECRET` | [mp.weixin.qq.com](https://mp.weixin.qq.com/) → 开发 → 基本配置 |
-| 小红书 | `XHS_APP_ID`, `XHS_APP_SECRET`, `XHS_ACCESS_TOKEN` | [小红书开放平台](https://open.xiaohongshu.com/) |
-| 知乎 | `ZHIHU_COOKIE` | 浏览器登录后从 DevTools Network 面板复制 Cookie |
+| Platform | Variables | Source |
+|----------|-----------|--------|
+| WeChat | `WECHAT_APP_ID`, `WECHAT_APP_SECRET` | [mp.weixin.qq.com](https://mp.weixin.qq.com/) > Development > Basic Config |
+| Xiaohongshu | `XHS_APP_ID`, `XHS_APP_SECRET`, `XHS_ACCESS_TOKEN` | [Xiaohongshu Open Platform](https://open.xiaohongshu.com/) |
+| Zhihu | `ZHIHU_COOKIE` | Browser DevTools > Network > copy Cookie |
 | X (Twitter) | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` | [developer.x.com](https://developer.x.com/) |
 
-#### AI Agent（可选）
+### AI Agent (Optional)
 
-| 变量 | 说明 |
-|------|------|
-| `AGENT_BASE_URL` | OpenAI 兼容 API 地址（如 `https://open.bigmodel.cn/api/paas/v4`） |
-| `AGENT_API_KEY` | 对应平台的 API Key |
-| `AGENT_MODEL` | 模型名（如 `glm-4-flash`、`deepseek-chat`） |
-| `AGENT_MAX_TOKENS` | 可选，默认 2048 |
-| `AGENT_TEMPERATURE` | 可选，默认 0.7 |
+All three required to activate AI features:
 
-三项必填配置完成后，编辑器 AI 命令、选题深度分析、平台适配、发布诊断功能自动激活。
+| Variable | Description |
+|----------|-------------|
+| `AGENT_BASE_URL` | OpenAI-compatible endpoint (e.g. `https://api.openai.com/v1`) |
+| `AGENT_API_KEY` | API key for the chosen provider |
+| `AGENT_MODEL` | Model name (e.g. `gpt-4o-mini`, `deepseek-chat`, `glm-4-flash`) |
+| `AGENT_MAX_TOKENS` | Optional, default 2048 |
+| `AGENT_TEMPERATURE` | Optional, default 0.7 |
 
-## Roadmap
+---
 
-- [ ] 更多平台支持（掘金、CSDN、B 站专栏）
-- [ ] 图片上传与管理（图床集成）
-- [ ] 排版模板系统
-- [x] 定时发布
-- [x] AI 写作辅助（扩写/缩写/改写/润色/续写）
-- [x] AI 平台内容适配
-- [x] AI 选题深度分析
-- [x] AI 发布诊断与智能重试
-- [ ] 数据看板（各平台阅读量、互动数据聚合）
+## Architecture
+
+```
+src/
+├── app/                        # Next.js App Router
+│   ├── page.tsx                  # Server Component (metadata + shell)
+│   ├── page-client.tsx           # Client Component (editor + panels)
+│   ├── ai-news/                  # AI topic discovery desk
+│   ├── analytics/                # Post-publish metrics dashboard
+│   ├── calendar/                 # Content scheduling calendar
+│   ├── drafts/                   # Draft library
+│   ├── settings/                 # Platform & AI configuration
+│   ├── sync-tasks/               # Distribution task tracking
+│   └── api/                      # Route Handlers
+│       ├── agent/                  # AI endpoints (write, adapt, research, diagnose, chat)
+│       ├── copilot/                # Content copilot (profile, recommend, style)
+│       ├── drafts/                 # Draft CRUD
+│       ├── metrics/                # Metrics collection
+│       ├── platforms/              # Platform connection management
+│       ├── publish/                # Publish endpoint
+│       ├── rss-sources/            # Custom RSS CRUD
+│       ├── sync-tasks/             # Sync task management
+│       └── custom-prompts/         # Custom prompt CRUD
+├── components/
+│   ├── layout/                   # AppShellHeader, Sidebar, SurfaceCard, ThemeToggle
+│   ├── editor/                   # MarkdownEditor, SlashCommandMenu, ImmersiveMode, WYSIWYG toggle
+│   ├── news/                     # AiNewsPageClient, TopicSignalCard, ScoreBar
+│   ├── publish/                  # PlatformSelector, PublishButton, ModerationWarning, PreviewPanel
+│   ├── sync/                     # SyncTaskList, SyncTaskDetail
+│   ├── agent/                    # AgentPanel, AgentStreamOutput
+│   ├── copilot/                  # BrandProfileForm, TopicRecommendationPanel, StyleProfile
+│   ├── analytics/                # MetricsCard
+│   ├── calendar/                 # CalendarPageClient
+│   └── drafts/                   # DraftLibraryClient
+├── hooks/                        # useAutoSave, useSlashCommands, useAgentStream, useImmersiveMode
+├── lib/
+│   ├── agent/                    # LLM provider, streaming, prompt templates
+│   ├── ai-news/                  # RSS aggregation, clustering, scoring
+│   ├── copilot/                  # Brand profile, style learning, topic recommendation
+│   ├── custom-prompts/           # Custom prompt storage
+│   ├── drafts/                   # Draft CRUD with version history
+│   ├── metrics/                  # Post-publish metrics storage
+│   ├── moderation/               # Sensitive word detection
+│   ├── platformAdapters/         # Content format adaptation per platform
+│   ├── platformConnections/      # Connection management & OAuth
+│   ├── platformRules/            # Platform content validation rules
+│   ├── publishers/               # Platform-specific publish logic
+│   ├── rss-sources/              # Custom RSS source storage
+│   ├── scheduler/                # Scheduled publish execution
+│   ├── storage/                  # JSON file collection, env file utilities
+│   └── sync/                     # Distribution task state machine
+├── stores/                       # Zustand stores (publishStore, agentStore, toastStore)
+├── styles/                       # Design tokens (spacing, typography, color, radius)
+└── types/                        # TypeScript type definitions
+```
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js 15 (App Router, React 19) |
+| Language | TypeScript 5 (strict mode) |
+| Styling | vanilla-extract (`@vanilla-extract/css` + `@vanilla-extract/recipes`) |
+| State | Zustand 5 |
+| Editor | @uiw/react-md-editor |
+| Markdown | marked 15 |
+| LLM Streaming | OpenAI-compatible SSE via fetch + ReadableStream |
+| Social API | twitter-api-v2 |
+| Linting | ESLint 9 + eslint-config-next |
+| Formatting | Prettier |
+| Testing | Vitest + Testing Library |
+| Git Hooks | Husky + lint-staged |
+| Package Manager | pnpm |
+
+---
+
+## Testing
+
+```bash
+pnpm test           # run all tests
+pnpm test -- --watch  # watch mode
+```
+
+115 tests across 37 test files covering stores, API routes, components, and utility functions.
+
+---
+
+## Design Tokens
+
+Centralized in `src/styles/tokens.css.ts`:
+
+- **Spacing**: xs(4px) through 4xl(40px)
+- **Typography**: xs(12px) through 4xl(28px), line heights tight/base/relaxed
+- **Color**: warm palette with orange/brown accent (#D97757), WCAG AA compliant contrast
+- **Radius**: sm(4px), md(6px), lg(8px), xl(12px)
+- **Theme**: light, dark, and system-preference modes
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Publio
 
+[English](./README.md) | [中文](./README_zh.md)
+
 [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](./package.json)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,249 @@
+# Publio
+
+[English](./README.md) | [中文](./README_zh.md)
+
+[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](./package.json)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)
+[![Next.js](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
+[![Tests](https://img.shields.io/badge/tests-115%20passing-brightgreen.svg)](#测试)
+
+> AI 原生内容运营平台。一次创作，全平台分发。
+
+Publio 是多平台内容分发工具，整合 Markdown 编辑、AI 选题发现、内容适配和一键发布于统一工作台。支持微信公众号、小红书、知乎和 X (Twitter)。
+
+---
+
+## 功能特性
+
+### 写作台
+
+- **Markdown 编辑器** — 桌面端实时预览，移动端降级方案
+- **所见即所得模式** — 源码编辑与实时预览一键切换
+- **沉浸式写作** — 全屏无干扰编辑，居中 720px 布局
+- **自动保存** — 1 秒防抖，首次保存自动创建草稿
+- **编辑上下文面板** — 标题状态、结构统计、可发布性指标
+- **斜杠命令** — `/ai-expand`、`/ai-condense`、`/ai-rewrite`、`/ai-polish`、`/ai-continue`
+- **版本历史** — 标题/内容变更自动快照，支持回滚
+- **内容模板** — 6 个内置模板快速起草
+
+### AI Agent 系统
+
+所有 AI 功能需 OpenAI 兼容 API（智谱 GLM、DeepSeek、Qwen、OpenAI、Ollama 等）。未配置时优雅降级。
+
+| 能力 | 说明 |
+|------|------|
+| **写作助手** | 扩写、缩写、改写、润色、续写 — 斜杠命令触发，流式输出 |
+| **平台适配** | 按平台规则重写内容（字数、格式约束） |
+| **选题研究** | 新闻聚合深度分析，多角度洞察 |
+| **发布诊断** | 失败原因分析，可操作重试建议 |
+| **内容 Copilot** | 基于品牌画像 + 当前热点的选题推荐 |
+| **风格学习** | 从历史草稿提取写作风格，注入 prompt |
+| **多轮对话** | 会话持久化的 AI 对话面板 |
+
+### AI 选题台
+
+- 聚合 9+ 内置 RSS 源 + 用户自定义源
+- 话题聚类，六维评分（新鲜度、影响力、势能、可信度、视觉就绪度、覆盖度）
+- 每个聚合话题生成研究底稿：发生了什么、为什么重要、影响谁、推荐角度
+- 一键转换为编辑器草稿，研究上下文自动嵌入
+
+### 多平台发布
+
+- `Promise.allSettled` 并发发布至所有已选平台
+- **内容审核** — 敏感词检测，发布前弹窗警告
+- **平台校验** — 自动规则检查（标题长度、内容限制、格式约束）
+- **发布进度浮层** — 实时状态轮询，逐平台接收回执
+- **分发任务追踪** — 失败诊断、智能重试、手动标记完成
+- **定时发布** — 后端 cron 执行，持久化任务队列
+- **发布后指标** — 阅读量、点赞、评论、分享聚合到分析看板
+
+### 内容排期日历
+
+- 月视图展示草稿、定时发布、已发布、失败事件
+- 点击跳转编辑器或分发任务详情
+
+### 设置与配置
+
+- 平台凭证管理，支持 OAuth 流程和连接验证
+- AI Agent 配置（base URL、API key、模型），热更新无需重启
+- 自定义 RSS 源管理
+- 自定义 AI prompt 编辑器（按平台和全局）
+- 品牌画像配置（用于内容 Copilot）
+- 写作风格画像，支持从历史草稿自动分析
+
+### 设计系统
+
+- **主题切换** — 亮色 / 暗色 / 跟随系统，localStorage 持久化
+- **设计 token** — 间距、字号、色彩、圆角，WCAG AA 合规对比度
+- **响应式布局** — 桌面端侧边栏导航，自适应内容区
+
+---
+
+## 快速开始
+
+### 环境要求
+
+- Node.js >= 18
+- pnpm
+
+### 安装
+
+```bash
+git clone https://github.com/rogerdigital/publio.git
+cd publio
+pnpm install
+cp .env.example .env.local   # 配置平台凭证（也可稍后在设置页配置）
+pnpm dev                      # 启动开发（含端口清理和缓存清除）
+```
+
+`pnpm dev` 自动清理残留 Next.js 进程并清除 `.next/cache`。使用 `pnpm run dev:raw` 跳过清理。
+
+打开 http://localhost:3000。
+
+### 命令
+
+```bash
+pnpm dev              # 开发模式（含端口清理）
+pnpm build            # 生产构建
+pnpm start            # 生产服务
+pnpm preview           # 构建 + 启动
+pnpm test             # 运行测试（Vitest）
+pnpm lint             # ESLint
+pnpm format           # Prettier 格式化
+pnpm verify           # lint + test + build
+```
+
+---
+
+## 配置
+
+### 平台凭证
+
+通过 `.env.local` 或设置页运行时管理：
+
+| 平台 | 变量 | 获取方式 |
+|------|------|---------|
+| 微信公众号 | `WECHAT_APP_ID`, `WECHAT_APP_SECRET` | [mp.weixin.qq.com](https://mp.weixin.qq.com/) > 开发 > 基本配置 |
+| 小红书 | `XHS_APP_ID`, `XHS_APP_SECRET`, `XHS_ACCESS_TOKEN` | [小红书开放平台](https://open.xiaohongshu.com/) |
+| 知乎 | `ZHIHU_COOKIE` | 浏览器 DevTools > Network > 复制 Cookie |
+| X (Twitter) | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` | [developer.x.com](https://developer.x.com/) |
+
+### AI Agent（可选）
+
+三项必填才能启用 AI 功能：
+
+| 变量 | 说明 |
+|------|------|
+| `AGENT_BASE_URL` | OpenAI 兼容端点（如 `https://api.openai.com/v1`） |
+| `AGENT_API_KEY` | 对应服务商的 API key |
+| `AGENT_MODEL` | 模型名（如 `gpt-4o-mini`、`deepseek-chat`、`glm-4-flash`） |
+| `AGENT_MAX_TOKENS` | 可选，默认 2048 |
+| `AGENT_TEMPERATURE` | 可选，默认 0.7 |
+
+---
+
+## 架构
+
+```
+src/
+├── app/                        # Next.js App Router
+│   ├── page.tsx                  # Server Component（metadata + shell）
+│   ├── page-client.tsx           # Client Component（编辑器 + 面板）
+│   ├── ai-news/                  # AI 选题工作台
+│   ├── analytics/                # 发布后指标看板
+│   ├── calendar/                 # 内容排期日历
+│   ├── drafts/                   # 稿件库
+│   ├── settings/                 # 平台与 AI 配置
+│   ├── sync-tasks/               # 分发任务追踪
+│   └── api/                      # Route Handlers
+│       ├── agent/                  # AI 端点（写作、适配、研究、诊断、对话）
+│       ├── copilot/                # 内容 Copilot（画像、推荐、风格）
+│       ├── drafts/                 # 草稿 CRUD
+│       ├── metrics/                # 指标采集
+│       ├── platforms/              # 平台连接管理
+│       ├── publish/                # 发布端点
+│       ├── rss-sources/            # 自定义 RSS CRUD
+│       ├── sync-tasks/             # 分发任务管理
+│       └── custom-prompts/         # 自定义 prompt CRUD
+├── components/
+│   ├── layout/                   # AppShellHeader, Sidebar, SurfaceCard, ThemeToggle
+│   ├── editor/                   # MarkdownEditor, SlashCommandMenu, ImmersiveMode, WYSIWYG 切换
+│   ├── news/                     # AiNewsPageClient, TopicSignalCard, ScoreBar
+│   ├── publish/                  # PlatformSelector, PublishButton, ModerationWarning, PreviewPanel
+│   ├── sync/                     # SyncTaskList, SyncTaskDetail
+│   ├── agent/                    # AgentPanel, AgentStreamOutput
+│   ├── copilot/                  # BrandProfileForm, TopicRecommendationPanel, StyleProfile
+│   ├── analytics/                # MetricsCard
+│   ├── calendar/                 # CalendarPageClient
+│   └── drafts/                   # DraftLibraryClient
+├── hooks/                        # useAutoSave, useSlashCommands, useAgentStream, useImmersiveMode
+├── lib/
+│   ├── agent/                    # LLM provider、流式传输、prompt 模板
+│   ├── ai-news/                  # RSS 聚合、聚类、评分
+│   ├── copilot/                  # 品牌画像、风格学习、选题推荐
+│   ├── custom-prompts/           # 自定义 prompt 存储
+│   ├── drafts/                   # 草稿 CRUD（含版本历史）
+│   ├── metrics/                  # 发布后指标存储
+│   ├── moderation/               # 敏感词检测
+│   ├── platformAdapters/         # 按平台适配内容格式
+│   ├── platformConnections/      # 连接管理与 OAuth
+│   ├── platformRules/            # 平台内容校验规则
+│   ├── publishers/               # 平台发布逻辑
+│   ├── rss-sources/              # 自定义 RSS 源存储
+│   ├── scheduler/                # 定时发布执行
+│   ├── storage/                  # JSON 文件集合、env 文件工具
+│   └── sync/                     # 分发任务状态机
+├── stores/                       # Zustand stores（publishStore, agentStore, toastStore）
+├── styles/                       # 设计 token（间距、字号、色彩、圆角）
+└── types/                        # TypeScript 类型定义
+```
+
+---
+
+## 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| 框架 | Next.js 15（App Router, React 19） |
+| 语言 | TypeScript 5（严格模式） |
+| 样式 | vanilla-extract（`@vanilla-extract/css` + `@vanilla-extract/recipes`） |
+| 状态 | Zustand 5 |
+| 编辑器 | @uiw/react-md-editor |
+| Markdown | marked 15 |
+| LLM 流式传输 | OpenAI 兼容 SSE（fetch + ReadableStream） |
+| 社交 API | twitter-api-v2 |
+| 代码检查 | ESLint 9 + eslint-config-next |
+| 格式化 | Prettier |
+| 测试 | Vitest + Testing Library |
+| Git Hooks | Husky + lint-staged |
+| 包管理 | pnpm |
+
+---
+
+## 测试
+
+```bash
+pnpm test           # 运行所有测试
+pnpm test -- --watch  # 监听模式
+```
+
+37 个测试文件，115 个测试用例，覆盖 stores、API 路由、组件和工具函数。
+
+---
+
+## 设计 Token
+
+集中在 `src/styles/tokens.css.ts`：
+
+- **间距**: xs(4px) 到 4xl(40px)
+- **字号**: xs(12px) 到 4xl(28px)，行高 tight/base/relaxed
+- **色彩**: 暖色调，橙/棕基调 (#D97757) accent，WCAG AA 合规对比度
+- **圆角**: sm(4px), md(6px), lg(8px), xl(12px)
+- **主题**: 亮色、暗色、跟随系统
+
+---
+
+## 许可证
+
+[MIT](./LICENSE)


### PR DESCRIPTION
## Summary
- Add `README_zh.md` with full Chinese translation of the README
- Add language switch links (`English | 中文`) at the top of both README files

## Test plan
- [ ] Verify language switch links work in both files
- [ ] Confirm content parity between English and Chinese versions