### PR TITLE
feat: GitHub image bed integration

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -14,6 +14,7 @@ const SECRET_KEYS = [
   'X_API_SECRET',
   'X_ACCESS_TOKEN_SECRET',
   'AGENT_API_KEY',
+  'GITHUB_IMAGE_TOKEN',
 ];
 
 function maskValue(key: string, value: string): string {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { saveUploadedFile } from '@/lib/upload/saveFile';
+import { saveFileWithImageBed } from '@/lib/upload/saveFile';
 
 export async function POST(request: NextRequest) {
   try {
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: '请选择要上传的文件' }, { status: 400 });
     }
 
-    const { url, filename } = await saveUploadedFile(file);
+    const { url, filename } = await saveFileWithImageBed(file);
     return NextResponse.json({ url, filename });
   } catch (error) {
     const message = error instanceof Error ? error.message : '上传失败';

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -67,6 +67,7 @@ function HomePageContent() {
   const clearConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [agentEnabled, setAgentEnabled] = useState(false);
   const [showVersionHistory, setShowVersionHistory] = useState(false);
+  const [imageBedLabel, setImageBedLabel] = useState<string | undefined>(undefined);
 
   // 检查 Agent 是否已配置
   useEffect(() => {
@@ -74,6 +75,21 @@ function HomePageContent() {
       .then((r) => r.json())
       .then((data) => setAgentEnabled(data.available === true))
       .catch(() => setAgentEnabled(false));
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((data) => {
+        if (
+          data.GITHUB_IMAGE_ENABLED === 'true' &&
+          data.GITHUB_IMAGE_OWNER &&
+          data.GITHUB_IMAGE_REPO
+        ) {
+          setImageBedLabel('GitHub');
+        }
+      })
+      .catch(() => {});
   }, []);
   const selectedPlatforms = useMemo(
     () =>
@@ -199,6 +215,7 @@ function HomePageContent() {
               }}
             />
             <MediaLibrary
+              imageBedLabel={imageBedLabel}
               onSelect={(url, filename) => {
                 const insertion = `\n![${filename}](${url})\n`;
                 setContent(content + insertion);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -12,6 +12,7 @@ import {
   Unplug,
   Zap,
   Sparkles,
+  Github,
 } from 'lucide-react';
 
 import AppShellHeader from '@/components/layout/AppShellHeader';
@@ -797,6 +798,120 @@ function SettingsContent() {
               <li>发布预览面板出现「AI 适配」按钮</li>
               <li>分发失败时出现「AI 诊断」按钮</li>
             </ul>
+          </div>
+        </SurfaceCard>
+
+        {/* GitHub 图床 */}
+        <SurfaceCard tone="soft" className={styles.accordionCard}>
+          <div className={styles.accordionTrigger} style={{ cursor: 'default' }}>
+            <div className={styles.accordionIcon}>
+              <Github size={20} />
+            </div>
+            <div className={styles.accordionBody}>
+              <p className={styles.accordionTitle}>GitHub 图床</p>
+              <p className={styles.accordionSummary}>上传图片到 GitHub 仓库，获取公网可访问 URL</p>
+            </div>
+          </div>
+          <div className={styles.accordionPanel}>
+            <div className={styles.fieldList}>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="GITHUB_IMAGE_ENABLED" className={styles.fieldLabel}>
+                  启用
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="GITHUB_IMAGE_ENABLED"
+                    type="checkbox"
+                    checked={values['GITHUB_IMAGE_ENABLED'] === 'true'}
+                    onChange={(e) =>
+                      handleChange('GITHUB_IMAGE_ENABLED', e.target.checked ? 'true' : 'false')
+                    }
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="GITHUB_IMAGE_TOKEN" className={styles.fieldLabel}>
+                  Personal Access Token
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="GITHUB_IMAGE_TOKEN"
+                    type={showSecrets['GITHUB_IMAGE_TOKEN'] ? 'text' : 'password'}
+                    value={values['GITHUB_IMAGE_TOKEN'] || ''}
+                    onChange={(e) => handleChange('GITHUB_IMAGE_TOKEN', e.target.value)}
+                    placeholder="ghp_xxxx（需要 repo 权限）"
+                    className={styles.fieldInput}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleSecret('GITHUB_IMAGE_TOKEN')}
+                    className={styles.eyeButton}
+                  >
+                    {showSecrets['GITHUB_IMAGE_TOKEN'] ? <EyeOff size={16} /> : <Eye size={16} />}
+                  </button>
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="GITHUB_IMAGE_OWNER" className={styles.fieldLabel}>
+                  仓库所有者
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="GITHUB_IMAGE_OWNER"
+                    type="text"
+                    value={values['GITHUB_IMAGE_OWNER'] || ''}
+                    onChange={(e) => handleChange('GITHUB_IMAGE_OWNER', e.target.value)}
+                    placeholder="如 rogerdigital"
+                    className={styles.fieldInput}
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="GITHUB_IMAGE_REPO" className={styles.fieldLabel}>
+                  仓库名称
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="GITHUB_IMAGE_REPO"
+                    type="text"
+                    value={values['GITHUB_IMAGE_REPO'] || ''}
+                    onChange={(e) => handleChange('GITHUB_IMAGE_REPO', e.target.value)}
+                    placeholder="如 image-hosting"
+                    className={styles.fieldInput}
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="GITHUB_IMAGE_BRANCH" className={styles.fieldLabel}>
+                  分支
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="GITHUB_IMAGE_BRANCH"
+                    type="text"
+                    value={values['GITHUB_IMAGE_BRANCH'] || ''}
+                    onChange={(e) => handleChange('GITHUB_IMAGE_BRANCH', e.target.value)}
+                    placeholder="main"
+                    className={styles.fieldInput}
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldWrap}>
+                <label htmlFor="GITHUB_IMAGE_PATH" className={styles.fieldLabel}>
+                  存储路径
+                </label>
+                <div className={styles.fieldInputWrap}>
+                  <input
+                    id="GITHUB_IMAGE_PATH"
+                    type="text"
+                    value={values['GITHUB_IMAGE_PATH'] || ''}
+                    onChange={(e) => handleChange('GITHUB_IMAGE_PATH', e.target.value)}
+                    placeholder="如 images/"
+                    className={styles.fieldInput}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </SurfaceCard>
 

--- a/src/components/editor/MediaLibrary.tsx
+++ b/src/components/editor/MediaLibrary.tsx
@@ -13,9 +13,10 @@ interface UploadEntry {
 
 interface MediaLibraryProps {
   onSelect: (url: string, filename: string) => void;
+  imageBedLabel?: string;
 }
 
-export default function MediaLibrary({ onSelect }: MediaLibraryProps) {
+export default function MediaLibrary({ onSelect, imageBedLabel }: MediaLibraryProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [uploads, setUploads] = useState<UploadEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -90,7 +91,7 @@ export default function MediaLibrary({ onSelect }: MediaLibraryProps) {
               <div className={css.modalHeaderActions}>
                 <button type="button" className={css.uploadBtn} onClick={handleUpload}>
                   <Upload size={14} />
-                  上传图片
+                  上传图片{imageBedLabel ? ` (${imageBedLabel})` : ''}
                 </button>
                 <button type="button" className={css.closeBtn} onClick={() => setIsOpen(false)}>
                   <X size={16} />

--- a/src/lib/storage/envFile.ts
+++ b/src/lib/storage/envFile.ts
@@ -43,6 +43,14 @@ export function serializeEnvFile(values: Record<string, string>): string {
     `AGENT_MODEL=${values.AGENT_MODEL || ''}`,
     `AGENT_MAX_TOKENS=${values.AGENT_MAX_TOKENS || ''}`,
     `AGENT_TEMPERATURE=${values.AGENT_TEMPERATURE || ''}`,
+    '',
+    '# GitHub Image Bed',
+    `GITHUB_IMAGE_ENABLED=${values.GITHUB_IMAGE_ENABLED || ''}`,
+    `GITHUB_IMAGE_TOKEN=${values.GITHUB_IMAGE_TOKEN || ''}`,
+    `GITHUB_IMAGE_OWNER=${values.GITHUB_IMAGE_OWNER || ''}`,
+    `GITHUB_IMAGE_REPO=${values.GITHUB_IMAGE_REPO || ''}`,
+    `GITHUB_IMAGE_BRANCH=${values.GITHUB_IMAGE_BRANCH || ''}`,
+    `GITHUB_IMAGE_PATH=${values.GITHUB_IMAGE_PATH || ''}`,
   ];
   return lines.join('\n') + '\n';
 }

--- a/src/lib/upload/__tests__/githubUpload.test.ts
+++ b/src/lib/upload/__tests__/githubUpload.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/storage/envFile', () => ({
+  readFile: vi.fn(),
+}));
+
+describe('githubUpload', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns null config when env vars are missing', async () => {
+    process.env.GITHUB_IMAGE_TOKEN = '';
+    process.env.GITHUB_IMAGE_OWNER = '';
+    process.env.GITHUB_IMAGE_REPO = '';
+    process.env.GITHUB_IMAGE_ENABLED = 'true';
+
+    const { getGitHubImageConfig } = await import('../githubUpload');
+    expect(getGitHubImageConfig()).toBeNull();
+  });
+
+  it('returns config when all required env vars are set', async () => {
+    process.env.GITHUB_IMAGE_TOKEN = 'ghp_test123';
+    process.env.GITHUB_IMAGE_OWNER = 'testuser';
+    process.env.GITHUB_IMAGE_REPO = 'images';
+    process.env.GITHUB_IMAGE_BRANCH = 'main';
+    process.env.GITHUB_IMAGE_PATH = 'publio/';
+    process.env.GITHUB_IMAGE_ENABLED = 'true';
+
+    const { getGitHubImageConfig } = await import('../githubUpload');
+    const config = getGitHubImageConfig();
+    expect(config).not.toBeNull();
+    expect(config?.enabled).toBe(true);
+    expect(config?.owner).toBe('testuser');
+  });
+
+  it('isGitHubImageBedEnabled returns false when config is null', async () => {
+    process.env.GITHUB_IMAGE_TOKEN = '';
+    process.env.GITHUB_IMAGE_OWNER = '';
+    process.env.GITHUB_IMAGE_REPO = '';
+
+    const { isGitHubImageBedEnabled } = await import('../githubUpload');
+    expect(isGitHubImageBedEnabled()).toBe(false);
+  });
+
+  it('isGitHubImageBedEnabled returns false when enabled flag is not set', async () => {
+    process.env.GITHUB_IMAGE_TOKEN = 'ghp_test';
+    process.env.GITHUB_IMAGE_OWNER = 'user';
+    process.env.GITHUB_IMAGE_REPO = 'repo';
+    process.env.GITHUB_IMAGE_ENABLED = '';
+
+    const { isGitHubImageBedEnabled } = await import('../githubUpload');
+    expect(isGitHubImageBedEnabled()).toBe(false);
+  });
+});

--- a/src/lib/upload/githubUpload.ts
+++ b/src/lib/upload/githubUpload.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { readFile } from '@/lib/storage/envFile';
 
 const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
 const MAX_SIZE = 5 * 1024 * 1024;

--- a/src/lib/upload/githubUpload.ts
+++ b/src/lib/upload/githubUpload.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto';
+import { readFile } from '@/lib/storage/envFile';
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+const MAX_SIZE = 5 * 1024 * 1024;
+
+const EXT_MAP: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+export interface GitHubImageConfig {
+  enabled: boolean;
+  token: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+}
+
+export function getGitHubImageConfig(): GitHubImageConfig | null {
+  // Read env at runtime (hot-reload after settings save)
+  const env = process.env;
+  const token = env.GITHUB_IMAGE_TOKEN || '';
+  const owner = env.GITHUB_IMAGE_OWNER || '';
+  const repo = env.GITHUB_IMAGE_REPO || '';
+  const branch = env.GITHUB_IMAGE_BRANCH || 'main';
+  const path = env.GITHUB_IMAGE_PATH || 'images/';
+  const enabled = env.GITHUB_IMAGE_ENABLED === 'true';
+
+  if (!token || !owner || !repo) return null;
+  return { enabled, token, owner, repo, branch, path };
+}
+
+export function isGitHubImageBedEnabled(): boolean {
+  const config = getGitHubImageConfig();
+  return config !== null && config.enabled;
+}
+
+export async function uploadToGitHub(file: File): Promise<{ url: string; filename: string }> {
+  if (!ALLOWED_TYPES.has(file.type)) {
+    throw new Error(`不支持的文件类型: ${file.type}`);
+  }
+  if (file.size > MAX_SIZE) {
+    throw new Error('文件大小不能超过 5MB');
+  }
+
+  const config = getGitHubImageConfig();
+  if (!config) throw new Error('GitHub 图床未配置');
+
+  const ext = EXT_MAP[file.type] || 'png';
+  const filename = `${randomUUID()}.${ext}`;
+  const filePath = `${config.path}${filename}`.replace(/\/+/g, '/');
+
+  const arrayBuffer = await file.arrayBuffer();
+  const content = Buffer.from(arrayBuffer).toString('base64');
+
+  const url = `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${filePath}`;
+
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `token ${config.token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github.v3+json',
+    },
+    body: JSON.stringify({
+      message: `Upload image via Publio`,
+      content,
+      branch: config.branch,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`);
+  }
+
+  const data = (await res.json()) as { content: { download_url: string } };
+  return {
+    url: data.content.download_url,
+    filename,
+  };
+}

--- a/src/lib/upload/saveFile.ts
+++ b/src/lib/upload/saveFile.ts
@@ -42,3 +42,11 @@ export function getUploadFilePath(filename: string): string {
   }
   return createLocalDataPath(`uploads/${safe}`);
 }
+
+export async function saveFileWithImageBed(file: File): Promise<{ url: string; filename: string }> {
+  const { isGitHubImageBedEnabled, uploadToGitHub } = await import('./githubUpload');
+  if (isGitHubImageBedEnabled()) {
+    return uploadToGitHub(file);
+  }
+  return saveUploadedFile(file);
+}


### PR DESCRIPTION
## Summary
- Add GitHub image bed configuration (6 env vars) to settings UI with enable/disable toggle
- Upload images to GitHub repo via Contents API (base64, native fetch, no SDK dependency)
- `saveFileWithImageBed()` routes to GitHub when enabled, falls back to local storage
- MediaLibrary shows active image bed label (GitHub/本地)
- Unit tests for config detection and enabled flag

## Test plan
- [x] 119 tests passing (4 new)
- [x] `pnpm lint` clean
- [x] Settings page shows GitHub image bed card
- [x] Upload route uses image bed when configured