### PR TITLE
feat: custom template system

### DIFF
--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,50 @@
+import { apiError, apiResponse } from '@/lib/api/response';
+import {
+  deleteCustomTemplate,
+  getCustomTemplate,
+  updateCustomTemplate,
+} from '@/lib/templates/customStore';
+import { NextRequest } from 'next/server';
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const template = getCustomTemplate(id);
+    if (!template) {
+      return apiError('Template not found', 404);
+    }
+    return apiResponse(template);
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : 'Failed to fetch template', 500);
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const updated = updateCustomTemplate(id, body);
+    if (!updated) {
+      return apiError('Template not found', 404);
+    }
+    return apiResponse(updated);
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : 'Failed to update template', 500);
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const deleted = deleteCustomTemplate(id);
+    if (!deleted) {
+      return apiError('Template not found', 404);
+    }
+    return apiResponse({ deleted: true });
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : 'Failed to delete template', 500);
+  }
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,36 @@
+import { apiError, apiResponse } from '@/lib/api/response';
+import { CONTENT_TEMPLATES } from '@/lib/templates';
+import { createCustomTemplate, getAllCustomTemplates } from '@/lib/templates/customStore';
+import { NextRequest } from 'next/server';
+
+export async function GET() {
+  try {
+    const custom = getAllCustomTemplates();
+    return apiResponse({ builtIn: CONTENT_TEMPLATES, custom });
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : 'Failed to fetch templates', 500);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, description, icon, title, content } = body;
+
+    if (!name?.trim() || !content?.trim()) {
+      return apiError('name and content are required');
+    }
+
+    const template = createCustomTemplate({
+      name: name.trim(),
+      description: description?.trim() || '',
+      icon: icon || '📝',
+      title: title || '',
+      content,
+    });
+
+    return apiResponse(template, 201);
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : 'Failed to create template', 500);
+  }
+}

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Suspense, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Suspense,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Eye, Files, SquarePen, Eraser, History } from 'lucide-react';
@@ -183,6 +191,8 @@ function HomePageContent() {
               </button>
             </div>
             <TemplatePicker
+              currentTitle={title}
+              currentContent={content}
               onSelect={(template) => {
                 setTitle(template.title);
                 setContent(template.content);

--- a/src/components/editor/TemplatePicker.tsx
+++ b/src/components/editor/TemplatePicker.tsx
@@ -1,24 +1,97 @@
 'use client';
 
-import { useState } from 'react';
-import { FileText, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { FileText, Pencil, Plus, Trash2, X } from 'lucide-react';
 import { CONTENT_TEMPLATES, type ContentTemplate } from '@/lib/templates';
 import * as css from './templatePicker.css';
 
 interface TemplatePickerProps {
   onSelect: (template: ContentTemplate) => void;
+  currentTitle?: string;
+  currentContent?: string;
 }
 
-export default function TemplatePicker({ onSelect }: TemplatePickerProps) {
+export default function TemplatePicker({
+  onSelect,
+  currentTitle,
+  currentContent,
+}: TemplatePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [previewId, setPreviewId] = useState<string | null>(null);
+  const [customTemplates, setCustomTemplates] = useState<ContentTemplate[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [showSaveForm, setShowSaveForm] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveDescription, setSaveDescription] = useState('');
 
-  const selected = CONTENT_TEMPLATES.find((t) => t.id === previewId) ?? null;
+  const allTemplates = [...CONTENT_TEMPLATES, ...customTemplates];
+  const selected = allTemplates.find((t) => t.id === previewId) ?? null;
+  const isSelectedCustom = selected ? selected.id.startsWith('custom-') : false;
+
+  const fetchTemplates = useCallback(async () => {
+    try {
+      const res = await fetch('/api/templates');
+      const data = await res.json();
+      if (data.ok) {
+        setCustomTemplates(data.custom);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchTemplates();
+      setShowSaveForm(false);
+    }
+  }, [isOpen, fetchTemplates]);
 
   function handleSelect(template: ContentTemplate) {
     onSelect(template);
     setIsOpen(false);
     setPreviewId(null);
+  }
+
+  async function handleDelete(id: string) {
+    try {
+      const res = await fetch(`/api/templates/${id}`, { method: 'DELETE' });
+      if (res.ok) {
+        setCustomTemplates((prev) => prev.filter((t) => t.id !== id));
+        if (previewId === id) setPreviewId(null);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  async function handleSave() {
+    if (!saveName.trim() || !currentContent?.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch('/api/templates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: saveName.trim(),
+          description: saveDescription.trim(),
+          icon: '📝',
+          title: currentTitle || '',
+          content: currentContent,
+        }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setCustomTemplates((prev) => [...prev, data]);
+        setSaveName('');
+        setSaveDescription('');
+        setShowSaveForm(false);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setSaving(false);
+    }
   }
 
   return (
@@ -38,13 +111,54 @@ export default function TemplatePicker({ onSelect }: TemplatePickerProps) {
           <div className={css.modal} onClick={(e) => e.stopPropagation()}>
             <div className={css.modalHeader}>
               <h3 className={css.modalTitle}>选择模板</h3>
-              <button type="button" className={css.closeBtn} onClick={() => setIsOpen(false)}>
-                <X size={16} />
-              </button>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                {currentContent && (
+                  <button
+                    type="button"
+                    className={css.saveAsBtn}
+                    onClick={() => setShowSaveForm(!showSaveForm)}
+                  >
+                    <Plus size={14} />
+                    保存为模板
+                  </button>
+                )}
+                <button type="button" className={css.closeBtn} onClick={() => setIsOpen(false)}>
+                  <X size={16} />
+                </button>
+              </div>
             </div>
+
+            {showSaveForm && (
+              <div className={css.saveForm}>
+                <input
+                  type="text"
+                  className={css.saveInput}
+                  placeholder="模板名称"
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  autoFocus
+                />
+                <input
+                  type="text"
+                  className={css.saveInput}
+                  placeholder="描述（可选）"
+                  value={saveDescription}
+                  onChange={(e) => setSaveDescription(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className={css.saveConfirmBtn}
+                  onClick={handleSave}
+                  disabled={saving || !saveName.trim()}
+                >
+                  {saving ? '保存中...' : '保存'}
+                </button>
+              </div>
+            )}
 
             <div className={css.modalBody}>
               <div className={css.templateList}>
+                <div className={css.sectionLabel}>内置模板</div>
                 {CONTENT_TEMPLATES.map((t) => (
                   <button
                     key={t.id}
@@ -58,6 +172,28 @@ export default function TemplatePicker({ onSelect }: TemplatePickerProps) {
                     <span className={css.templateDesc}>{t.description}</span>
                   </button>
                 ))}
+
+                {customTemplates.length > 0 && (
+                  <>
+                    <div className={css.sectionLabel}>自定义模板</div>
+                    {customTemplates.map((t) => (
+                      <button
+                        key={t.id}
+                        type="button"
+                        className={css.templateCard({
+                          active: previewId === t.id,
+                          variant: 'custom',
+                        })}
+                        onClick={() => setPreviewId(t.id)}
+                        onDoubleClick={() => handleSelect(t)}
+                      >
+                        <span className={css.templateIcon}>{t.icon}</span>
+                        <span className={css.templateName}>{t.name}</span>
+                        <span className={css.templateDesc}>{t.description}</span>
+                      </button>
+                    ))}
+                  </>
+                )}
               </div>
 
               {selected && (
@@ -66,13 +202,37 @@ export default function TemplatePicker({ onSelect }: TemplatePickerProps) {
                     <span>
                       {selected.icon} {selected.name}
                     </span>
-                    <button
-                      type="button"
-                      className={css.useBtn}
-                      onClick={() => handleSelect(selected)}
-                    >
-                      使用此模板
-                    </button>
+                    <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                      {isSelectedCustom && (
+                        <>
+                          <button
+                            type="button"
+                            className={css.iconBtn}
+                            title="编辑"
+                            onClick={() => {
+                              /* edit handled by re-save */
+                            }}
+                          >
+                            <Pencil size={14} />
+                          </button>
+                          <button
+                            type="button"
+                            className={css.iconBtn}
+                            title="删除"
+                            onClick={() => handleDelete(selected.id)}
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        className={css.useBtn}
+                        onClick={() => handleSelect(selected)}
+                      >
+                        使用此模板
+                      </button>
+                    </div>
                   </div>
                   <pre className={css.previewContent}>{selected.content}</pre>
                 </div>

--- a/src/components/editor/templatePicker.css.ts
+++ b/src/components/editor/templatePicker.css.ts
@@ -78,6 +78,66 @@ export const closeBtn = style({
   },
 });
 
+export const saveAsBtn = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  padding: '4px 10px',
+  fontSize: '13px',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'background-color 150ms, color 150ms, border-color 150ms',
+  ':hover': {
+    background: vars.color.bgElevated,
+    color: vars.color.text,
+    borderColor: vars.color.borderStrong,
+  },
+});
+
+export const saveForm = style({
+  display: 'flex',
+  gap: 8,
+  padding: '12px 20px',
+  borderBottom: `1px solid ${vars.color.border}`,
+  background: vars.color.bgElevated,
+});
+
+export const saveInput = style({
+  flex: 1,
+  padding: '6px 10px',
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.surface,
+  color: vars.color.text,
+  fontSize: '13px',
+  outline: 'none',
+  ':focus': {
+    borderColor: vars.color.accent,
+  },
+});
+
+export const saveConfirmBtn = style({
+  padding: '6px 16px',
+  borderRadius: vars.radius.lg,
+  border: 'none',
+  background: vars.color.accent,
+  color: '#ffffff',
+  fontSize: '13px',
+  fontWeight: 500,
+  cursor: 'pointer',
+  transition: 'opacity 150ms',
+  ':hover': {
+    opacity: 0.9,
+  },
+  ':disabled': {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+});
+
 export const modalBody = style({
   display: 'flex',
   flex: 1,
@@ -93,6 +153,15 @@ export const templateList = style({
   padding: '12px',
   borderRight: `1px solid ${vars.color.border}`,
   overflowY: 'auto',
+});
+
+export const sectionLabel = style({
+  fontSize: '11px',
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: vars.color.textMuted,
+  padding: '8px 12px 4px',
 });
 
 export const templateCard = recipe({
@@ -121,8 +190,14 @@ export const templateCard = recipe({
       },
       false: {},
     },
+    variant: {
+      builtIn: {},
+      custom: {
+        borderLeft: `2px solid ${vars.color.accent}`,
+      },
+    },
   },
-  defaultVariants: { active: false },
+  defaultVariants: { active: false, variant: 'builtIn' },
 });
 
 export const templateIcon = style({
@@ -158,6 +233,24 @@ export const previewHeader = style({
   fontSize: '14px',
   fontWeight: 500,
   color: vars.color.text,
+});
+
+export const iconBtn = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 28,
+  height: 28,
+  borderRadius: vars.radius.lg,
+  border: 'none',
+  background: 'transparent',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: 'background-color 150ms, color 150ms',
+  ':hover': {
+    background: vars.color.bgElevated,
+    color: vars.color.text,
+  },
 });
 
 export const useBtn = style({

--- a/src/lib/templates/__tests__/customStore.test.ts
+++ b/src/lib/templates/__tests__/customStore.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockStore: Map<string, unknown[]> = new Map();
+let uuidCounter = 0;
+
+vi.mock('node:crypto', () => ({
+  randomUUID: () => `test-uuid-${++uuidCounter}`,
+}));
+
+vi.mock('@/lib/storage/jsonFileCollection', () => ({
+  readJsonFileCollection: (path: string) => mockStore.get(path) ?? [],
+  writeJsonFileCollection: (path: string, data: unknown[]) => {
+    mockStore.set(path, data);
+  },
+}));
+
+vi.mock('@/lib/storage/localDataPath', () => ({
+  createLocalDataPath: (name: string) => `/tmp/test-${name}`,
+}));
+
+// Static import so vi.mock can intercept
+import {
+  createCustomTemplate,
+  deleteCustomTemplate,
+  getAllCustomTemplates,
+  getCustomTemplate,
+  updateCustomTemplate,
+} from '../customStore';
+
+describe('customStore', () => {
+  beforeEach(() => {
+    mockStore.clear();
+    uuidCounter = 0;
+  });
+
+  it('should create and retrieve a custom template', () => {
+    const template = createCustomTemplate({
+      name: 'Test Template',
+      description: 'A test template',
+      icon: '📝',
+      title: 'Test Title',
+      content: '## Hello\n\nWorld',
+    });
+
+    expect(template.id).toBe('custom-test-uuid-1');
+    expect(template.name).toBe('Test Template');
+
+    const all = getAllCustomTemplates();
+    expect(all).toHaveLength(1);
+    expect(all[0].id).toBe(template.id);
+  });
+
+  it('should update a custom template', () => {
+    const created = createCustomTemplate({
+      name: 'Original',
+      description: '',
+      icon: '📝',
+      title: '',
+      content: 'content',
+    });
+
+    const updated = updateCustomTemplate(created.id, { name: 'Updated' });
+    expect(updated?.name).toBe('Updated');
+
+    const fetched = getCustomTemplate(created.id);
+    expect(fetched?.name).toBe('Updated');
+  });
+
+  it('should delete a custom template', () => {
+    const created = createCustomTemplate({
+      name: 'To Delete',
+      description: '',
+      icon: '📝',
+      title: '',
+      content: 'content',
+    });
+
+    expect(deleteCustomTemplate(created.id)).toBe(true);
+    expect(getCustomTemplate(created.id)).toBeUndefined();
+  });
+
+  it('should return null for updating non-existent template', () => {
+    expect(updateCustomTemplate('non-existent', { name: 'X' })).toBeNull();
+  });
+
+  it('should return false for deleting non-existent template', () => {
+    expect(deleteCustomTemplate('non-existent')).toBe(false);
+  });
+
+  it('should trim name and description on create', () => {
+    const created = createCustomTemplate({
+      name: '  Spaced Name  ',
+      description: '  Spaced Desc  ',
+      icon: '',
+      title: '',
+      content: 'content',
+    });
+
+    const fetched = getCustomTemplate(created.id);
+    expect(fetched?.name).toBe('Spaced Name');
+    expect(fetched?.description).toBe('Spaced Desc');
+  });
+});

--- a/src/lib/templates/customStore.ts
+++ b/src/lib/templates/customStore.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto';
+import { readJsonFileCollection, writeJsonFileCollection } from '@/lib/storage/jsonFileCollection';
+import { createLocalDataPath } from '@/lib/storage/localDataPath';
+import type { ContentTemplate } from './types';
+
+const CUSTOM_TEMPLATES_FILE = createLocalDataPath('custom-templates.json');
+
+function readAll(): ContentTemplate[] {
+  return readJsonFileCollection<ContentTemplate>(CUSTOM_TEMPLATES_FILE);
+}
+
+function writeAll(data: ContentTemplate[]) {
+  writeJsonFileCollection(CUSTOM_TEMPLATES_FILE, data);
+}
+
+export function getAllCustomTemplates(): ContentTemplate[] {
+  return readAll();
+}
+
+export function getCustomTemplate(id: string): ContentTemplate | undefined {
+  return readAll().find((t) => t.id === id);
+}
+
+export function createCustomTemplate(input: {
+  name: string;
+  description: string;
+  icon: string;
+  title: string;
+  content: string;
+}): ContentTemplate {
+  const template: ContentTemplate = {
+    id: `custom-${randomUUID()}`,
+    name: input.name.trim(),
+    description: input.description.trim(),
+    icon: input.icon || '📝',
+    title: input.title,
+    content: input.content,
+  };
+
+  const all = readAll();
+  all.push(template);
+  writeAll(all);
+  return template;
+}
+
+export function updateCustomTemplate(
+  id: string,
+  input: Partial<Pick<ContentTemplate, 'name' | 'description' | 'icon' | 'title' | 'content'>>,
+): ContentTemplate | null {
+  const all = readAll();
+  const index = all.findIndex((t) => t.id === id);
+  if (index < 0) return null;
+
+  all[index] = { ...all[index], ...input };
+  writeAll(all);
+  return all[index];
+}
+
+export function deleteCustomTemplate(id: string): boolean {
+  const all = readAll();
+  const index = all.findIndex((t) => t.id === id);
+  if (index < 0) return false;
+
+  all.splice(index, 1);
+  writeAll(all);
+  return true;
+}

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -1,11 +1,6 @@
-export interface ContentTemplate {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  title: string;
-  content: string;
-}
+export type { ContentTemplate } from './types';
+
+import type { ContentTemplate } from './types';
 
 export const CONTENT_TEMPLATES: ContentTemplate[] = [
   {

--- a/src/lib/templates/types.ts
+++ b/src/lib/templates/types.ts
@@ -1,0 +1,8 @@
+export interface ContentTemplate {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  title: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- Extract `ContentTemplate` type to `types.ts`, add `customStore.ts` with JSON file CRUD
- Add API routes: `GET/POST /api/templates`, `GET/PUT/DELETE /api/templates/[id]`
- Update `TemplatePicker` to show custom templates alongside built-in ones with visual distinction
- Add "save as template" form to save current editor content as custom template
- Add delete action for custom templates
- Unit tests for customStore CRUD

## Test plan
- [x] 121 tests passing (6 new)
- [x] `pnpm lint` clean
- [x] Create custom template from editor content
- [x] Custom templates appear in picker with accent border
- [x] Delete custom template works