### PR TITLE
Unify publish job execution

### DIFF
--- a/src/app/api/publish/route.ts
+++ b/src/app/api/publish/route.ts
@@ -1,15 +1,8 @@
 import { NextRequest } from 'next/server';
 import { PlatformId } from '@/types';
-import { getDraftRegistry } from '@/lib/drafts/registry';
 import { getSyncHistoryStore } from '@/lib/sync/registry';
-import {
-  type PlatformPublishDrafts,
-  inferFailureCode,
-  publishToPlatforms,
-  toDraftStatus,
-  toNextAction,
-  toSyncReceiptStatus,
-} from '@/lib/publishers/executePublish';
+import type { PlatformPublishDrafts } from '@/lib/publishers/executePublish';
+import { runPublishJob } from '@/lib/publishers/publishJobRunner';
 import { adaptContentForPlatforms } from '@/lib/platformAdapters/adaptContent';
 import { validateTitle, validateContent, validatePlatforms } from '@/lib/validation';
 import { checkContent } from '@/lib/moderation/check';
@@ -70,59 +63,18 @@ export async function POST(request: NextRequest) {
     logger.info('Publish task created', { taskId: syncTask.id, platforms });
 
     void (async () => {
-      try {
-        const publishResults = await publishToPlatforms(
-          platforms as PlatformId[],
-          title,
-          content,
-          platformDrafts,
-        );
-
-        for (const result of publishResults) {
-          const receiptStatus = toSyncReceiptStatus(result);
-          const isFailed = receiptStatus === 'failed';
-          const failureCode = isFailed ? inferFailureCode(result.message) : undefined;
-          const nextAction = isFailed && failureCode ? toNextAction(failureCode) : undefined;
-
-          syncTask =
-            syncStore.updateReceipt(syncTask.id, result.platform, {
-              status: receiptStatus,
-              message: result.message,
-              url: result.url,
-              failureCode,
-              failureMessage: isFailed ? (result.message ?? '未知错误') : undefined,
-              nextAction,
-            }) ?? syncTask;
-        }
-
-        if (syncTask.draftId) {
-          getDraftRegistry().updateDraft(syncTask.draftId, {
-            status: toDraftStatus(syncTask.status),
-          });
-        }
-
-        logger.info('Publish completed', {
-          taskId: syncTask.id,
-          durationMs: Date.now() - startTime,
-        });
-      } catch (err) {
-        logger.error('Publish failed in background', {
-          taskId: syncTask.id,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        for (const platform of platforms as PlatformId[]) {
-          const receipt = syncStore
-            .getTask(syncTask.id)
-            ?.receipts.find((r) => r.platform === platform && r.status === 'pending');
-          if (receipt) {
-            syncStore.updateReceipt(syncTask.id, platform, {
-              status: 'failed',
-              failureCode: 'unknown',
-              failureMessage: '发布过程中发生未知错误',
-            });
-          }
-        }
-      }
+      const result = await runPublishJob({
+        syncTaskId: syncTask.id,
+        title,
+        content,
+        platforms: platforms as PlatformId[],
+        platformDrafts,
+      });
+      syncTask = result.syncTask;
+      logger.info('Publish completed', {
+        taskId: syncTask.id,
+        durationMs: Date.now() - startTime,
+      });
     })();
 
     return apiResponse({ syncTaskId: syncTask.id, syncTask });

--- a/src/app/api/sync-tasks/[id]/retry/route.ts
+++ b/src/app/api/sync-tasks/[id]/retry/route.ts
@@ -2,13 +2,7 @@ import { NextRequest } from 'next/server';
 
 import { getDraftRegistry } from '@/lib/drafts/registry';
 import { getSyncHistoryStore } from '@/lib/sync/registry';
-import {
-  inferFailureCode,
-  publishToPlatforms,
-  toDraftStatus,
-  toNextAction,
-  toSyncReceiptStatus,
-} from '@/lib/publishers/executePublish';
+import { runPublishJob } from '@/lib/publishers/publishJobRunner';
 import { apiResponse, apiError } from '@/lib/api/response';
 
 export const dynamic = 'force-dynamic';
@@ -45,34 +39,17 @@ export async function POST(_request: NextRequest | Request, { params }: RetrySyn
     return apiError('没有可重试的平台（需要重新授权的平台请先前往设置页重新连接）');
   }
 
-  const publishResults = await publishToPlatforms(retryPlatforms, draft.title, draft.content);
-
   syncStore.appendRetryEvent(syncTask.id);
-
-  for (const result of publishResults) {
-    const receiptStatus = toSyncReceiptStatus(result);
-    const isFailed = receiptStatus === 'failed';
-    const failureCode = isFailed ? inferFailureCode(result.message) : undefined;
-    const nextAction = isFailed && failureCode ? toNextAction(failureCode) : undefined;
-
-    syncTask =
-      syncStore.updateReceipt(syncTask.id, result.platform, {
-        status: receiptStatus,
-        message: result.message,
-        url: result.url,
-        failureCode,
-        failureMessage: isFailed ? (result.message ?? '未知错误') : undefined,
-        nextAction,
-      }) ?? syncTask;
-  }
-
-  getDraftRegistry().updateDraft(draft.id, {
-    status: toDraftStatus(syncTask.status),
+  const { syncTask: updatedTask, results } = await runPublishJob({
+    syncTaskId: syncTask.id,
+    title: draft.title,
+    content: draft.content,
+    platforms: retryPlatforms,
   });
 
   return apiResponse({
-    syncTask,
+    syncTask: updatedTask,
     retriedPlatforms: retryPlatforms,
-    results: publishResults,
+    results,
   });
 }

--- a/src/lib/publishers/__tests__/publishJobRunner.test.ts
+++ b/src/lib/publishers/__tests__/publishJobRunner.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getDraftRegistry, resetDraftRegistryForTests } from '@/lib/drafts/registry';
+import { runPublishJob } from '@/lib/publishers/publishJobRunner';
+import { publishToPlatforms } from '@/lib/publishers/executePublish';
+import { resetSyncHistoryStoreForTests } from '@/lib/sync/registry';
+
+vi.mock('@/lib/publishers/executePublish', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/publishers/executePublish')>();
+  return {
+    ...actual,
+    publishToPlatforms: vi.fn(),
+  };
+});
+
+describe('runPublishJob', () => {
+  beforeEach(() => {
+    vi.mocked(publishToPlatforms).mockReset();
+    const drafts = resetDraftRegistryForTests({
+      createId: () => 'draft-1',
+      now: () => '2026-05-09T10:00:00.000Z',
+    });
+    drafts.createDraft({
+      title: '稿件标题',
+      content: '稿件正文',
+      source: 'manual',
+      scheduledAt: '2026-05-09T09:00:00.000Z',
+      platforms: ['wechat'],
+    });
+    resetSyncHistoryStoreForTests({
+      createId: () => 'sync-1',
+      now: () => '2026-05-09T10:00:00.000Z',
+    });
+  });
+
+  test('updates receipts and clears scheduledAt through the shared path', async () => {
+    vi.mocked(publishToPlatforms).mockResolvedValueOnce([
+      {
+        platform: 'wechat',
+        status: 'success',
+        message: '发布成功',
+        url: 'https://example.com/post',
+      },
+    ]);
+
+    const syncStore = resetSyncHistoryStoreForTests({
+      createId: () => 'sync-1',
+      now: () => '2026-05-09T10:00:00.000Z',
+    });
+    const task = syncStore.createTask({
+      draftId: 'draft-1',
+      title: '稿件标题',
+      platforms: ['wechat'],
+    });
+
+    const result = await runPublishJob({
+      syncTaskId: task.id,
+      title: '稿件标题',
+      content: '稿件正文',
+      platforms: ['wechat'],
+      clearScheduledAt: true,
+    });
+
+    expect(result.syncTask.status).toBe('completed');
+    expect(result.syncTask.receipts[0]).toMatchObject({
+      platform: 'wechat',
+      status: 'published',
+      url: 'https://example.com/post',
+    });
+    expect(getDraftRegistry().getDraft('draft-1')).toMatchObject({
+      status: 'synced',
+      scheduledAt: undefined,
+    });
+  });
+
+  test('marks all requested platforms failed when execution throws', async () => {
+    vi.mocked(publishToPlatforms).mockRejectedValueOnce(new Error('network down'));
+    const syncStore = resetSyncHistoryStoreForTests({
+      createId: () => 'sync-1',
+      now: () => '2026-05-09T10:00:00.000Z',
+    });
+    const task = syncStore.createTask({
+      draftId: 'draft-1',
+      title: '稿件标题',
+      platforms: ['wechat', 'x'],
+    });
+
+    const result = await runPublishJob({
+      syncTaskId: task.id,
+      title: '稿件标题',
+      content: '稿件正文',
+      platforms: ['wechat', 'x'],
+    });
+
+    expect(result.syncTask.status).toBe('failed');
+    expect(result.syncTask.receipts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: 'wechat',
+          status: 'failed',
+          failureCode: 'network-error',
+        }),
+        expect.objectContaining({
+          platform: 'x',
+          status: 'failed',
+          failureCode: 'network-error',
+        }),
+      ]),
+    );
+  });
+});

