### PR TITLE
Add AI request input limits

### DIFF
--- a/src/app/api/agent/adapt/route.ts
+++ b/src/app/api/agent/adapt/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getAgentConfig } from '@/lib/agent/config';
 import { createOpenAIProvider } from '@/lib/agent/provider';
 import { createSSEResponse } from '@/lib/agent/stream';
+import { AGENT_INPUT_LIMITS, limitText, markTruncated } from '@/lib/agent/inputLimits';
 import { buildAdaptationMessages } from '@/lib/agent/prompts/adaptation';
 import type { AdaptAgentRequest } from '@/lib/agent/types';
 import { PLATFORMS } from '@/types';
@@ -31,9 +32,20 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: '内容不能为空' }, { status: 400 });
   }
 
-  const messages = buildAdaptationMessages(platform, title || '', content, customPrompt);
+  const limitedTitle = limitText(title, AGENT_INPUT_LIMITS.titleChars);
+  const limitedContent = limitText(content, AGENT_INPUT_LIMITS.contentChars);
+  const limitedCustomPrompt = limitText(customPrompt, AGENT_INPUT_LIMITS.customPromptChars);
+  const messages = buildAdaptationMessages(
+    platform,
+    limitedTitle.value,
+    limitedContent.value,
+    limitedCustomPrompt.value,
+  );
   const provider = createOpenAIProvider(config);
   const tokens = provider.stream({ messages });
 
-  return createSSEResponse(tokens, request.signal);
+  return markTruncated(
+    createSSEResponse(tokens, request.signal),
+    limitedTitle.truncated || limitedContent.truncated || limitedCustomPrompt.truncated,
+  );
 }

--- a/src/app/api/agent/chat/route.ts
+++ b/src/app/api/agent/chat/route.ts
@@ -2,6 +2,12 @@ import { NextRequest } from 'next/server';
 import { getAgentConfig } from '@/lib/agent/config';
 import { createOpenAIProvider } from '@/lib/agent/provider';
 import { createSSEResponse } from '@/lib/agent/stream';
+import {
+  AGENT_INPUT_LIMITS,
+  limitChatMessages,
+  limitText,
+  markTruncated,
+} from '@/lib/agent/inputLimits';
 import type { ChatMessage } from '@/lib/agent/types';
 
 export const dynamic = 'force-dynamic';
@@ -39,28 +45,38 @@ export async function POST(request: NextRequest) {
 
   const { messages, context } = body;
 
-  if (!messages?.length) {
+  if (!Array.isArray(messages) || messages.length === 0) {
     return Response.json({ error: '消息不能为空' }, { status: 400 });
   }
 
+  const limitedMessages = limitChatMessages(messages);
   // 构建带上下文的系统消息
   let systemPrompt = SYSTEM_PROMPT;
+  let contextTruncated = false;
   if (context?.title || context?.content) {
     systemPrompt += '\n\n当前文章上下文：';
     if (context.title) {
-      systemPrompt += `\n标题：${context.title}`;
+      const limitedTitle = limitText(context.title, AGENT_INPUT_LIMITS.titleChars);
+      contextTruncated = contextTruncated || limitedTitle.truncated;
+      systemPrompt += `\n标题：${limitedTitle.value}`;
     }
     if (context.content) {
-      const truncated =
-        context.content.length > 2000 ? context.content.slice(0, 2000) + '...' : context.content;
-      systemPrompt += `\n内容：\n${truncated}`;
+      const limitedContent = limitText(context.content, AGENT_INPUT_LIMITS.contentChars);
+      contextTruncated = contextTruncated || limitedContent.truncated;
+      systemPrompt += `\n内容：\n${limitedContent.value}`;
     }
   }
 
-  const fullMessages: ChatMessage[] = [{ role: 'system', content: systemPrompt }, ...messages];
+  const fullMessages: ChatMessage[] = [
+    { role: 'system', content: systemPrompt },
+    ...limitedMessages.value,
+  ];
 
   const provider = createOpenAIProvider(config);
   const tokens = provider.stream({ messages: fullMessages });
 
-  return createSSEResponse(tokens, request.signal);
+  return markTruncated(
+    createSSEResponse(tokens, request.signal),
+    limitedMessages.truncated || contextTruncated,
+  );
 }

--- a/src/app/api/agent/diagnose/route.ts
+++ b/src/app/api/agent/diagnose/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getAgentConfig } from '@/lib/agent/config';
 import { createOpenAIProvider } from '@/lib/agent/provider';
 import { createSSEResponse } from '@/lib/agent/stream';
