### PR TITLE
Prevent JSON storage lost updates

### DIFF
--- a/src/lib/custom-prompts/store.ts
+++ b/src/lib/custom-prompts/store.ts
@@ -1,6 +1,6 @@
 import {
   readJsonFileCollection,
-  writeJsonFileCollection,
+  writeMergedJsonFileCollection,
 } from '@/lib/storage/jsonFileCollection';
 import { createLocalDataPath } from '@/lib/storage/localDataPath';
 import type { PlatformId } from '@/types';
@@ -18,7 +18,7 @@ function readAll(): CustomPrompt[] {
 }
 
 function writeAll(data: CustomPrompt[]) {
-  writeJsonFileCollection(PROMPTS_FILE, data);
+  writeMergedJsonFileCollection(PROMPTS_FILE, data, (prompt) => prompt.platform);
 }
 
 export function getCustomPrompt(platform: PlatformId | 'global'): string | undefined {

--- a/src/lib/drafts/__tests__/store.test.ts
+++ b/src/lib/drafts/__tests__/store.test.ts
@@ -136,6 +136,35 @@ describe('createDraftStore', () => {
     ]);
   });
 
+  test('preserves records written by another store instance', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'publio-drafts-'));
+    const storagePath = join(dataDir, 'drafts.json');
+
+    try {
+      const firstStore = createDraftStore({
+        createId: () => 'draft-1',
+        now: () => '2026-05-09T10:00:00.000Z',
+        storagePath,
+      });
+      const secondStore = createDraftStore({
+        createId: () => 'draft-2',
+        now: () => '2026-05-09T10:01:00.000Z',
+        storagePath,
+      });
+
+      firstStore.createDraft({ title: '第一篇', content: '正文', source: 'manual' });
+      secondStore.createDraft({ title: '第二篇', content: '正文', source: 'manual' });
+
+      const reader = createDraftStore({ storagePath });
+      expect(reader.listDrafts({ includeArchived: true }).map((draft) => draft.id)).toEqual([
+        'draft-2',
+        'draft-1',
+      ]);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   test('returns null when updating or archiving a missing draft', () => {
     const store = createDraftStore();
 

--- a/src/lib/drafts/store.ts
+++ b/src/lib/drafts/store.ts
@@ -5,7 +5,10 @@ import type {
   ListDraftsOptions,
   UpdateDraftInput,
 } from '@/lib/drafts/types';
-import { readJsonFileCollection, writeJsonFileCollection } from '@/lib/storage/jsonFileCollection';
+import {
+  readJsonFileCollection,
+  writeMergedJsonFileCollection,
+} from '@/lib/storage/jsonFileCollection';
 
 interface DraftStoreOptions {
   createId?: () => string;
@@ -37,7 +40,7 @@ export function createDraftStore(options: DraftStoreOptions = {}) {
 
   function persistDrafts() {
     if (!storagePath) return;
-    writeJsonFileCollection(storagePath, Array.from(drafts.values()));
+    writeMergedJsonFileCollection(storagePath, Array.from(drafts.values()), (draft) => draft.id);
   }
 
   return {

--- a/src/lib/metrics/store.ts
+++ b/src/lib/metrics/store.ts
@@ -1,6 +1,6 @@
 import {
   readJsonFileCollection,
-  writeJsonFileCollection,
+  writeMergedJsonFileCollection,
 } from '@/lib/storage/jsonFileCollection';
 import { createLocalDataPath } from '@/lib/storage/localDataPath';
 import type { SyncTaskMetrics, MetricsSummary } from './types';
@@ -12,7 +12,7 @@ function readAll(): SyncTaskMetrics[] {
 }
 
 function writeAll(data: SyncTaskMetrics[]) {
-  writeJsonFileCollection(METRICS_FILE, data);
+  writeMergedJsonFileCollection(METRICS_FILE, data, (metrics) => metrics.syncTaskId);
 }
 
 export function getMetricsStore() {
@@ -40,22 +40,13 @@ export function getMetricsStore() {
     getSummary(): MetricsSummary {
       const all = readAll();
       return {
-        totalViews: all.reduce(
-          (s, m) => s + m.platforms.reduce((ps, p) => ps + p.views, 0),
-          0,
-        ),
-        totalLikes: all.reduce(
-          (s, m) => s + m.platforms.reduce((ps, p) => ps + p.likes, 0),
-          0,
-        ),
+        totalViews: all.reduce((s, m) => s + m.platforms.reduce((ps, p) => ps + p.views, 0), 0),
+        totalLikes: all.reduce((s, m) => s + m.platforms.reduce((ps, p) => ps + p.likes, 0), 0),
         totalComments: all.reduce(
           (s, m) => s + m.platforms.reduce((ps, p) => ps + p.comments, 0),
           0,
         ),
-        totalShares: all.reduce(
-          (s, m) => s + m.platforms.reduce((ps, p) => ps + p.shares, 0),
-          0,
-        ),
+        totalShares: all.reduce((s, m) => s + m.platforms.reduce((ps, p) => ps + p.shares, 0), 0),
         postCount: all.length,
       };
     },

--- a/src/lib/storage/__tests__/localDataPath.test.ts
+++ b/src/lib/storage/__tests__/localDataPath.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { createLocalDataPath } from '@/lib/storage/localDataPath';
+import {
+  readJsonFileCollection,
+  writeJsonFileCollection,
+  writeMergedJsonFileCollection,
+} from '@/lib/storage/jsonFileCollection';
 
 describe('createLocalDataPath', () => {
   test('stores runtime data in the project local data directory by default', () => {
@@ -11,5 +19,31 @@ describe('createLocalDataPath', () => {
     expect(createLocalDataPath('sync-tasks.json', '/tmp/publio-data')).toBe(
       '/tmp/publio-data/sync-tasks.json',
     );
+  });
+});
+
+describe('json file collection writes', () => {
+  test('merges by key before writing to avoid stale snapshot overwrite', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'publio-json-'));
+    const filePath = join(dir, 'items.json');
+
+    try {
+      writeJsonFileCollection(filePath, [{ id: 'a', value: 1 }]);
+      writeMergedJsonFileCollection(
+        filePath,
+        [
+          { id: 'b', value: 2 },
+          { id: 'a', value: 3 },
+        ],
+        (item) => item.id,
+      );
+
+      expect(readJsonFileCollection<{ id: string; value: number }>(filePath)).toEqual([
+        { id: 'a', value: 3 },
+        { id: 'b', value: 2 },
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/storage/jsonFileCollection.ts
+++ b/src/lib/storage/jsonFileCollection.ts
@@ -25,3 +25,21 @@ export function writeJsonFileCollection<T>(filePath: string, values: T[]) {
   writeFileSync(tempPath, `${JSON.stringify(values, null, 2)}\n`, 'utf-8');
   renameSync(tempPath, filePath);
 }
+
+export function writeMergedJsonFileCollection<T>(
+  filePath: string,
+  values: T[],
+  getKey: (value: T) => string,
+) {
+  const latestValues = readJsonFileCollection<T>(filePath);
+  const merged = new Map<string, T>();
+
+  for (const value of latestValues) {
+    merged.set(getKey(value), value);
+  }
+  for (const value of values) {
+    merged.set(getKey(value), value);
+  }
+
+  writeJsonFileCollection(filePath, Array.from(merged.values()));
+}

--- a/src/lib/sync/store.ts
+++ b/src/lib/sync/store.ts
@@ -7,7 +7,10 @@ import type {
   SyncTaskStatus,
   UpdateSyncReceiptInput,
 } from '@/lib/sync/types';
-import { readJsonFileCollection, writeJsonFileCollection } from '@/lib/storage/jsonFileCollection';
+import {
+  readJsonFileCollection,
+  writeMergedJsonFileCollection,
+} from '@/lib/storage/jsonFileCollection';
 
 interface SyncHistoryStoreOptions {
   createId?: () => string;
@@ -65,7 +68,7 @@ export function createSyncHistoryStore(options: SyncHistoryStoreOptions = {}) {
 
   function persistTasks() {
     if (!storagePath) return;
-    writeJsonFileCollection(storagePath, Array.from(tasks.values()));
+    writeMergedJsonFileCollection(storagePath, Array.from(tasks.values()), (task) => task.id);
   }
 
   function appendEvent(task: SyncTask, event: Omit<SyncEvent, 'timestamp'>): SyncTask {


### PR DESCRIPTION
## Summary
- add keyed merge writes for JSON collections
- use merge writes for upsert-style draft, sync task, metrics, and custom prompt stores
- leave delete-capable stores on replacement writes to preserve delete semantics
- add regression coverage for stale snapshot writes from separate store instances

## Verification
- pnpm test -- src/lib/storage/__tests__/localDataPath.test.ts src/lib/drafts/__tests__/store.test.ts src/lib/sync/__tests__/store.test.ts src/lib/metrics/__tests__/fetchers.test.ts
- pnpm check:no-js-source
- pnpm build

Closes #44