--- a/src/lib/publishers/publishJobRunner.ts
+++ b/src/lib/publishers/publishJobRunner.ts
@@ -1,0 +1,89 @@
+import type { PlatformId, PlatformPublishResult } from '@/types';
+import { getDraftRegistry } from '@/lib/drafts/registry';
+import { getSyncHistoryStore } from '@/lib/sync/registry';
+import type { SyncTask } from '@/lib/sync/types';
+import {
+  type PlatformPublishDrafts,
+  inferFailureCode,
+  publishToPlatforms,
+  toDraftStatus,
+  toNextAction,
+  toSyncReceiptStatus,
+} from '@/lib/publishers/executePublish';
+
+export interface RunPublishJobInput {
+  syncTaskId: string;
+  title: string;
+  content: string;
+  platforms: PlatformId[];
+  platformDrafts?: PlatformPublishDrafts;
+  clearScheduledAt?: boolean;
+}
+
+export interface RunPublishJobResult {
+  syncTask: SyncTask;
+  results: PlatformPublishResult[];
+}
+
+function updateDraftFromTask(syncTask: SyncTask, clearScheduledAt?: boolean) {
+  if (!syncTask.draftId) return;
+  getDraftRegistry().updateDraft(syncTask.draftId, {
+    status: toDraftStatus(syncTask.status),
+    ...(clearScheduledAt ? { scheduledAt: undefined } : {}),
+  });
+}
+
+function applyPublishResults(syncTask: SyncTask, results: PlatformPublishResult[]): SyncTask {
+  const syncStore = getSyncHistoryStore();
+  let updatedTask = syncTask;
+
+  for (const result of results) {
+    const receiptStatus = toSyncReceiptStatus(result);
+    const isFailed = receiptStatus === 'failed';
+    const failureCode = isFailed ? inferFailureCode(result.message) : undefined;
+    const nextAction = isFailed && failureCode ? toNextAction(failureCode) : undefined;
+
+    updatedTask =
+      syncStore.updateReceipt(updatedTask.id, result.platform, {
+        status: receiptStatus,
+        message: result.message,
+        url: result.url,
+        failureCode,
+        failureMessage: isFailed ? (result.message ?? '未知错误') : undefined,
+        nextAction,
+      }) ?? updatedTask;
+  }
+
+  return updatedTask;
+}
+
+export async function runPublishJob(input: RunPublishJobInput): Promise<RunPublishJobResult> {
+  const syncStore = getSyncHistoryStore();
+  let syncTask = syncStore.getTask(input.syncTaskId);
+  if (!syncTask) {
+    throw new Error(`Sync task not found: ${input.syncTaskId}`);
+  }
+
+  try {
+    const results = await publishToPlatforms(
+      input.platforms,
+      input.title,
+      input.content,
+      input.platformDrafts,
+    );
+    syncTask = applyPublishResults(syncTask, results);
+    updateDraftFromTask(syncTask, input.clearScheduledAt);
+    return { syncTask, results };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '发布过程中发生未知错误';
+    const failedResults: PlatformPublishResult[] = input.platforms.map((platform) => ({
+      platform,
+      status: 'error',
+      message,
+    }));
+
+    syncTask = applyPublishResults(syncTask, failedResults);
+    updateDraftFromTask(syncTask, input.clearScheduledAt);
+    return { syncTask, results: failedResults };
+  }
+}