+import { AGENT_INPUT_LIMITS, limitText, markTruncated } from '@/lib/agent/inputLimits';
 import { buildDiagnoseMessages } from '@/lib/agent/prompts/diagnose';
 import type { DiagnoseAgentRequest } from '@/lib/agent/types';
 
@@ -26,9 +27,19 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: '平台和错误信息不能为空' }, { status: 400 });
   }
 
-  const messages = buildDiagnoseMessages(platform, errorMessage, statusCode, context);
+  const limitedErrorMessage = limitText(errorMessage, AGENT_INPUT_LIMITS.signalSummaryChars);
+  const limitedContext = limitText(context, AGENT_INPUT_LIMITS.diagnoseContextChars);
+  const messages = buildDiagnoseMessages(
+    platform,
+    limitedErrorMessage.value,
+    statusCode,
+    limitedContext.value,
+  );
   const provider = createOpenAIProvider(config);
   const tokens = provider.stream({ messages, maxTokens: 1000 });
 
-  return createSSEResponse(tokens, request.signal);
+  return markTruncated(
+    createSSEResponse(tokens, request.signal),
+    limitedErrorMessage.truncated || limitedContext.truncated,
+  );
 }

--- a/src/app/api/agent/research/route.ts
+++ b/src/app/api/agent/research/route.ts
@@ -2,6 +2,12 @@ import { NextRequest } from 'next/server';
 import { getAgentConfig } from '@/lib/agent/config';
 import { createOpenAIProvider } from '@/lib/agent/provider';
 import { createSSEResponse } from '@/lib/agent/stream';
+import {
+  AGENT_INPUT_LIMITS,
+  limitResearchSignals,
+  limitText,
+  markTruncated,
+} from '@/lib/agent/inputLimits';
 import { buildResearchMessages } from '@/lib/agent/prompts/research';
 import type { ResearchAgentRequest } from '@/lib/agent/types';
 
@@ -30,9 +36,14 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: '至少需要一条信号' }, { status: 400 });
   }
 
-  const messages = buildResearchMessages(clusterTitle, signals);
+  const limitedClusterTitle = limitText(clusterTitle, AGENT_INPUT_LIMITS.titleChars);
+  const limitedSignals = limitResearchSignals(signals);
+  const messages = buildResearchMessages(limitedClusterTitle.value, limitedSignals.value);
   const provider = createOpenAIProvider(config);
   const tokens = provider.stream({ messages, maxTokens: 3000 });
 
-  return createSSEResponse(tokens, request.signal);
+  return markTruncated(
+    createSSEResponse(tokens, request.signal),
+    limitedClusterTitle.truncated || limitedSignals.truncated,
+  );
 }

--- a/src/app/api/agent/write/route.ts
+++ b/src/app/api/agent/write/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getAgentConfig } from '@/lib/agent/config';
 import { createOpenAIProvider } from '@/lib/agent/provider';
 import { createSSEResponse } from '@/lib/agent/stream';
+import { AGENT_INPUT_LIMITS, limitText, markTruncated } from '@/lib/agent/inputLimits';
 import { buildWritingMessages } from '@/lib/agent/prompts/writing';
 import { getStyleProfile } from '@/lib/copilot/styleProfile';
 import type { WritingAction, WritingAgentRequest } from '@/lib/agent/types';
@@ -39,14 +40,20 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: '内容不能为空' }, { status: 400 });
   }
 
+  const limitedContent = limitText(content, AGENT_INPUT_LIMITS.contentChars);
+  const limitedTitle = limitText(title, AGENT_INPUT_LIMITS.titleChars);
+  const limitedSelection = limitText(selection, AGENT_INPUT_LIMITS.selectionChars);
   const styleProfile = getStyleProfile();
