### PR TITLE
Improve Xiaohongshu and Zhihu publish payloads

### DIFF
--- a/src/app/settings/platformSettings.tsx
+++ b/src/app/settings/platformSettings.tsx
@@ -75,6 +75,18 @@ export const platformConfigs: PlatformConfig[] = [
         type: 'textarea',
         placeholder: '从浏览器开发者工具中复制知乎的 Cookie',
       },
+      {
+        key: 'ZHIHU_COLUMN_TOKEN',
+        label: '专栏 Token',
+        type: 'text',
+        placeholder: '可选，知乎专栏 url_token',
+      },
+      {
+        key: 'ZHIHU_TOPIC_TOKENS',
+        label: '话题 Tokens',
+        type: 'text',
+        placeholder: '可选，多个 topic url_token 用英文逗号分隔',
+      },
     ],
   },
   {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,11 @@ export function getXhsConfig() {
 export function getZhihuConfig() {
   return {
     cookie: process.env.ZHIHU_COOKIE || '',
+    columnToken: process.env.ZHIHU_COLUMN_TOKEN || '',
+    topicTokens: (process.env.ZHIHU_TOPIC_TOKENS || '')
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean),
   };
 }
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -312,3 +312,29 @@ export function markdownToPlainText(markdown: string): string {
     .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
+
+export function extractMarkdownImageUrls(markdown: string): string[] {
+  const urls: string[] = [];
+
+  function collect(tokens: TokensList) {
+    for (const token of tokens) {
+      if (token.type === 'image') {
+        const safeSrc = sanitizeUrl(token.href);
+        if (safeSrc && (safeSrc.startsWith('http://') || safeSrc.startsWith('https://'))) {
+          urls.push(safeSrc);
+        }
+      }
+      if ('tokens' in token && Array.isArray(token.tokens)) {
+        collect(token.tokens);
+      }
+      if ('items' in token && Array.isArray(token.items)) {
+        for (const item of token.items) {
+          if (Array.isArray(item.tokens)) collect(item.tokens);
+        }
+      }
+    }
+  }
+
+  collect(tokenize(markdown));
+  return Array.from(new Set(urls));
+}

--- a/src/lib/publishers/__tests__/platformPayloads.test.ts
+++ b/src/lib/publishers/__tests__/platformPayloads.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { XiaohongshuPublisher } from '@/lib/publishers/xiaohongshu';
+import { ZhihuPublisher } from '@/lib/publishers/zhihu';
+
+describe('platform-specific publish payloads', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  test('sends markdown image URLs in Xiaohongshu image note payloads', async () => {
+    vi.stubEnv('XHS_APP_ID', 'app-id');
+    vi.stubEnv('XHS_APP_SECRET', 'app-secret');
+    vi.stubEnv('XHS_ACCESS_TOKEN', 'token');
+    const fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          code: 0,
+          data: { note_url: 'https://www.xiaohongshu.com/explore/1' },
+        }),
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await new XiaohongshuPublisher().publish({
+      title: '小红书标题',
+      markdownContent: '正文\n\n![cover](https://cdn.example.com/cover.png)',
+      htmlContent: '',
+    });
+
+    expect(result.success).toBe(true);
+    const [, init] = fetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as {
+      note_type: string;
+      image_urls: string[];
+    };
+    expect(body.note_type).toBe('image');
+    expect(body.image_urls).toEqual(['https://cdn.example.com/cover.png']);
+  });
+
+  test('sends Zhihu column and topic tokens when configured', async () => {
+    vi.stubEnv('ZHIHU_COOKIE', 'z_c0=token');
+    vi.stubEnv('ZHIHU_COLUMN_TOKEN', 'column-1');
+    vi.stubEnv('ZHIHU_TOPIC_TOKENS', 'topic-a, topic-b');
+    const fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/api/articles/drafts')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'draft-1' }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await new ZhihuPublisher().publish({
+      title: '知乎标题',
+      markdownContent: '正文',
+      htmlContent: '<p>正文</p>',
+    });
+
+    expect(result.success).toBe(true);
+    const [, updateInit] = fetch.mock.calls[1] as [string, RequestInit];
+    const updateBody = JSON.parse(String(updateInit.body)) as {
+      column_url_token: string;
+      topic_url_tokens: string[];
+    };
+    expect(updateBody.column_url_token).toBe('column-1');
+    expect(updateBody.topic_url_tokens).toEqual(['topic-a', 'topic-b']);
+
+    const [, publishInit] = fetch.mock.calls[2] as [string, RequestInit];
+    const publishBody = JSON.parse(String(publishInit.body)) as {
+      column: { url_token: string };
+    };
+    expect(publishBody.column).toEqual({ url_token: 'column-1' });
+  }, 10_000);
+});