--- a/src/lib/scheduler/__tests__/checkDueDrafts.test.ts
+++ b/src/lib/scheduler/__tests__/checkDueDrafts.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getDraftRegistry, resetDraftRegistryForTests } from '@/lib/drafts/registry';
+import { checkDueDrafts } from '@/lib/scheduler/checkDueDrafts';
+import { runPublishJob } from '@/lib/publishers/publishJobRunner';
+import { resetSyncHistoryStoreForTests } from '@/lib/sync/registry';
+
+vi.mock('@/lib/publishers/publishJobRunner', () => ({
+  runPublishJob: vi.fn().mockResolvedValue({ syncTask: null, results: [] }),
+}));
+
+describe('checkDueDrafts', () => {
+  beforeEach(() => {
+    vi.mocked(runPublishJob).mockClear();
+    resetDraftRegistryForTests({
+      createId: () => 'draft-1',
+      now: () => '2026-05-09T10:00:00.000Z',
+    });
+    resetSyncHistoryStoreForTests({
+      createId: () => 'sync-1',
+      now: () => '2026-05-09T10:00:00.000Z',
+    });
+  });
+
+  test('marks due drafts syncing before running the shared publish job', async () => {
+    getDraftRegistry().createDraft({
+      title: '稿件标题',
+      content: '稿件正文',
+      source: 'manual',
+      scheduledAt: '2026-05-09T09:00:00.000Z',
+      platforms: ['wechat'],
+    });
+
+    await checkDueDrafts();
+    await checkDueDrafts();
+
+    expect(runPublishJob).toHaveBeenCalledTimes(1);
+    expect(runPublishJob).toHaveBeenCalledWith({
+      syncTaskId: 'sync-1',
+      title: '稿件标题',
+      content: '稿件正文',
+      platforms: ['wechat'],
+      clearScheduledAt: true,
+    });
+    expect(getDraftRegistry().getDraft('draft-1')).toMatchObject({
+      status: 'syncing',
+    });
+  });
+});