-  const messages = buildWritingMessages(action, content, {
-    title,
-    selection,
+  const messages = buildWritingMessages(action, limitedContent.value, {
+    title: limitedTitle.value,
+    selection: limitedSelection.value,
     styleDescription: styleProfile?.description,
   });
   const provider = createOpenAIProvider(config);
   const tokens = provider.stream({ messages });
 
-  return createSSEResponse(tokens, request.signal);
+  return markTruncated(
+    createSSEResponse(tokens, request.signal),
+    limitedContent.truncated || limitedTitle.truncated || limitedSelection.truncated,
+  );
 }

--- a/src/app/api/copilot/recommend/route.ts
+++ b/src/app/api/copilot/recommend/route.ts
@@ -2,6 +2,12 @@ import { NextRequest } from 'next/server';
 import { getAgentConfig } from '@/lib/agent/config';
 import { createOpenAIProvider } from '@/lib/agent/provider';
 import { createSSEResponse } from '@/lib/agent/stream';
+import {
+  AGENT_INPUT_LIMITS,
+  limitRecommendationClusters,
+  limitText,
+  markTruncated,
+} from '@/lib/agent/inputLimits';
 import { getBrandProfile } from '@/lib/copilot/profile';
 import { buildRecommendPrompt } from '@/lib/copilot/recommend';
 import type { AiNewsCluster } from '@/lib/ai-news/types';
@@ -31,10 +37,27 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: '没有可用的新闻话题' }, { status: 400 });
   }
 
-  const prompt = buildRecommendPrompt(profile, body.clusters);
+  const limitedProfile = {
+    ...profile,
+    brandName: limitText(profile.brandName, AGENT_INPUT_LIMITS.brandProfileFieldChars).value,
+    industry: limitText(profile.industry, AGENT_INPUT_LIMITS.brandProfileFieldChars).value,
+    persona: limitText(profile.persona, AGENT_INPUT_LIMITS.brandProfileFieldChars).value,
+    targetAudience: limitText(profile.targetAudience, AGENT_INPUT_LIMITS.brandProfileFieldChars)
+      .value,
+    contentStyle: limitText(profile.contentStyle, AGENT_INPUT_LIMITS.brandProfileFieldChars).value,
+  };
+  const profileTruncated = Object.entries(profile).some(([key, value]) => {
+    const limited = limitText(String(value), AGENT_INPUT_LIMITS.brandProfileFieldChars);
+    return limited.truncated && key in limitedProfile;
+  });
+  const limitedClusters = limitRecommendationClusters(body.clusters);
+  const prompt = buildRecommendPrompt(limitedProfile, limitedClusters.value);
   const messages: ChatMessage[] = [{ role: 'user', content: prompt }];
   const provider = createOpenAIProvider(config);
   const tokens = provider.stream({ messages, temperature: 0.7 });
 
-  return createSSEResponse(tokens, request.signal);
+  return markTruncated(
+    createSSEResponse(tokens, request.signal),
+    profileTruncated || limitedClusters.truncated,
+  );
 }