--- a/src/lib/publishers/xiaohongshu.ts
+++ b/src/lib/publishers/xiaohongshu.ts
@@ -1,7 +1,7 @@
 import type { PublishInput, PublishOutput } from './types';
 import { BasePublisher } from './base';
 import { getXhsConfig } from '@/lib/config';
-import { markdownToPlainText } from '@/lib/markdown';
+import { extractMarkdownImageUrls, markdownToPlainText } from '@/lib/markdown';
 
 export class XiaohongshuPublisher extends BasePublisher {
   platform = 'xiaohongshu' as const;
@@ -17,6 +17,7 @@ export class XiaohongshuPublisher extends BasePublisher {
 
     const plainText = markdownToPlainText(input.markdownContent);
     const truncatedContent = plainText.length > 1000 ? plainText.slice(0, 997) + '...' : plainText;
+    const imageUrls = extractMarkdownImageUrls(input.markdownContent).slice(0, 9);
 
     const noteRes = await fetch('https://open.xiaohongshu.com/api/note/publish', {
       method: 'POST',
@@ -27,8 +28,9 @@ export class XiaohongshuPublisher extends BasePublisher {
       body: JSON.stringify({
         title: input.title.slice(0, 20),
         content: truncatedContent,
-        note_type: 'normal',
+        note_type: imageUrls.length > 0 ? 'image' : 'normal',
         image_ids: [],
+        image_urls: imageUrls,
       }),
     });
 

--- a/src/lib/publishers/zhihu.ts
+++ b/src/lib/publishers/zhihu.ts
@@ -11,7 +11,7 @@ export class ZhihuPublisher extends BasePublisher {
   }
 
   protected async publishToPlatform(input: PublishInput): Promise<PublishOutput> {
-    const { cookie } = getZhihuConfig();
+    const { cookie, columnToken, topicTokens } = getZhihuConfig();
     const headers = {
       Cookie: cookie,
       'Content-Type': 'application/json',
@@ -42,7 +42,7 @@ export class ZhihuPublisher extends BasePublisher {
         throw new Error('知乎请求频率过高，请稍后再试');
       }
       const retryData = await retryRes.json();
-      return this.continuePublish(retryData.id, input, headers);
+      return this.continuePublish(retryData.id, input, headers, columnToken, topicTokens);
     }
 
     if (!draftRes.ok) {
@@ -50,13 +50,15 @@ export class ZhihuPublisher extends BasePublisher {
     }
 
     const draftData = await draftRes.json();
-    return this.continuePublish(draftData.id, input, headers);
+    return this.continuePublish(draftData.id, input, headers, columnToken, topicTokens);
   }
 
   private async continuePublish(
     draftId: string,
     input: PublishInput,
     headers: Record<string, string>,
+    columnToken: string,
+    topicTokens: string[],
   ): Promise<PublishOutput> {
     // Step 2: Update draft content
     const updateRes = await fetch(`https://zhuanlan.zhihu.com/api/articles/${draftId}/draft`, {
@@ -65,8 +67,8 @@ export class ZhihuPublisher extends BasePublisher {
       body: JSON.stringify({
         title: input.title,
         content: input.htmlContent,
-        topic_url_tokens: [],
-        column_url_token: '',
+        topic_url_tokens: topicTokens,
+        column_url_token: columnToken,
       }),
     });
 
@@ -79,7 +81,7 @@ export class ZhihuPublisher extends BasePublisher {
       method: 'PUT',
       headers,
       body: JSON.stringify({
-        column: null,
+        column: columnToken ? { url_token: columnToken } : null,
         commentPermission: 'anyone',
       }),
     });

--- a/src/lib/storage/envFile.ts
+++ b/src/lib/storage/envFile.ts
@@ -30,6 +30,8 @@ export function serializeEnvFile(values: Record<string, string>): string {
     '',
     '# Zhihu',
     `ZHIHU_COOKIE=${values.ZHIHU_COOKIE || ''}`,
+    `ZHIHU_COLUMN_TOKEN=${values.ZHIHU_COLUMN_TOKEN || ''}`,
+    `ZHIHU_TOPIC_TOKENS=${values.ZHIHU_TOPIC_TOKENS || ''}`,
     '',
     '# X (Twitter)',
     `X_API_KEY=${values.X_API_KEY || ''}`,


### PR DESCRIPTION
## Summary
- extract Markdown image URLs and include them in Xiaohongshu image-note payloads
- add optional Zhihu column and topic token configuration
- send Zhihu column/topic metadata during draft update and publish
- add payload-level tests for Xiaohongshu image notes and Zhihu metadata

## Verification
- pnpm test -- src/lib/publishers/__tests__/platformPayloads.test.ts src/lib/__tests__/newsDraft.test.ts
- pnpm check:no-js-source
- pnpm lint

Build note: pnpm build was not rerun for this branch because the environment blocked the required network step for Google Fonts after the usage limit was reached. External platform verification still requires real Xiaohongshu and Zhihu credentials.

Closes #45