--- a/src/lib/scheduler/checkDueDrafts.ts
+++ b/src/lib/scheduler/checkDueDrafts.ts
@@ -1,12 +1,6 @@
 import { getDraftRegistry } from '@/lib/drafts/registry';
 import { getSyncHistoryStore } from '@/lib/sync/registry';
-import {
-  publishToPlatforms,
-  toSyncReceiptStatus,
-  inferFailureCode,
-  toNextAction,
-  toDraftStatus,
-} from '@/lib/publishers/executePublish';
+import { runPublishJob } from '@/lib/publishers/publishJobRunner';
 import type { PlatformId } from '@/types';
 
 export async function checkDueDrafts() {
@@ -28,38 +22,18 @@ export async function checkDueDrafts() {
 
     const platforms = draft.platforms as PlatformId[];
     const syncStore = getSyncHistoryStore();
-    let syncTask = syncStore.createTask({
+    const syncTask = syncStore.createTask({
       draftId: draft.id,
       title: draft.title,
       platforms,
     });
 
-    try {
-      const publishResults = await publishToPlatforms(platforms, draft.title, draft.content);
-
-      for (const result of publishResults) {
-        const receiptStatus = toSyncReceiptStatus(result);
-        const isFailed = receiptStatus === 'failed';
-        const failureCode = isFailed ? inferFailureCode(result.message) : undefined;
-        const nextAction = isFailed && failureCode ? toNextAction(failureCode) : undefined;
-
-        syncTask =
-          syncStore.updateReceipt(syncTask.id, result.platform, {
-            status: receiptStatus,
-            message: result.message,
-            url: result.url,
-            failureCode,
-            failureMessage: isFailed ? (result.message ?? '未知错误') : undefined,
-            nextAction,
-          }) ?? syncTask;
-      }
-
-      getDraftRegistry().updateDraft(draft.id, {
-        status: toDraftStatus(syncTask.status),
-        scheduledAt: undefined,
-      });
-    } catch {
-      getDraftRegistry().updateDraft(draft.id, { status: 'failed' });
-    }
+    await runPublishJob({
+      syncTaskId: syncTask.id,
+      title: draft.title,
+      content: draft.content,
+      platforms,
+      clearScheduledAt: true,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add a shared publish job runner for applying publish results to sync tasks and drafts
- route immediate publish, scheduled publish, and retry execution through the shared runner
- keep scheduled drafts marked syncing before execution so they are not picked up twice
- add regression tests for runner behavior and scheduled duplicate protection

## Verification
- pnpm test -- src/lib/publishers/__tests__/publishJobRunner.test.ts src/lib/scheduler/__tests__/checkDueDrafts.test.ts src/app/api/publish/__tests__/route.test.ts 'src/app/api/sync-tasks/[id]/retry/__tests__/route.test.ts'
- pnpm check:no-js-source
- pnpm build

Closes #41