### PR TITLE
ci: enable tsc --noEmit type check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
-      # TODO: enable after fixing existing type errors
-      # - name: Type check
-      #   run: pnpm tsc --noEmit
+      - name: Type check
+        run: pnpm tsc --noEmit
 
   test:
     name: Test

--- a/src/app/api/briefs/__tests__/route.test.ts
+++ b/src/app/api/briefs/__tests__/route.test.ts
@@ -60,6 +60,7 @@ describe('/api/briefs', () => {
     topicStore.createTopic({ title: '测试选题', signalIds: ['sig-1'] });
     signalStore.createSignal({
       title: '测试信号',
+      summary: '测试信号概述',
       sourceType: 'rss',
       sourceId: 'src-1',
       url: 'https://example.com/signal',

--- a/src/app/api/publish/__tests__/route.test.ts
+++ b/src/app/api/publish/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
 
 import { resetDraftRegistryForTests } from '@/lib/drafts/registry';
 import { resetSyncHistoryStoreForTests } from '@/lib/sync/registry';
@@ -34,7 +35,7 @@ vi.mock('@/lib/publishers/x', () => ({
 }));
 
 function createJsonRequest(body: unknown) {
-  return new Request('http://localhost/api/publish', {
+  return new NextRequest('http://localhost/api/publish', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),

--- a/src/components/publish/__tests__/PlatformPreviewPanel.test.tsx
+++ b/src/components/publish/__tests__/PlatformPreviewPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 

--- a/src/components/publish/__tests__/PublishButton.test.tsx
+++ b/src/components/publish/__tests__/PublishButton.test.tsx
@@ -51,7 +51,7 @@ describe('PublishButton', () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledTimes(2);
     });
-    const publishCall = fetch.mock.calls.find(([url]: [string]) => url === '/api/publish') as [
+    const publishCall = fetch.mock.calls.find((call) => call[0] === '/api/publish') as [
       string,
       RequestInit,
     ];

--- a/src/components/sync/__tests__/SyncTaskDetail.test.tsx
+++ b/src/components/sync/__tests__/SyncTaskDetail.test.tsx
@@ -45,6 +45,7 @@ describe('SyncTaskDetail', () => {
       status: 'partial',
       createdAt: '2026-04-11T00:00:00.000Z',
       updatedAt: '2026-04-11T00:00:00.000Z',
+      events: [],
       receipts: [
         {
           platform: 'wechat',

--- a/src/components/sync/__tests__/SyncTaskList.test.tsx
+++ b/src/components/sync/__tests__/SyncTaskList.test.tsx
@@ -34,6 +34,7 @@ describe('SyncTaskList', () => {
         status: 'needs-action',
         createdAt: '2026-04-11T08:00:00.000Z',
         updatedAt: '2026-04-11T08:05:00.000Z',
+        events: [],
         receipts: [
           {
             platform: 'xiaohongshu',

--- a/src/lib/agent/contextBuilder.test.ts
+++ b/src/lib/agent/contextBuilder.test.ts
@@ -18,6 +18,7 @@ function makeSignal(overrides: Partial<Signal> = {}): Signal {
     capturedAt: '2026-05-10T00:00:00.000Z',
     status: 'new',
     tags: ['AI'],
+    score: { freshness: 80, relevance: 70, credibility: 85, writingPotential: 75, audienceFit: 60 },
     createdAt: '2026-05-10T00:00:00.000Z',
     updatedAt: '2026-05-10T00:00:00.000Z',
     ...overrides,
@@ -28,9 +29,14 @@ function makeTopic(overrides: Partial<Topic> = {}): Topic {
   return {
     id: 'topic-1',
     title: '大模型落地',
+    angle: '',
+    summary: '',
     signalIds: ['sig-1'],
-    status: 'active',
+    status: 'idea',
     tags: ['AI'],
+    recommendedPlatforms: [],
+    writingValue: 0,
+    urgency: 0,
     createdAt: '2026-05-10T00:00:00.000Z',
     updatedAt: '2026-05-10T00:00:00.000Z',
     ...overrides,
@@ -47,6 +53,7 @@ function makeBrief(overrides: Partial<Brief> = {}): Brief {
     tone: '专业',
     outline: [{ heading: '引言', purpose: '铺垫', evidenceSignalIds: [] }],
     sourceLinks: [{ title: '来源A', url: 'https://a.com' }],
+    platformPlan: [],
     createdAt: '2026-05-10T00:00:00.000Z',
     updatedAt: '2026-05-10T00:00:00.000Z',
     ...overrides,
@@ -58,7 +65,7 @@ function makeDraft(overrides: Partial<ContentDraft> = {}): ContentDraft {
     id: 'draft-1',
     title: '测试稿件',
     content: '稿件正文内容',
-    status: 'editing',
+    status: 'draft',
     source: 'manual',
     createdAt: '2026-05-10T00:00:00.000Z',
     updatedAt: '2026-05-10T00:00:00.000Z',
@@ -144,7 +151,7 @@ describe('formatAgentContext', () => {
     expect(text).toContain('选题：话题A');
     expect(text).toContain('角度：技术落地');
     expect(text).toContain('核心观点：核心观点');
-    expect(text).toContain('稿件[editing]：测试稿件');
+    expect(text).toContain('稿件[draft]：测试稿件');
   });
 
   test('handles empty context', () => {

--- a/src/lib/ai-news/__tests__/requestTimeout.test.ts
+++ b/src/lib/ai-news/__tests__/requestTimeout.test.ts
@@ -4,7 +4,7 @@ import { fetchTextWithTimeout } from '@/lib/ai-news/requestTimeout';
 
 describe('fetchTextWithTimeout', () => {
   test('上游请求长期不返回时会在超时后尽快失败', async () => {
-    const fetchMock = vi.fn(() => new Promise(() => undefined));
+    const fetchMock = vi.fn(() => new Promise(() => undefined)) as unknown as typeof fetch;
 
     await expect(
       fetchTextWithTimeout('https://example.com/feed.xml', {

--- a/src/lib/ai-news/__tests__/research.test.ts
+++ b/src/lib/ai-news/__tests__/research.test.ts
@@ -50,7 +50,6 @@ function createScoredCluster(overrides: Partial<ScoredAiNewsCluster>): ScoredAiN
     coverageCount: overrides.coverageCount ?? 2,
     officialSourceCount: overrides.officialSourceCount ?? 1,
     mediaSourceCount: overrides.mediaSourceCount ?? 1,
-    creatorSourceCount: overrides.creatorSourceCount ?? 0,
     scores: overrides.scores ?? {
       freshness: 88,
       impact: 84,

--- a/src/lib/ai-news/__tests__/score.test.ts
+++ b/src/lib/ai-news/__tests__/score.test.ts
@@ -67,7 +67,6 @@ function createCluster(overrides: Partial<AiNewsCluster>): AiNewsCluster {
     coverageCount: overrides.coverageCount ?? 2,
     officialSourceCount: overrides.officialSourceCount ?? 1,
     mediaSourceCount: overrides.mediaSourceCount ?? 1,
-    creatorSourceCount: overrides.creatorSourceCount ?? 1,
   };
 }
 


### PR DESCRIPTION
## Summary

- Fix 20 TypeScript type errors in 8 test files (mock objects missing required fields, invalid enum values, wrong types)
- Uncomment `tsc --noEmit` step in CI lint job so type regressions are caught on every PR

## Changes

| File | Fix |
|------|-----|
| `SyncTaskDetail.test.tsx` / `SyncTaskList.test.tsx` | Add missing `events: []` |
| `contextBuilder.test.ts` | Add `score`, fix `status` enums, add required Topic/Brief fields |
| `briefs/route.test.ts` | Add `summary` to `createSignal` call |
| `publish/route.test.ts` | Use `NextRequest` instead of `Request` |
| `PlatformPreviewPanel.test.tsx` | Add `vi` to vitest import |
| `PublishButton.test.tsx` | Fix `.find()` callback typing |
| `requestTimeout.test.ts` | Cast mock as `typeof fetch` |
| `research.test.ts` / `score.test.ts` | Remove non-existent `creatorSourceCount` |
| `ci.yml` | Uncomment type check step |

## Test plan

- [x] `pnpm tsc --noEmit` passes locally (0 errors)
- [x] `pnpm test` — 332 tests passing
- [ ] CI passes on this PR