--- a/src/lib/agent/__tests__/inputLimits.test.ts
+++ b/src/lib/agent/__tests__/inputLimits.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  AGENT_INPUT_LIMITS,
+  limitChatMessages,
+  limitRecommendationClusters,
+  limitResearchSignals,
+  limitText,
+  markTruncated,
+} from '@/lib/agent/inputLimits';
+import type { AiNewsCluster, NormalizedAiNewsSignal } from '@/lib/ai-news/types';
+
+function createSignal(overrides: Partial<NormalizedAiNewsSignal> = {}): NormalizedAiNewsSignal {
+  return {
+    id: 'signal-1',
+    title: 'signal title',
+    canonicalTitle: 'signal title',
+    summary: 'summary',
+    link: 'https://example.com',
+    sourceWeight: 1,
+    sourceName: 'Source',
+    sourceType: 'media',
+    sourceDomain: 'example.com',
+    publishedAt: '2026-05-09T00:00:00.000Z',
+    fetchedAt: '2026-05-09T00:00:00.000Z',
+    entityTokens: [],
+    topicTags: [],
+    isOfficialSource: false,
+    ...overrides,
+  };
+}
+
+function createCluster(index: number, signals: NormalizedAiNewsSignal[] = []): AiNewsCluster {
+  const primarySignal = signals[0] ?? createSignal({ id: `signal-${index}` });
+  return {
+    clusterId: `cluster-${index}`,
+    title: `cluster ${index}`,
+    normalizedTitle: `cluster ${index}`,
+    topicTags: [],
+    entityTokens: [],
+    signals: signals.length ? signals : [primarySignal],
+    primarySignal,
+    earliestPublishedAt: '2026-05-09T00:00:00.000Z',
+    latestPublishedAt: '2026-05-09T00:00:00.000Z',
+    coverageCount: 1,
+    officialSourceCount: 0,
+    mediaSourceCount: 1,
+  };
+}
+
+describe('agent input limits', () => {
+  test('limits text by character count', () => {
+    const result = limitText('abcdef', 3);
+
+    expect(result).toEqual({ value: 'abc', truncated: true });
+  });
+
+  test('keeps only recent chat messages and trims message content', () => {
+    const messages = Array.from({ length: AGENT_INPUT_LIMITS.chatMessages + 2 }, (_, index) => ({
+      role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: index === AGENT_INPUT_LIMITS.chatMessages + 1 ? 'x'.repeat(5_000) : `msg-${index}`,
+    }));
+
+    const result = limitChatMessages(messages);
+
+    expect(result.truncated).toBe(true);
+    expect(result.value).toHaveLength(AGENT_INPUT_LIMITS.chatMessages);
+    expect(result.value[0].content).toBe('msg-2');
+    expect(result.value.at(-1)?.content).toHaveLength(AGENT_INPUT_LIMITS.chatMessageChars);
+  });
+
+  test('limits research signal count and field length', () => {
+    const signals = Array.from({ length: AGENT_INPUT_LIMITS.researchSignals + 1 }, (_, index) => ({
+      title: index === 0 ? 't'.repeat(500) : `title-${index}`,
+      summary: 's'.repeat(2_000),
+      source: 'source',
+    }));
+
+    const result = limitResearchSignals(signals);
+
+    expect(result.truncated).toBe(true);
+    expect(result.value).toHaveLength(AGENT_INPUT_LIMITS.researchSignals);
+    expect(result.value[0].title).toHaveLength(AGENT_INPUT_LIMITS.signalTitleChars);
+    expect(result.value[0].summary).toHaveLength(AGENT_INPUT_LIMITS.signalSummaryChars);
+  });
+
+  test('limits recommendation clusters and nested signal source names', () => {
+    const clusters = Array.from(
+      { length: AGENT_INPUT_LIMITS.recommendationClusters + 1 },
+      (_, index) =>
+        createCluster(
+          index,
+          Array.from({ length: AGENT_INPUT_LIMITS.clusterSignals + 1 }, (_, signalIndex) =>
+            createSignal({
+              id: `signal-${index}-${signalIndex}`,
+              sourceName: 'source'.repeat(50),
+            }),
+          ),
+        ),
+    );
+
+    const result = limitRecommendationClusters(clusters);
+
+    expect(result.truncated).toBe(true);
+    expect(result.value).toHaveLength(AGENT_INPUT_LIMITS.recommendationClusters);
+    expect(result.value[0].signals).toHaveLength(AGENT_INPUT_LIMITS.clusterSignals);
+    expect(result.value[0].signals[0].sourceName).toHaveLength(
+      AGENT_INPUT_LIMITS.signalSourceChars,
+    );
+  });
+
+  test('marks truncated responses with a header', () => {
+    const response = markTruncated(new Response('ok'), true);
+
+    expect(response.headers.get('X-Agent-Input-Truncated')).toBe('true');
+  });
+});

