### PR TITLE
Split settings page platform model

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -20,134 +20,21 @@ import SurfaceCard from '@/components/layout/SurfaceCard';
 import { getPlatformConnectionProfiles } from '@/lib/platformConnections/profiles';
 import type {
   PlatformConnectionMode,
-  PlatformConnectionStatus,
   PlatformConnectionRecord,
 } from '@/lib/platformConnections/types';
 import type { PlatformId } from '@/types';
 import { useToastStore } from '@/stores/toastStore';
-import { WechatIcon, XiaohongshuIcon, ZhihuIcon, XIcon } from '@/components/icons/PlatformIcons';
 import RssSourceManager from '@/components/settings/RssSourceManager';
 import PromptEditor from '@/components/settings/PromptEditor';
 import BrandProfileForm from '@/components/copilot/BrandProfileForm';
 import StyleProfile from '@/components/copilot/StyleProfile';
+import {
+  VERIFY_ONLY_PLATFORMS,
+  formatRelativeTime,
+  platformConfigs,
+  statusLabels,
+} from './platformSettings';
 import * as styles from './settings.css';
-
-interface PlatformConfig {
-  id: PlatformId;
-  name: string;
-  Icon: React.ComponentType<{ size?: number }>;
-  summary: string;
-  hint: React.ReactNode;
-  fields: {
-    key: string;
-    label: string;
-    type: 'text' | 'password' | 'textarea';
-    placeholder: string;
-  }[];
-}
-
-const platformConfigs: PlatformConfig[] = [
-  {
-    id: 'wechat',
-    name: '微信公众号',
-    Icon: WechatIcon,
-    summary: '文章分发与公众号素材投递',
-    hint: (
-      <>
-        前往 <code className={styles.inlineCode}>mp.weixin.qq.com</code> → 开发 → 基本配置，获取
-        AppID 和 AppSecret
-      </>
-    ),
-    fields: [
-      { key: 'WECHAT_APP_ID', label: 'App ID', type: 'text', placeholder: '输入微信公众号 App ID' },
-      {
-        key: 'WECHAT_APP_SECRET',
-        label: 'App Secret',
-        type: 'password',
-        placeholder: '输入微信公众号 App Secret',
-      },
-    ],
-  },
-  {
-    id: 'xiaohongshu',
-    name: '小红书',
-    Icon: XiaohongshuIcon,
-    summary: '图文分发与笔记发布通道',
-    hint: '前往小红书开放平台注册开发者账号并创建应用',
-    fields: [
-      { key: 'XHS_APP_ID', label: 'App ID', type: 'text', placeholder: '输入小红书 App ID' },
-      {
-        key: 'XHS_APP_SECRET',
-        label: 'App Secret',
-        type: 'password',
-        placeholder: '输入小红书 App Secret',
-      },
-      {
-        key: 'XHS_ACCESS_TOKEN',
-        label: 'Access Token',
-        type: 'password',
-        placeholder: '输入小红书 Access Token（可选，授权后自动写入）',
-      },
-    ],
-  },
-  {
-    id: 'zhihu',
-    name: '知乎',
-    Icon: ZhihuIcon,
-    summary: '长文转载与问答场景投递',
-    hint: '使用浏览器登录知乎后，在开发者工具的 Network 面板中复制 Cookie',
-    fields: [
-      {
-        key: 'ZHIHU_COOKIE',
-        label: 'Cookie',
-        type: 'textarea',
-        placeholder: '从浏览器开发者工具中复制知乎的 Cookie',
-      },
-    ],
-  },
-  {
-    id: 'x',
-    name: 'X (Twitter)',
-    Icon: XIcon,
-    summary: '短帖同步与外部扩散',
-    hint: (
-      <>
-        前往 <code className={styles.inlineCode}>developer.x.com</code> 创建项目并生成 API Keys 和
-        Access Tokens
-      </>
-    ),
-    fields: [
-      { key: 'X_API_KEY', label: 'API Key', type: 'text', placeholder: '输入 X API Key' },
-      {
-        key: 'X_API_SECRET',
-        label: 'API Secret',
-        type: 'password',
-        placeholder: '输入 X API Secret',
-      },
-      {
-        key: 'X_ACCESS_TOKEN',
-        label: 'Access Token',
-        type: 'text',
-        placeholder: '输入 X Access Token',
-      },
-      {
-        key: 'X_ACCESS_TOKEN_SECRET',
-        label: 'Access Token Secret',
-        type: 'password',
-        placeholder: '输入 X Access Token Secret',
-      },
-    ],
-  },
-];
-
-// 这些平台不走 OAuth 重定向，直接调 check 验证凭证
-const VERIFY_ONLY_PLATFORMS = new Set<PlatformId>(['wechat', 'x']);
-
-const statusLabels: Record<PlatformConnectionStatus, string> = {
-  connected: '已连接',
-  available: '可授权',
-  'manual-required': '需配置',
-};
 
 interface CheckState {
   checking: boolean;
@@ -160,16 +47,6 @@ interface CheckState {
 interface DisconnectState {
   disconnecting: boolean;
   done?: boolean;
-}
-
-function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return '刚刚';
-  if (minutes < 60) return `${minutes} 分钟前`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours} 小时前`;
-  return `${Math.floor(hours / 24)} 天前`;
 }
 
 function SettingsContent() {

--- a/src/app/settings/platformSettings.tsx
+++ b/src/app/settings/platformSettings.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from 'react';
+import { WechatIcon, XiaohongshuIcon, ZhihuIcon, XIcon } from '@/components/icons/PlatformIcons';
+import type { PlatformConnectionStatus } from '@/lib/platformConnections/types';
+import type { PlatformId } from '@/types';
+import * as styles from './settings.css';
+
+export interface PlatformConfig {
+  id: PlatformId;
+  name: string;
+  Icon: React.ComponentType<{ size?: number }>;
+  summary: string;
+  hint: ReactNode;
+  fields: {
+    key: string;
+    label: string;
+    type: 'text' | 'password' | 'textarea';
+    placeholder: string;
+  }[];
+}
+
+export const platformConfigs: PlatformConfig[] = [
+  {
+    id: 'wechat',
+    name: '微信公众号',
+    Icon: WechatIcon,
+    summary: '文章分发与公众号素材投递',
+    hint: (
+      <>
+        前往 <code className={styles.inlineCode}>mp.weixin.qq.com</code> → 开发 → 基本配置，获取
+        AppID 和 AppSecret
+      </>
+    ),
+    fields: [
+      { key: 'WECHAT_APP_ID', label: 'App ID', type: 'text', placeholder: '输入微信公众号 App ID' },
+      {
+        key: 'WECHAT_APP_SECRET',
+        label: 'App Secret',
+        type: 'password',
+        placeholder: '输入微信公众号 App Secret',
+      },
+    ],
+  },
+  {
+    id: 'xiaohongshu',
+    name: '小红书',
+    Icon: XiaohongshuIcon,
+    summary: '图文分发与笔记发布通道',
+    hint: '前往小红书开放平台注册开发者账号并创建应用',
+    fields: [
+      { key: 'XHS_APP_ID', label: 'App ID', type: 'text', placeholder: '输入小红书 App ID' },
+      {
+        key: 'XHS_APP_SECRET',
+        label: 'App Secret',
+        type: 'password',
+        placeholder: '输入小红书 App Secret',
+      },
+      {
+        key: 'XHS_ACCESS_TOKEN',
+        label: 'Access Token',
+        type: 'password',
+        placeholder: '输入小红书 Access Token（可选，授权后自动写入）',
+      },
+    ],
+  },
+  {
+    id: 'zhihu',
+    name: '知乎',
+    Icon: ZhihuIcon,
+    summary: '长文转载与问答场景投递',
+    hint: '使用浏览器登录知乎后，在开发者工具的 Network 面板中复制 Cookie',
+    fields: [
+      {
+        key: 'ZHIHU_COOKIE',
+        label: 'Cookie',
+        type: 'textarea',
+        placeholder: '从浏览器开发者工具中复制知乎的 Cookie',
+      },
+    ],
+  },
+  {
+    id: 'x',
+    name: 'X (Twitter)',
+    Icon: XIcon,
+    summary: '短帖同步与外部扩散',
+    hint: (
+      <>
+        前往 <code className={styles.inlineCode}>developer.x.com</code> 创建项目并生成 API Keys 和
+        Access Tokens
+      </>
+    ),
+    fields: [
+      { key: 'X_API_KEY', label: 'API Key', type: 'text', placeholder: '输入 X API Key' },
+      {
+        key: 'X_API_SECRET',
+        label: 'API Secret',
+        type: 'password',
+        placeholder: '输入 X API Secret',
+      },
+      {
+        key: 'X_ACCESS_TOKEN',
+        label: 'Access Token',
+        type: 'text',
+        placeholder: '输入 X Access Token',
+      },
+      {
+        key: 'X_ACCESS_TOKEN_SECRET',
+        label: 'Access Token Secret',
+        type: 'password',
+        placeholder: '输入 X Access Token Secret',
+      },
+    ],
+  },
+];
+
+export const VERIFY_ONLY_PLATFORMS = new Set<PlatformId>(['wechat', 'x']);
+
+export const statusLabels: Record<PlatformConnectionStatus, string> = {
+  connected: '已连接',
+  available: '可授权',
+  'manual-required': '需配置',
+};
+
+export function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  return `${Math.floor(hours / 24)} 天前`;
+}


### PR DESCRIPTION
## Summary
- move platform settings metadata, verify-only platform set, status labels, and relative-time formatting out of the settings page
- keep existing settings page state flow and UI behavior unchanged
- reduce the page component size and create a clearer boundary for later section extraction

## Verification
- pnpm test -- src/app/settings/page.tsx
- pnpm check:no-js-source
- pnpm lint

Build note: pnpm build was not rerun for this branch because the environment blocked the required network step for Google Fonts after the usage limit was reached.

Closes #46