### PR TITLE
docs: update README for new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 
 # AI tools
 .claude/
+.playwright-mcp/
 
 # Project local
 tasks/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)
 [![Next.js](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
-[![Tests](https://img.shields.io/badge/tests-115%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-129%20passing-brightgreen.svg)](#testing)
 
 > AI-native content operations platform. Write once, publish everywhere.
 
@@ -25,7 +25,8 @@ Publio is a multi-platform content distribution tool that consolidates Markdown 
 - **Editorial context panel** — title status, structural statistics, publishability signals
 - **Slash commands** — `/ai-expand`, `/ai-condense`, `/ai-rewrite`, `/ai-polish`, `/ai-continue`
 - **Version history** — auto-snapshot on title/content changes with restore capability
-- **Content templates** — 6 built-in templates for rapid drafting
+- **Content templates** — 6 built-in templates plus custom template CRUD
+- **GitHub image bed** — upload images to GitHub repo as persistent hosting
 
 ### AI Agent System
 
@@ -56,7 +57,7 @@ All AI features require an OpenAI-compatible API (Zhipu GLM, DeepSeek, Qwen, Ope
 - **Publish progress overlay** — real-time status polling with per-platform receipts
 - **Sync task tracking** — failure diagnosis, smart retry, manual mark-done
 - **Scheduled publish** — backend cron-based execution with persistent task queue
-- **Post-publish metrics** — views, likes, comments, shares aggregated in analytics dashboard
+- **Post-publish metrics** — views, likes, comments, shares aggregated in analytics dashboard with per-task and bulk refresh
 
 ### Content Calendar
 
@@ -164,6 +165,19 @@ All three required to activate AI features:
 | `AGENT_MAX_TOKENS` | Optional, default 2048 |
 | `AGENT_TEMPERATURE` | Optional, default 0.7 |
 
+### GitHub Image Bed (Optional)
+
+Enable image upload to GitHub repo as persistent hosting. Configure via Settings page or `.env.local`:
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_IMAGE_ENABLED` | Set to `true` to enable |
+| `GITHUB_IMAGE_TOKEN` | GitHub personal access token with repo scope |
+| `GITHUB_IMAGE_OWNER` | GitHub username or org |
+| `GITHUB_IMAGE_REPO` | Target repository name |
+| `GITHUB_IMAGE_BRANCH` | Optional, default `main` |
+| `GITHUB_IMAGE_PATH` | Optional, default `images/` |
+
 ---
 
 ## Architecture
@@ -188,10 +202,12 @@ src/
 │       ├── publish/                # Publish endpoint
 │       ├── rss-sources/            # Custom RSS CRUD
 │       ├── sync-tasks/             # Sync task management
+│       ├── templates/              # Custom template CRUD
+│       ├── upload/                 # Image upload (GitHub image bed)
 │       └── custom-prompts/         # Custom prompt CRUD
 ├── components/
 │   ├── layout/                   # AppShellHeader, Sidebar, SurfaceCard, ThemeToggle
-│   ├── editor/                   # MarkdownEditor, SlashCommandMenu, ImmersiveMode, WYSIWYG toggle
+│   ├── editor/                   # MarkdownEditor, TemplatePicker, SlashCommandMenu, ImmersiveMode, WYSIWYG toggle
 │   ├── news/                     # AiNewsPageClient, TopicSignalCard, ScoreBar
 │   ├── publish/                  # PlatformSelector, PublishButton, ModerationWarning, PreviewPanel
 │   ├── sync/                     # SyncTaskList, SyncTaskDetail
@@ -216,7 +232,9 @@ src/
 │   ├── rss-sources/              # Custom RSS source storage
 │   ├── scheduler/                # Scheduled publish execution
 │   ├── storage/                  # JSON file collection, env file utilities
-│   └── sync/                     # Distribution task state machine
+│   ├── sync/                     # Distribution task state machine
+│   ├── templates/                # Custom template store
+│   └── upload/                   # GitHub image upload
 ├── stores/                       # Zustand stores (publishStore, agentStore, toastStore)
 ├── styles/                       # Design tokens (spacing, typography, color, radius)
 └── types/                        # TypeScript type definitions
@@ -251,7 +269,7 @@ pnpm test           # run all tests
 pnpm test -- --watch  # watch mode
 ```
 
-115 tests across 37 test files covering stores, API routes, components, and utility functions.
+129 tests across 40 test files covering stores, API routes, components, and utility functions.
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)
 [![Next.js](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
-[![Tests](https://img.shields.io/badge/tests-115%20passing-brightgreen.svg)](#测试)
+[![Tests](https://img.shields.io/badge/tests-129%20passing-brightgreen.svg)](#测试)
 
 > AI 原生内容运营平台。一次创作，全平台分发。
 
@@ -25,7 +25,8 @@ Publio 是多平台内容分发工具，整合 Markdown 编辑、AI 选题发现
 - **编辑上下文面板** — 标题状态、结构统计、可发布性指标
 - **斜杠命令** — `/ai-expand`、`/ai-condense`、`/ai-rewrite`、`/ai-polish`、`/ai-continue`
 - **版本历史** — 标题/内容变更自动快照，支持回滚
-- **内容模板** — 6 个内置模板快速起草
+- **内容模板** — 6 个内置模板 + 自定义模板 CRUD
+- **GitHub 图床** — 图片上传至 GitHub 仓库作为持久化图床
 
 ### AI Agent 系统
 
@@ -56,7 +57,7 @@ Publio 是多平台内容分发工具，整合 Markdown 编辑、AI 选题发现
 - **发布进度浮层** — 实时状态轮询，逐平台接收回执
 - **分发任务追踪** — 失败诊断、智能重试、手动标记完成
 - **定时发布** — 后端 cron 执行，持久化任务队列
-- **发布后指标** — 阅读量、点赞、评论、分享聚合到分析看板
+- **发布后指标** — 阅读量、点赞、评论、分享聚合到分析看板，支持单任务和全量刷新
 
 ### 内容排期日历
 
@@ -164,6 +165,19 @@ pnpm verify           # lint + test + build
 | `AGENT_MAX_TOKENS` | 可选，默认 2048 |
 | `AGENT_TEMPERATURE` | 可选，默认 0.7 |
 
+### GitHub 图床（可选）
+
+启用图片上传至 GitHub 仓库作为持久化图床。通过设置页或 `.env.local` 配置：
+
+| 变量 | 说明 |
+|------|------|
+| `GITHUB_IMAGE_ENABLED` | 设为 `true` 启用 |
+| `GITHUB_IMAGE_TOKEN` | GitHub personal access token（需 repo scope） |
+| `GITHUB_IMAGE_OWNER` | GitHub 用户名或组织 |
+| `GITHUB_IMAGE_REPO` | 目标仓库名 |
+| `GITHUB_IMAGE_BRANCH` | 可选，默认 `main` |
+| `GITHUB_IMAGE_PATH` | 可选，默认 `images/` |
+
 ---
 
 ## 架构
@@ -188,10 +202,12 @@ src/
 │       ├── publish/                # 发布端点
 │       ├── rss-sources/            # 自定义 RSS CRUD
 │       ├── sync-tasks/             # 分发任务管理
+│       ├── templates/              # 自定义模板 CRUD
+│       ├── upload/                 # 图片上传（GitHub 图床）
 │       └── custom-prompts/         # 自定义 prompt CRUD
 ├── components/
 │   ├── layout/                   # AppShellHeader, Sidebar, SurfaceCard, ThemeToggle
-│   ├── editor/                   # MarkdownEditor, SlashCommandMenu, ImmersiveMode, WYSIWYG 切换
+│   ├── editor/                   # MarkdownEditor, TemplatePicker, SlashCommandMenu, ImmersiveMode, WYSIWYG 切换
 │   ├── news/                     # AiNewsPageClient, TopicSignalCard, ScoreBar
 │   ├── publish/                  # PlatformSelector, PublishButton, ModerationWarning, PreviewPanel
 │   ├── sync/                     # SyncTaskList, SyncTaskDetail
@@ -216,7 +232,9 @@ src/
 │   ├── rss-sources/              # 自定义 RSS 源存储
 │   ├── scheduler/                # 定时发布执行
 │   ├── storage/                  # JSON 文件集合、env 文件工具
-│   └── sync/                     # 分发任务状态机
+│   ├── sync/                     # 分发任务状态机
+│   ├── templates/                # 自定义模板存储
+│   └── upload/                   # GitHub 图片上传
 ├── stores/                       # Zustand stores（publishStore, agentStore, toastStore）
 ├── styles/                       # 设计 token（间距、字号、色彩、圆角）
 └── types/                        # TypeScript 类型定义
@@ -251,7 +269,7 @@ pnpm test           # 运行所有测试
 pnpm test -- --watch  # 监听模式
 ```
 
-37 个测试文件，115 个测试用例，覆盖 stores、API 路由、组件和工具函数。
+40 个测试文件，129 个测试用例，覆盖 stores、API 路由、组件和工具函数。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.1",
     "lint-staged": "^17.0.2",
+    "playwright": "^1.59.1",
     "prettier": "^3.8.3",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       lint-staged:
         specifier: ^17.0.2
         version: 17.0.2
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2109,6 +2112,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2976,6 +2984,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5776,6 +5794,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6938,6 +6959,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -1,0 +1,40 @@
+import { chromium } from 'playwright';
+import path from 'path';
+
+const BASE = 'http://localhost:3001';
+const OUT = path.resolve(__dirname, '../docs/screenshots');
+
+const pages = [
+  { name: 'editor', path: '/', waitFor: '.mde-text' },
+  { name: 'ai-news', path: '/ai-news', waitFor: 'h1' },
+  { name: 'calendar', path: '/calendar', waitFor: 'h1' },
+  { name: 'settings', path: '/settings', waitFor: 'h1' },
+];
+
+async function main() {
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await ctx.newPage();
+
+  for (const p of pages) {
+    await page.goto(`${BASE}${p.path}`, { waitUntil: 'networkidle' });
+    try {
+      await page.waitForSelector(p.waitFor, { timeout: 10000 });
+    } catch {
+      // fallback: wait a bit
+      await page.waitForTimeout(3000);
+    }
+    // extra settle time for animations
+    await page.waitForTimeout(1000);
+    const filePath = path.join(OUT, `${p.name}.png`);
+    await page.screenshot({ path: filePath, fullPage: false });
+    console.log(`✓ ${p.name} → ${filePath}`);
+  }
+
+  await browser.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Update test badge and count (115 → 129)
- Add custom templates and GitHub image bed to features
- Add GitHub Image Bed configuration section
- Update architecture tree (templates/, upload/, TemplatePicker)
- Add screenshot script with playwright dev dependency
- Gitignore .playwright-mcp/ cache directory

## Test plan
- [x] `pnpm verify` passes locally