--- a/src/lib/agent/inputLimits.ts
+++ b/src/lib/agent/inputLimits.ts
@@ -1,0 +1,111 @@
+import type { ChatMessage } from '@/lib/agent/types';
+import type { AiNewsCluster } from '@/lib/ai-news/types';
+
+export const AGENT_INPUT_LIMITS = {
+  titleChars: 200,
+  contentChars: 12_000,
+  selectionChars: 4_000,
+  customPromptChars: 2_000,
+  diagnoseContextChars: 4_000,
+  chatMessages: 20,
+  chatMessageChars: 4_000,
+  researchSignals: 12,
+  signalTitleChars: 240,
+  signalSummaryChars: 1_200,
+  signalSourceChars: 120,
+  recommendationClusters: 10,
+  clusterSignals: 5,
+  brandProfileFieldChars: 600,
+} as const;
+
+export interface LimitedValue<T> {
+  value: T;
+  truncated: boolean;
+}
+
+export function limitText(value: string | undefined, maxChars: number): LimitedValue<string> {
+  if (!value) return { value: '', truncated: false };
+  if (value.length <= maxChars) return { value, truncated: false };
+  return { value: value.slice(0, maxChars), truncated: true };
+}
+
+export function limitChatMessages(messages: ChatMessage[]): LimitedValue<ChatMessage[]> {
+  const recentMessages = messages.slice(-AGENT_INPUT_LIMITS.chatMessages);
+  let truncated = recentMessages.length !== messages.length;
+
+  const value = recentMessages.map((message) => {
+    const limitedContent = limitText(message.content, AGENT_INPUT_LIMITS.chatMessageChars);
+    if (limitedContent.truncated) truncated = true;
+    return {
+      ...message,
+      content: limitedContent.value,
+    };
+  });
+
+  return { value, truncated };
+}
+
+export function limitResearchSignals<
+  T extends { title: string; summary: string; source: string; publishedAt?: string },
+>(signals: T[]): LimitedValue<T[]> {
+  const limitedSignals = signals.slice(0, AGENT_INPUT_LIMITS.researchSignals);
+  let truncated = limitedSignals.length !== signals.length;
+
+  const value = limitedSignals.map((signal) => {
+    const title = limitText(signal.title, AGENT_INPUT_LIMITS.signalTitleChars);
+    const summary = limitText(signal.summary, AGENT_INPUT_LIMITS.signalSummaryChars);
+    const source = limitText(signal.source, AGENT_INPUT_LIMITS.signalSourceChars);
+    if (title.truncated || summary.truncated || source.truncated) truncated = true;
+    return {
+      ...signal,
+      title: title.value,
+      summary: summary.value,
+      source: source.value,
+    };
+  });
+
+  return { value, truncated };
+}
+
+export function limitRecommendationClusters(
+  clusters: AiNewsCluster[],
+): LimitedValue<AiNewsCluster[]> {
+  const limitedClusters = clusters.slice(0, AGENT_INPUT_LIMITS.recommendationClusters);
+  let truncated = limitedClusters.length !== clusters.length;
+
+  const value = limitedClusters.map((cluster) => {
+    const title = limitText(cluster.title, AGENT_INPUT_LIMITS.signalTitleChars);
+    const primaryTitle = limitText(
+      cluster.primarySignal.title,
+      AGENT_INPUT_LIMITS.signalTitleChars,
+    );
+    const signals = cluster.signals.slice(0, AGENT_INPUT_LIMITS.clusterSignals).map((signal) => {
+      const sourceName = limitText(signal.sourceName, AGENT_INPUT_LIMITS.signalSourceChars);
+      if (sourceName.truncated) truncated = true;
+      return { ...signal, sourceName: sourceName.value };
+    });
+
+    if (title.truncated || primaryTitle.truncated || signals.length !== cluster.signals.length) {
+      truncated = true;
+    }
+
+    return {
+      ...cluster,
+      title: title.value,
+      primarySignal: {
+        ...cluster.primarySignal,
+        title: primaryTitle.value,
+      },
+      signals,
+    };
+  });
+
+  return { value, truncated };
+}
+
+export function markTruncated(response: Response, truncated: boolean): Response {
+  if (truncated) {
+    response.headers.set('X-Agent-Input-Truncated', 'true');
+  }
+  return response;
+}


### PR DESCRIPTION
## Summary
- add shared AI input budget helpers for text, chat history, research signals, and recommendation clusters
- apply deterministic truncation before prompt construction across agent and copilot routes
- mark truncated SSE responses with X-Agent-Input-Truncated
- add regression tests for the shared input limit behavior

## Verification
- pnpm test -- src/lib/agent/__tests__/inputLimits.test.ts
- pnpm check:no-js-source
- pnpm build

Closes #43