### PR TITLE
docs: rewrite README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,312 +6,76 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)
 [![Next.js](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
-[![Tests](https://img.shields.io/badge/tests-332%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-332%20passing-brightgreen.svg)](#development)
 
 > AI-native content operations platform. Write once, publish everywhere.
 
-Publio is a multi-platform content distribution tool that consolidates Markdown editing, AI-powered topic discovery, content adaptation, and one-click publishing into a unified workspace. It supports WeChat Official Account, Xiaohongshu, Zhihu, and X (Twitter).
-
----
-
-## Features
-
-### Content Workflow
-
-Publio's core workflow follows the full lifecycle of content creation:
-
-1. **Signal Inbox** — Ingest news signals from RSS feeds, manually add or AI-discover
-2. **Topic Library** — Promote signals to tracked topics with lifecycle management (active → dormant → archived)
-3. **Writing Brief** — Structured brief per topic: thesis, outline, platform publishing plan
-4. **Writing Desk** — Markdown editor with AI writing assistance, slash commands, auto-save
-5. **Platform Variants** — Per-platform content versions (synced, AI-adapted, or manually edited)
-6. **Multi-Platform Publish** — Concurrent publish with progress tracking and scheduled delivery
-7. **Feedback Loop** — Post-publish metrics → AI review → learnings → feed back into recommendations
-
-### Writing Desk
-
-- **Rich Markdown editor** with desktop live-preview and mobile fallback
-- **WYSIWYG mode** — toggle between source editing and side-by-side live preview
-- **Immersive writing mode** — full-screen distraction-free editing with centered 720px layout
-- **Auto-save** with 1-second debounce and automatic draft creation
-- **Editorial context panel** — title status, structural statistics, publishability signals
-- **Slash commands** — `/ai-expand`, `/ai-condense`, `/ai-rewrite`, `/ai-polish`, `/ai-continue`
-- **Version history** — auto-snapshot on title/content changes with restore capability
-- **Content templates** — 6 built-in templates plus custom template CRUD
-- **GitHub image bed** — upload images to GitHub repo as persistent hosting
-
-### AI Agent System
-
-All AI features require an OpenAI-compatible API (Zhipu GLM, DeepSeek, Qwen, OpenAI, Ollama, etc.). Gracefully degrades when unconfigured.
-
-| Capability | Description |
-|-----------|-------------|
-| **Writing Assistant** | Expand, condense, rewrite, polish, continue — via slash commands with streaming output |
-| **Platform Adaptation** | Per-platform content rewrite with rule injection and change summary explaining adaptation decisions |
-| **Topic Research** | Deep analysis of news clusters with multi-angle insights |
-| **Signal Review** | AI-powered inbox triage: surfaces high-value signals, suggests combinations, recommends actions |
-| **Topic Writing Pack** | Generates structured writing packs (background, facts, angles, audience, counter-arguments, structure) |
-| **Brief Assist** | Generate full Brief from topic, rewrite thesis, fill outline, generate platform plan |
-| **Publish Diagnose** | Structured failure diagnosis (root cause, evidence, fix steps, retry recommendation) with event timeline context |
-| **Content Copilot** | Brand profile-driven topic recommendations based on current news trends |
-| **Style Learning** | Extracts writing style from historical drafts and injects into prompts |
-| **Multi-turn Chat** | Conversational AI panel with session-persistent history |
-
-### AI News Desk
-
-- Aggregates RSS feeds from 9+ built-in sources plus custom user-defined sources
-- **Signal Inbox** — triage incoming signals (pin, dismiss, promote to topic)
-- **Topic Library** — manage topics with lifecycle states, link to briefs, track performance
-- Topic clustering, 6-dimension scoring (freshness, impact, momentum, credibility, visual-readiness, coverage)
-- Research brief per cluster with what happened, why it matters, who is affected, recommended angles
-- One-click conversion to editor draft with research context embedded
-
-### Multi-Platform Publishing
-
-- Concurrent publish via `Promise.allSettled` across all selected platforms
-- **Platform Variants** — each platform gets an independent content version (synced from main draft, AI-adapted, or manually edited)
-- **Variant status tracking** — synced / adapted / edited / checked / scheduled / published
-- **Content moderation** — sensitive word detection with pre-publish warning dialog
-- **Platform validation** — automatic rule checking (title length, content limits, format constraints)
-- **Publish progress overlay** — real-time status polling with per-platform receipts
-- **Sync task tracking** — failure diagnosis, smart retry, manual mark-done
-- **Scheduled publish** — backend cron-based execution with persistent task queue
-- **Post-publish metrics** — views, likes, comments, shares aggregated in analytics dashboard with per-task and bulk refresh
-
-### Content Feedback Loop
-
-- **Feedback storage** — structured feedback per draft/variant/topic with learnings and next-actions
-- **AI review agent** — generates performance summary, effective factors, issues, and actionable suggestions
-- **Analytics insights** — per-platform and per-topic aggregation tables, top performers, review candidates
-- **Feedback-driven recommendations** — topic library shows historical performance; low-performing topics get risk hints rather than suppression; writing briefs surface related feedback; AI recommendations include recent performance context
-
-### Content Calendar
-
-- Monthly view with event display for drafts, scheduled, published, and failed items
-- Click-through navigation to editor or sync task detail
-
-### Today's Workbench
-
-- Unified dashboard showing pending items across all workflow stages
-- Pending signals, active topics, incomplete briefs, draft-ready variants, in-progress tasks
-- Direct action links to jump into each workflow
-
-### Data Management
-
-- **Auto-migration** — schema versioning with automatic backup before structural changes
-- **Workspace export/import** — export all entities (signals, topics, briefs, drafts, variants, tasks, feedback) as JSON bundle; import with dry-run preview and merge semantics
-
-### Settings & Configuration
-
-- Platform credential management with OAuth flow and connection verification
-- AI Agent configuration (base URL, API key, model) with hot-reload
-- Custom RSS feed source management
-- Custom AI prompt editor (per-platform and global)
-- Brand profile configuration for content copilot
-- Writing style profile with auto-analysis from historical drafts
-
-### Design System
-
-- **Theme toggle** — light / dark / system preference with localStorage persistence
-- **Design tokens** — spacing, typography, color, radius with WCAG AA compliant contrast
-- **Responsive layout** — desktop sidebar navigation, adaptive content areas
+- **Full lifecycle workflow** — from topic discovery to post-publish review, all in one workspace
+- **AI-powered writing** — expand, condense, rewrite, polish, continue via slash commands with streaming output
+- **Multi-platform publish** — concurrent delivery to WeChat, Xiaohongshu, Zhihu, and X (Twitter)
+- **Provider-agnostic AI** — works with any OpenAI-compatible API (GLM, DeepSeek, Qwen, OpenAI, Ollama)
 
 ---
 
 ## Quick Start
 
-### Prerequisites
-
-- Node.js >= 18
-- pnpm
-
-### Installation
-
 ```bash
 git clone https://github.com/rogerdigital/publio.git
 cd publio
 pnpm install
-pnpm dev                      # starts with port cleanup and cache clearing
+pnpm dev
 ```
 
-Configure platform credentials and AI agent in Settings (`/settings`) after first launch.
+Open http://localhost:3000. Configure platform credentials and AI agent in Settings (`/settings`).
 
-`pnpm dev` automatically kills stale Next.js processes and clears `.next/cache`. Use `pnpm run dev:raw` to skip cleanup.
+---
 
-Open http://localhost:3000.
+## Workflow
 
-### Commands
+**Signal Inbox** → **Topic Library** → **Writing Brief** → **Writing Desk** → **Platform Variants** → **Publish** → **Feedback Loop**
 
-```bash
-pnpm dev              # development mode (with port cleanup)
-pnpm build            # production build
-pnpm start            # production server
-pnpm preview           # build + start
-pnpm test             # run tests (Vitest)
-pnpm lint             # ESLint
-pnpm format           # Prettier format all files
-pnpm verify           # lint + test + build
-```
+Each stage feeds the next. Signals are promoted to topics, topics get structured briefs, briefs guide drafts, drafts are adapted per-platform, published concurrently, and post-publish metrics feed back into recommendations.
+
+---
+
+## Features
+
+### Writing Desk
+
+Rich Markdown editor with live preview, immersive full-screen mode, auto-save, slash commands for AI writing assistance, version history with restore, and content templates. GitHub image bed for persistent image hosting.
+
+### AI Agent System
+
+Writing assistant (5 slash commands), platform content adaptation, topic research with multi-angle insights, signal inbox triage, structured writing packs, brief generation, publish failure diagnosis, content review, and style learning from historical drafts. All streaming, all optional.
+
+### Multi-Platform Publishing
+
+Concurrent publish with progress tracking. Each platform gets an independent content variant — synced, AI-adapted, or manually edited. Includes content moderation, platform validation rules, scheduled delivery, failure diagnosis with smart retry, and post-publish metrics aggregation.
+
+### Topic Discovery
+
+Aggregates 9+ RSS sources plus custom feeds. Signal inbox with triage actions, topic library with lifecycle management, 6-dimension scoring, research briefs per cluster, and one-click conversion to editor drafts with context embedded.
 
 ---
 
 ## Configuration
 
-### Platform Credentials
-
-Managed via `.env.local` or the Settings page at runtime:
-
-| Platform | Variables | Source |
-|----------|-----------|--------|
-| WeChat | `WECHAT_APP_ID`, `WECHAT_APP_SECRET` | [mp.weixin.qq.com](https://mp.weixin.qq.com/) > Development > Basic Config |
-| Xiaohongshu | `XHS_APP_ID`, `XHS_APP_SECRET`, `XHS_ACCESS_TOKEN` | [Xiaohongshu Open Platform](https://open.xiaohongshu.com/) |
-| Zhihu | `ZHIHU_COOKIE` | Browser DevTools > Network > copy Cookie |
-| X (Twitter) | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` | [developer.x.com](https://developer.x.com/) |
-
-### AI Agent (Optional)
-
-All three required to activate AI features:
-
-| Variable | Description |
-|----------|-------------|
-| `AGENT_BASE_URL` | OpenAI-compatible endpoint (e.g. `https://api.openai.com/v1`) |
-| `AGENT_API_KEY` | API key for the chosen provider |
-| `AGENT_MODEL` | Model name (e.g. `gpt-4o-mini`, `deepseek-chat`, `glm-4-flash`) |
-| `AGENT_MAX_TOKENS` | Optional, default 2048 |
-| `AGENT_TEMPERATURE` | Optional, default 0.7 |
-
-### GitHub Image Bed (Optional)
-
-Enable image upload to GitHub repo as persistent hosting. Configure via Settings page or `.env.local`:
-
-| Variable | Description |
-|----------|-------------|
-| `GITHUB_IMAGE_ENABLED` | Set to `true` to enable |
-| `GITHUB_IMAGE_TOKEN` | GitHub personal access token with repo scope |
-| `GITHUB_IMAGE_OWNER` | GitHub username or org |
-| `GITHUB_IMAGE_REPO` | Target repository name |
-| `GITHUB_IMAGE_BRANCH` | Optional, default `main` |
-| `GITHUB_IMAGE_PATH` | Optional, default `images/` |
+See [docs/configuration.md](./docs/configuration.md) for platform credentials, AI agent setup, and GitHub image bed.
 
 ---
 
-## Architecture
+## Development
 
-```
-src/
-├── app/                        # Next.js App Router
-│   ├── page.tsx                  # Server Component (metadata + shell)
-│   ├── page-client.tsx           # Client Component (editor + panels)
-│   ├── ai-news/                  # AI topic discovery desk
-│   ├── analytics/                # Post-publish metrics dashboard
-│   ├── calendar/                 # Content scheduling calendar
-│   ├── drafts/                   # Draft library
-│   ├── settings/                 # Platform & AI configuration
-│   ├── sync-tasks/               # Distribution task tracking
-│   └── api/                      # Route Handlers
-│       ├── agent/                  # AI endpoints (write, adapt, research, diagnose, chat, feedback)
-│       ├── copilot/                # Content copilot (profile, recommend, style)
-│       ├── briefs/                 # Brief CRUD
-│       ├── signals/                # Signal inbox CRUD
-│       ├── topics/                 # Topic library CRUD
-│       ├── drafts/                 # Draft CRUD
-│       ├── feedback/               # Feedback CRUD
-│       ├── export/                 # Workspace export
-│       ├── import/                 # Workspace import (with dry-run)
-│       ├── metrics/                # Metrics collection
-│       ├── platforms/              # Platform connection management
-│       ├── publish/                # Publish endpoint
-│       ├── rss-sources/            # Custom RSS CRUD
-│       ├── sync-tasks/             # Sync task management
-│       ├── templates/              # Custom template CRUD
-│       ├── upload/                 # Image upload (GitHub image bed)
-│       └── custom-prompts/         # Custom prompt CRUD
-├── components/
-│   ├── layout/                   # AppShellHeader, Sidebar, SurfaceCard, ThemeToggle
-│   ├── editor/                   # MarkdownEditor, WritingBriefCard, TemplatePicker, SlashCommandMenu
-│   ├── news/                     # SignalInbox, TopicLibrary, TopicSignalCard, ScoreBar
-│   ├── briefs/                   # BriefOutlineEditor, BriefSourceList
-│   ├── publish/                  # PlatformSelector, PublishButton, ModerationWarning, PreviewPanel
-│   ├── sync/                     # SyncTaskList, SyncTaskDetail
-│   ├── agent/                    # AgentPanel, AgentStreamOutput
-│   ├── copilot/                  # BrandProfileForm, TopicRecommendationPanel, StyleProfile
-│   ├── analytics/                # MetricsCard, ContentInsightPanel, TopicPerformanceTable
-│   ├── workbench/                # TodayWorkbench
-│   ├── feedback/                 # EmptyState, ErrorState
-│   ├── calendar/                 # CalendarPageClient
-│   └── drafts/                   # DraftLibraryClient
-├── hooks/                        # useAutoSave, useSlashCommands, useAgentStream, useImmersiveMode
-├── lib/
-│   ├── agent/                    # LLM provider, streaming, prompt templates
-│   ├── ai-news/                  # RSS aggregation, clustering, scoring, signal persistence
-│   ├── briefs/                   # Writing brief storage and CRUD
-│   ├── copilot/                  # Brand profile, style learning, topic recommendation
-│   ├── custom-prompts/           # Custom prompt storage
-│   ├── drafts/                   # Draft CRUD with version history
-│   ├── export/                   # Workspace export/import logic
-│   ├── feedback/                 # Content feedback storage
-│   ├── metrics/                  # Post-publish metrics with aggregation
-│   ├── moderation/               # Sensitive word detection
-│   ├── platformAdapters/         # Content format adaptation per platform
-│   ├── platformConnections/      # Connection management & OAuth
-│   ├── platformRules/            # Platform content validation rules
-│   ├── platformVariants/         # Per-platform content version registry
-│   ├── publishers/               # Platform-specific publish logic
-│   ├── rss-sources/              # Custom RSS source storage
-│   ├── scheduler/                # Scheduled publish execution
-│   ├── signals/                  # Signal inbox storage
-│   ├── storage/                  # JSON file collection, env file, migrations
-│   ├── sync/                     # Distribution task state machine
-│   ├── templates/                # Custom template store
-│   ├── topics/                   # Topic library storage
-│   └── upload/                   # GitHub image upload
-├── stores/                       # Zustand stores (publishStore, agentStore, toastStore)
-├── styles/                       # Design tokens (spacing, typography, color, radius)
-└── types/                        # TypeScript type definitions
-```
-
----
-
-## Tech Stack
-
-| Layer | Technology |
-|-------|-----------|
-| Framework | Next.js 15 (App Router, React 19) |
-| Language | TypeScript 5 (strict mode) |
-| Styling | vanilla-extract (`@vanilla-extract/css` + `@vanilla-extract/recipes`) |
-| State | Zustand 5 |
-| Editor | @uiw/react-md-editor |
-| Markdown | marked 15 |
-| LLM Streaming | OpenAI-compatible SSE via fetch + ReadableStream |
-| Social API | twitter-api-v2 |
-| Linting | ESLint 9 + eslint-config-next |
-| Formatting | Prettier |
-| Testing | Vitest + Testing Library |
-| Git Hooks | Husky + lint-staged |
-| Package Manager | pnpm |
-
----
-
-## Testing
+Built with Next.js 15 (App Router), TypeScript 5 (strict), vanilla-extract, and Zustand.
 
 ```bash
-pnpm test           # run all tests
-pnpm test -- --watch  # watch mode
+pnpm dev              # development (with port cleanup)
+pnpm build            # production build
+pnpm test             # run tests (Vitest, 332 passing)
+pnpm lint             # ESLint
+pnpm format           # Prettier
+pnpm verify           # lint + test + build
 ```
-
-332 tests across 64 test files covering stores, API routes, components, and utility functions.
-
----
-
-## Design Tokens
-
-Centralized in `src/styles/tokens.css.ts`:
-
-- **Spacing**: xs(4px) through 4xl(40px)
-- **Typography**: xs(12px) through 4xl(28px), line heights tight/base/relaxed
-- **Color**: warm palette with orange/brown accent (#D97757), WCAG AA compliant contrast
-- **Radius**: sm(4px), md(6px), lg(8px), xl(12px)
-- **Theme**: light, dark, and system-preference modes
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,313 +6,76 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](./tsconfig.json)
 [![Next.js](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
-[![Tests](https://img.shields.io/badge/tests-332%20passing-brightgreen.svg)](#测试)
+[![Tests](https://img.shields.io/badge/tests-332%20passing-brightgreen.svg)](#开发)
 
 > AI 原生内容运营平台。一次创作，全平台分发。
 
-Publio 是多平台内容分发工具，整合 Markdown 编辑、AI 选题发现、内容适配和一键发布于统一工作台。支持微信公众号、小红书、知乎和 X (Twitter)。
-
----
-
-## 功能特性
-
-### 内容工作流
-
-Publio 核心工作流覆盖内容创作全生命周期：
-
-1. **信号收件箱** — 从 RSS 源摄入新闻信号，手动添加或 AI 发现
-2. **选题库** — 将信号晋升为跟踪选题，生命周期管理（活跃 → 休眠 → 归档）
-3. **写作大纲** — 每个选题的结构化 Brief：论点、大纲、平台发布计划
-4. **写作台** — Markdown 编辑器 + AI 写作辅助、斜杠命令、自动保存
-5. **渠道版本** — 每个平台独立的内容版本（同步、AI 适配、手动编辑）
-6. **多平台发布** — 并发发布 + 进度追踪 + 定时发布
-7. **内容复盘** — 发布后指标 → AI 复盘 → 经验沉淀 → 反哺推荐
-
-### 写作台
-
-- **Markdown 编辑器** — 桌面端实时预览，移动端降级方案
-- **所见即所得模式** — 源码编辑与实时预览一键切换
-- **沉浸式写作** — 全屏无干扰编辑，居中 720px 布局
-- **自动保存** — 1 秒防抖，首次保存自动创建草稿
-- **编辑上下文面板** — 标题状态、结构统计、可发布性指标
-- **斜杠命令** — `/ai-expand`、`/ai-condense`、`/ai-rewrite`、`/ai-polish`、`/ai-continue`
-- **版本历史** — 标题/内容变更自动快照，支持回滚
-- **内容模板** — 6 个内置模板 + 自定义模板 CRUD
-- **GitHub 图床** — 图片上传至 GitHub 仓库作为持久化图床
-
-### AI Agent 系统
-
-所有 AI 功能需 OpenAI 兼容 API（智谱 GLM、DeepSeek、Qwen、OpenAI、Ollama 等）。未配置时优雅降级。
-
-| 能力 | 说明 |
-|------|------|
-| **写作助手** | 扩写、缩写、改写、润色、续写 — 斜杠命令触发，流式输出 |
-| **平台适配** | 按平台规则重写内容，附带适配决策说明 |
-| **选题研究** | 新闻聚合深度分析，多角度洞察 |
-| **信号审阅** | AI 驱动收件箱分诊：高价值信号、组合建议、行动推荐 |
-| **选题写作包** | 生成结构化写作素材（背景、事实、角度、受众、反论、结构） |
-| **Brief 辅助** | 从选题生成 Brief、改写论点、填充大纲、生成渠道计划 |
-| **发布诊断** | 失败原因分析（根因、证据、修复步骤、重试建议） |
-| **内容复盘** | 基于指标生成表现总结、有效因素、问题和建议 |
-| **内容 Copilot** | 基于品牌画像 + 当前热点 + 历史表现的选题推荐 |
-| **风格学习** | 从历史草稿提取写作风格，注入 prompt |
-| **多轮对话** | 会话持久化的 AI 对话面板 |
-
-### AI 选题台
-
-- 聚合 9+ 内置 RSS 源 + 用户自定义源
-- **信号收件箱** — 分类处理信号（置顶、忽略、晋升为选题）
-- **选题库** — 生命周期管理、关联 Brief、追踪表现
-- 话题聚类，六维评分（新鲜度、影响力、势能、可信度、视觉就绪度、覆盖度）
-- 每个聚合话题生成研究底稿：发生了什么、为什么重要、影响谁、推荐角度
-- 一键转换为编辑器草稿，研究上下文自动嵌入
-
-### 多平台发布
-
-- `Promise.allSettled` 并发发布至所有已选平台
-- **渠道版本** — 每个平台拥有独立的内容版本（从主稿同步、AI 适配、或手动编辑）
-- **版本状态追踪** — 已同步 / AI 适配 / 已编辑 / 已检查 / 已排期 / 已发布
-- **内容审核** — 敏感词检测，发布前弹窗警告
-- **平台校验** — 自动规则检查（标题长度、内容限制、格式约束）
-- **发布进度浮层** — 实时状态轮询，逐平台接收回执
-- **分发任务追踪** — 失败诊断、智能重试、手动标记完成
-- **定时发布** — 后端 cron 执行，持久化任务队列
-- **发布后指标** — 阅读量、点赞、评论、分享聚合到分析看板，支持单任务和全量刷新
-
-### 内容复盘
-
-- **复盘存储** — 每篇草稿/版本/选题的结构化复盘，含经验和后续行动
-- **AI 复盘 Agent** — 生成表现总结、有效因素、问题和可操作建议
-- **分析洞察** — 按渠道和按选题聚合表、表现最佳内容、待复盘内容
-- **复盘驱动推荐** — 选题库展示历史表现；低表现选题提示风险而非压制；写作 Brief 关联相关复盘；AI 推荐融入近期表现上下文
-
-### 内容排期日历
-
-- 月视图展示草稿、定时发布、已发布、失败事件
-- 点击跳转编辑器或分发任务详情
-
-### 今日工作台
-
-- 统一面板展示各流程阶段的待办项
-- 待处理信号、活跃选题、未完成 Brief、待发布版本、进行中任务
-- 直接链接跳转至各工作流
-
-### 数据管理
-
-- **自动迁移** — schema 版本化，结构变更前自动备份
-- **工作空间导入导出** — 导出所有实体（信号、选题、Brief、草稿、版本、任务、复盘）为 JSON；导入支持 dry-run 预览和合并语义
-
-### 设置与配置
-
-- 平台凭证管理，支持 OAuth 流程和连接验证
-- AI Agent 配置（base URL、API key、模型），热更新无需重启
-- 自定义 RSS 源管理
-- 自定义 AI prompt 编辑器（按平台和全局）
-- 品牌画像配置（用于内容 Copilot）
-- 写作风格画像，支持从历史草稿自动分析
-
-### 设计系统
-
-- **主题切换** — 亮色 / 暗色 / 跟随系统，localStorage 持久化
-- **设计 token** — 间距、字号、色彩、圆角，WCAG AA 合规对比度
-- **响应式布局** — 桌面端侧边栏导航，自适应内容区
+- **全生命周期工作流** — 从选题发现到发布后复盘，一个工作台搞定
+- **AI 写作辅助** — 扩写、缩写、改写、润色、续写，斜杠命令触发，流式输出
+- **多平台一键发布** — 并发分发至微信公众号、小红书、知乎、X (Twitter)
+- **Provider 无关** — 支持任何 OpenAI 兼容 API（智谱 GLM、DeepSeek、Qwen、OpenAI、Ollama）
 
 ---
 
 ## 快速开始
 
-### 环境要求
-
-- Node.js >= 18
-- pnpm
-
-### 安装
-
 ```bash
 git clone https://github.com/rogerdigital/publio.git
 cd publio
 pnpm install
-pnpm dev                      # 启动开发（含端口清理和缓存清除）
+pnpm dev
 ```
 
-首次启动后在设置页（`/settings`）配置平台凭证和 AI Agent。
+打开 http://localhost:3000。首次启动后在设置页（`/settings`）配置平台凭证和 AI Agent。
 
-`pnpm dev` 自动清理残留 Next.js 进程并清除 `.next/cache`。使用 `pnpm run dev:raw` 跳过清理。
+---
 
-打开 http://localhost:3000。
+## 工作流
 
-### 命令
+**信号收件箱** → **选题库** → **写作 Brief** → **写作台** → **渠道版本** → **发布** → **内容复盘**
 
-```bash
-pnpm dev              # 开发模式（含端口清理）
-pnpm build            # 生产构建
-pnpm start            # 生产服务
-pnpm preview           # 构建 + 启动
-pnpm test             # 运行测试（Vitest）
-pnpm lint             # ESLint
-pnpm format           # Prettier 格式化
-pnpm verify           # lint + test + build
-```
+每个阶段承接上一步。信号晋升为选题，选题生成结构化 Brief，Brief 指导写作，稿件按平台适配，并发发布，发布后指标反哺推荐。
+
+---
+
+## 功能亮点
+
+### 写作台
+
+Markdown 编辑器，支持实时预览、沉浸式全屏模式、自动保存、AI 斜杠命令、版本历史回滚和内容模板。GitHub 图床提供持久化图片托管。
+
+### AI Agent 系统
+
+写作助手（5 个斜杠命令）、平台内容适配、选题深度研究、信号收件箱分诊、结构化写作包、Brief 生成、发布失败诊断、内容复盘、风格学习。全部流式，全部可选。
+
+### 多平台发布
+
+并发发布 + 进度追踪。每个平台拥有独立渠道版本 — 同步、AI 适配或手动编辑。包含敏感词检测、平台规则校验、定时发布、失败诊断智能重试、发布后指标聚合。
+
+### AI 选题台
+
+聚合 9+ RSS 源 + 自定义源。信号收件箱分类处理，选题库生命周期管理，六维评分，研究底稿生成，一键转为编辑器草稿并嵌入研究上下文。
 
 ---
 
 ## 配置
 
-### 平台凭证
-
-通过 `.env.local` 或设置页运行时管理：
-
-| 平台 | 变量 | 获取方式 |
-|------|------|---------|
-| 微信公众号 | `WECHAT_APP_ID`, `WECHAT_APP_SECRET` | [mp.weixin.qq.com](https://mp.weixin.qq.com/) > 开发 > 基本配置 |
-| 小红书 | `XHS_APP_ID`, `XHS_APP_SECRET`, `XHS_ACCESS_TOKEN` | [小红书开放平台](https://open.xiaohongshu.com/) |
-| 知乎 | `ZHIHU_COOKIE` | 浏览器 DevTools > Network > 复制 Cookie |
-| X (Twitter) | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` | [developer.x.com](https://developer.x.com/) |
-
-### AI Agent（可选）
-
-三项必填才能启用 AI 功能：
-
-| 变量 | 说明 |
-|------|------|
-| `AGENT_BASE_URL` | OpenAI 兼容端点（如 `https://api.openai.com/v1`） |
-| `AGENT_API_KEY` | 对应服务商的 API key |
-| `AGENT_MODEL` | 模型名（如 `gpt-4o-mini`、`deepseek-chat`、`glm-4-flash`） |
-| `AGENT_MAX_TOKENS` | 可选，默认 2048 |
-| `AGENT_TEMPERATURE` | 可选，默认 0.7 |
-
-### GitHub 图床（可选）
-
-启用图片上传至 GitHub 仓库作为持久化图床。通过设置页或 `.env.local` 配置：
-
-| 变量 | 说明 |
-|------|------|
-| `GITHUB_IMAGE_ENABLED` | 设为 `true` 启用 |
-| `GITHUB_IMAGE_TOKEN` | GitHub personal access token（需 repo scope） |
-| `GITHUB_IMAGE_OWNER` | GitHub 用户名或组织 |
-| `GITHUB_IMAGE_REPO` | 目标仓库名 |
-| `GITHUB_IMAGE_BRANCH` | 可选，默认 `main` |
-| `GITHUB_IMAGE_PATH` | 可选，默认 `images/` |
+参见 [docs/configuration.md](./docs/configuration.md)，包含平台凭证、AI Agent 配置和 GitHub 图床设置。
 
 ---
 
-## 架构
+## 开发
 
-```
-src/
-├── app/                        # Next.js App Router
-│   ├── page.tsx                  # Server Component（metadata + shell）
-│   ├── page-client.tsx           # Client Component（编辑器 + 面板）
-│   ├── ai-news/                  # AI 选题工作台
-│   ├── analytics/                # 发布后指标看板
-│   ├── calendar/                 # 内容排期日历
-│   ├── drafts/                   # 稿件库
-│   ├── settings/                 # 平台与 AI 配置
-│   ├── sync-tasks/               # 分发任务追踪
-│   └── api/                      # Route Handlers
-│       ├── agent/                  # AI 端点（写作、适配、研究、诊断、对话、复盘）
-│       ├── copilot/                # 内容 Copilot（画像、推荐、风格）
-│       ├── signals/                # Signal 收件箱 CRUD
-│       ├── topics/                 # Topic 库 CRUD
-│       ├── briefs/                 # Brief CRUD
-│       ├── drafts/                 # 草稿 CRUD
-│       ├── feedback/               # 内容复盘 CRUD
-│       ├── export/                 # 工作空间导出
-│       ├── import/                 # 工作空间导入
-│       ├── metrics/                # 指标采集
-│       ├── platforms/              # 平台连接管理
-│       ├── publish/                # 发布端点
-│       ├── rss-sources/            # 自定义 RSS CRUD
-│       ├── sync-tasks/             # 分发任务管理
-│       ├── templates/              # 自定义模板 CRUD
-│       ├── upload/                 # 图片上传（GitHub 图床）
-│       └── custom-prompts/         # 自定义 prompt CRUD
-├── components/
-│   ├── layout/                   # AppShellHeader, Sidebar, SurfaceCard, ThemeToggle
-│   ├── editor/                   # MarkdownEditor, WritingBriefCard, TemplatePicker, SlashCommandMenu
-│   ├── news/                     # SignalInbox, TopicLibrary, TopicSignalCard, ScoreBar
-│   ├── briefs/                   # BriefOutlineEditor, BriefSourceList
-│   ├── publish/                  # PlatformSelector, PublishButton, ModerationWarning, PreviewPanel
-│   ├── sync/                     # SyncTaskList, SyncTaskDetail
-│   ├── agent/                    # AgentPanel, AgentStreamOutput
-│   ├── copilot/                  # BrandProfileForm, TopicRecommendationPanel, StyleProfile
-│   ├── analytics/                # MetricsCard, ContentInsightPanel, TopicPerformanceTable
-│   ├── workbench/                # TodayWorkbench
-│   ├── feedback/                 # EmptyState, ErrorState
-│   ├── calendar/                 # CalendarPageClient
-│   └── drafts/                   # DraftLibraryClient
-├── hooks/                        # useAutoSave, useSlashCommands, useAgentStream, useImmersiveMode
-├── lib/
-│   ├── agent/                    # LLM provider、流式传输、prompt 模板
-│   ├── ai-news/                  # RSS 聚合、聚类、评分、信号持久化
-│   ├── signals/                  # Signal 收件箱存储
-│   ├── topics/                   # Topic 库存储
-│   ├── briefs/                   # Brief 存储
-│   ├── copilot/                  # 品牌画像、风格学习、选题推荐
-│   ├── custom-prompts/           # 自定义 prompt 存储
-│   ├── drafts/                   # 草稿 CRUD（含版本历史）
-│   ├── export/                   # 工作空间导入导出
-│   ├── feedback/                 # 内容复盘存储
-│   ├── metrics/                  # 发布后指标与聚合
-│   ├── moderation/               # 敏感词检测
-│   ├── platformAdapters/         # 按平台适配内容格式
-│   ├── platformConnections/      # 连接管理与 OAuth
-│   ├── platformRules/            # 平台内容校验规则
-│   ├── platformVariants/         # 渠道版本存储
-│   ├── publishers/               # 平台发布逻辑
-│   ├── rss-sources/              # 自定义 RSS 源存储
-│   ├── scheduler/                # 定时发布执行
-│   ├── storage/                  # JSON 文件集合、env 文件、数据迁移
-│   ├── sync/                     # 分发任务状态机
-│   ├── templates/                # 自定义模板存储
-│   └── upload/                   # GitHub 图片上传
-├── stores/                       # Zustand stores（publishStore, agentStore, toastStore）
-├── styles/                       # 设计 token（间距、字号、色彩、圆角）
-└── types/                        # TypeScript 类型定义
-```
-
----
-
-## 技术栈
-
-| 层级 | 技术 |
-|------|------|
-| 框架 | Next.js 15（App Router, React 19） |
-| 语言 | TypeScript 5（严格模式） |
-| 样式 | vanilla-extract（`@vanilla-extract/css` + `@vanilla-extract/recipes`） |
-| 状态 | Zustand 5 |
-| 编辑器 | @uiw/react-md-editor |
-| Markdown | marked 15 |
-| LLM 流式传输 | OpenAI 兼容 SSE（fetch + ReadableStream） |
-| 社交 API | twitter-api-v2 |
-| 代码检查 | ESLint 9 + eslint-config-next |
-| 格式化 | Prettier |
-| 测试 | Vitest + Testing Library |
-| Git Hooks | Husky + lint-staged |
-| 包管理 | pnpm |
-
----
-
-## 测试
+基于 Next.js 15 (App Router)、TypeScript 5 (strict)、vanilla-extract 和 Zustand 构建。
 
 ```bash
-pnpm test           # 运行所有测试
-pnpm test -- --watch  # 监听模式
+pnpm dev              # 开发模式（含端口清理）
+pnpm build            # 生产构建
+pnpm test             # 运行测试（Vitest，332 用例通过）
+pnpm lint             # ESLint
+pnpm format           # Prettier 格式化
+pnpm verify           # lint + test + build
 ```
-
-64 个测试文件，332 个测试用例，覆盖 stores、API 路由、组件和工具函数。
-
----
-
-## 设计 Token
-
-集中在 `src/styles/tokens.css.ts`：
-
-- **间距**: xs(4px) 到 4xl(40px)
-- **字号**: xs(12px) 到 4xl(28px)，行高 tight/base/relaxed
-- **色彩**: 暖色调，橙/棕基调 (#D97757) accent，WCAG AA 合规对比度
-- **圆角**: sm(4px), md(6px), lg(8px), xl(12px)
-- **主题**: 亮色、暗色、跟随系统
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,45 @@
+# Configuration
+
+All credentials can be managed via `.env.local` or the Settings page (`/settings`) at runtime.
+
+---
+
+## Platform Credentials
+
+| Platform | Variables | Source |
+|----------|-----------|--------|
+| WeChat | `WECHAT_APP_ID`, `WECHAT_APP_SECRET` | [mp.weixin.qq.com](https://mp.weixin.qq.com/) > Development > Basic Config |
+| Xiaohongshu | `XHS_APP_ID`, `XHS_APP_SECRET`, `XHS_ACCESS_TOKEN` | [Xiaohongshu Open Platform](https://open.xiaohongshu.com/) |
+| Zhihu | `ZHIHU_COOKIE` | Browser DevTools > Network > copy Cookie |
+| X (Twitter) | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` | [developer.x.com](https://developer.x.com/) |
+
+---
+
+## AI Agent
+
+All three required to activate AI features. Supports any OpenAI-compatible API (Zhipu GLM, DeepSeek, Qwen, OpenAI, Ollama, etc.).
+
+| Variable | Description |
+|----------|-------------|
+| `AGENT_BASE_URL` | OpenAI-compatible endpoint (e.g. `https://api.openai.com/v1`) |
+| `AGENT_API_KEY` | API key for the chosen provider |
+| `AGENT_MODEL` | Model name (e.g. `gpt-4o-mini`, `deepseek-chat`, `glm-4-flash`) |
+| `AGENT_MAX_TOKENS` | Optional, default 2048 |
+| `AGENT_TEMPERATURE` | Optional, default 0.7 |
+
+AI features gracefully degrade when unconfigured — all AI entry points are hidden.
+
+---
+
+## GitHub Image Bed
+
+Upload images to a GitHub repo as persistent hosting. Optional.
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_IMAGE_ENABLED` | Set to `true` to enable |
+| `GITHUB_IMAGE_TOKEN` | GitHub personal access token with `repo` scope |
+| `GITHUB_IMAGE_OWNER` | GitHub username or org |
+| `GITHUB_IMAGE_REPO` | Target repository name |
+| `GITHUB_IMAGE_BRANCH` | Optional, default `main` |
+| `GITHUB_IMAGE_PATH` | Optional, default `images/` |


### PR DESCRIPTION
## Summary

- Condense README from ~320 lines to ~80 — product-focused, scannable
- Move all configuration tables to `docs/configuration.md`
- Remove architecture tree, tech stack table, design tokens section (already in CLAUDE.md)
- Keep bilingual EN/ZH structure

## Structure

1. One-line tagline + 4 core value bullets
2. Quick Start (4 lines)
3. Workflow overview (one paragraph)
4. Features (4 sections, 2-3 sentences each)
5. Config link → docs/
6. Development commands
7. License