### PR TITLE
feat: sidebar branding redesign — pen nib logo, handwritten font, color icons

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,16 +1,9 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- 背景 -->
-  <rect width="64" height="64" rx="16" fill="#F5EDE4"/>
-  <!-- P 字母主体 -->
-  <text
-    x="11"
-    y="50"
-    font-family="Georgia, 'Times New Roman', serif"
-    font-size="52"
-    font-style="italic"
-    font-weight="700"
-    fill="#D97757"
-  >P</text>
-  <!-- 右下角装饰点 -->
-  <circle cx="50" cy="50" r="5" fill="#D97757" opacity="0.35"/>
+<svg width="64" height="64" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="8" fill="#F5EDE4"/>
+  <!-- 笔尖主体 -->
+  <path d="M13 4Q9 16 16 29Q23 16 19 4Z" fill="#D97757"/>
+  <!-- 呼吸孔 -->
+  <circle cx="16" cy="11" r="2" fill="white" opacity="0.85"/>
+  <!-- 中缝 -->
+  <line x1="16" y1="13" x2="16" y2="29" stroke="white" stroke-width="0.8" opacity="0.5"/>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { Inter } from 'next/font/google';
+import { Inter, Caveat } from 'next/font/google';
 import '@/styles/globals.css';
 import { darkTheme } from '@/styles/tokens.css';
 import Sidebar from '@/components/layout/Sidebar';
@@ -15,6 +15,13 @@ const inter = Inter({
   display: 'swap',
 });
 
+const caveat = Caveat({
+  subsets: ['latin'],
+  weight: ['500', '600', '700'],
+  variable: '--font-caveat',
+  display: 'swap',
+});
+
 export const metadata: Metadata = {
   title: 'Publio',
   description: 'Publish Markdown content to multiple platforms in one workflow.',
@@ -24,7 +31,7 @@ const themeScript = `(function(){try{var c='${darkTheme}',s=localStorage.getItem
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="zh-CN" className={inter.variable} suppressHydrationWarning>
+    <html lang="zh-CN" className={`${inter.variable} ${caveat.variable}`} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>

--- a/src/components/layout/Logo.css.ts
+++ b/src/components/layout/Logo.css.ts
@@ -3,8 +3,5 @@ import { style } from '@vanilla-extract/css';
 
 export const logoSvg = style({
   display: 'block',
-  color: vars.color.text,
-  vars: {
-    '--logo-letter': vars.color.surfaceDarkText,
-  },
+  color: '#D97757',
 });

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -5,18 +5,18 @@ export default function Logo({ size = 28 }: { size?: number }) {
     <svg
       width={size}
       height={size}
-      viewBox="0 0 28 28"
+      viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
       className={styles.logoSvg}
     >
-      <rect width="28" height="28" rx="6" fill="currentColor" />
-      <path
-        d="M9 20V8h4.8c1.3 0 2.3.38 3.02 1.12.72.74 1.08 1.7 1.08 2.88 0 1.18-.36 2.14-1.08 2.88-.72.74-1.72 1.12-3.02 1.12H11.4V20H9Z M11.4 14h2.2c.7 0 1.22-.2 1.58-.58.36-.4.54-.9.54-1.52 0-.62-.18-1.12-.54-1.52-.36-.38-.88-.58-1.58-.58H11.4V14Z"
-        fill="var(--logo-letter)"
-        fillRule="evenodd"
-      />
+      {/* 笔尖主体 */}
+      <path d="M13 4Q9 16 16 29Q23 16 19 4Z" fill="currentColor" />
+      {/* 呼吸孔 */}
+      <circle cx="16" cy="11" r="2" fill="white" opacity="0.85" />
+      {/* 中缝 */}
+      <line x1="16" y1="13" x2="16" y2="29" stroke="white" strokeWidth="0.8" opacity="0.5" />
     </svg>
   );
 }

--- a/src/components/layout/Sidebar.css.ts
+++ b/src/components/layout/Sidebar.css.ts
@@ -80,9 +80,10 @@ export const brandLogo = style({
 });
 
 export const brandName = style({
-  fontSize: '15px',
+  fontSize: '20px',
   fontWeight: 700,
-  color: vars.color.text,
+  fontFamily: 'var(--font-caveat), cursive',
+  color: '#D97757',
   lineHeight: 1,
   opacity: 0,
   width: 0,
@@ -229,6 +230,12 @@ export const footer = style({
   alignItems: 'center',
   justifyContent: 'center',
   paddingTop: '12px',
+  selectors: {
+    [`${sidebarVariants.expanded} &`]: {
+      justifyContent: 'flex-start',
+      paddingLeft: '12px',
+    },
+  },
 });
 
 export const themeToggleRow = style({

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -22,13 +22,13 @@ import * as styles from './Sidebar.css';
 const STORAGE_KEY = 'publio-sidebar-expanded';
 
 const navItems = [
-  { href: '/ai-news', label: '选题台', icon: Newspaper },
-  { href: '/', label: '写作台', icon: PenLine },
-  { href: '/drafts', label: '稿件库', icon: Library },
-  { href: '/sync-tasks', label: '分发记录', icon: Send },
-  { href: '/analytics', label: '数据看板', icon: BarChart3 },
-  { href: '/calendar', label: '排期日历', icon: CalendarDays },
-  { href: '/settings', label: '设置', icon: Settings2 },
+  { href: '/ai-news', label: '选题台', icon: Newspaper, color: '#F97316' },
+  { href: '/', label: '写作台', icon: PenLine, color: '#3B82F6' },
+  { href: '/drafts', label: '稿件库', icon: Library, color: '#8B5CF6' },
+  { href: '/sync-tasks', label: '分发记录', icon: Send, color: '#EC4899' },
+  { href: '/analytics', label: '数据看板', icon: BarChart3, color: '#14B8A6' },
+  { href: '/calendar', label: '排期日历', icon: CalendarDays, color: '#EAB308' },
+  { href: '/settings', label: '设置', icon: Settings2, color: '#6B7280' },
 ];
 
 export default function Sidebar() {
@@ -97,7 +97,7 @@ export default function Sidebar() {
                 className={cn(styles.navItemBase, styles.navItemVariants[state])}
               >
                 <span className={cn(styles.navIconBase, styles.navIconVariants[state])}>
-                  <Icon size={20} />
+                  <Icon size={20} color={isActive ? undefined : item.color} />
                 </span>
                 <span className={cn(styles.navLabel, styles.navLabelVariants[state])}>
                   {item.label}
@@ -110,7 +110,7 @@ export default function Sidebar() {
 
         <div className={styles.footer}>
           <div className={styles.themeToggleRow}>
-            <ThemeToggle />
+            <ThemeToggle expanded={expanded} />
           </div>
         </div>
       </aside>
@@ -129,7 +129,7 @@ export default function Sidebar() {
               className={styles.mobileTabItem[state]}
               aria-current={isActive ? 'page' : undefined}
             >
-              <Icon size={20} />
+              <Icon size={20} color={isActive ? undefined : item.color} />
               <span className={styles.mobileTabLabel[state]}>{item.label}</span>
             </Link>
           );

--- a/src/components/layout/ThemeToggle.css.ts
+++ b/src/components/layout/ThemeToggle.css.ts
@@ -18,3 +18,37 @@ export const toggle = style({
     background: vars.color.accentSoft,
   },
 });
+
+export const segmented = style({
+  display: 'flex',
+  alignItems: 'center',
+  background: vars.color.accentSoft,
+  borderRadius: '8px',
+  padding: '3px',
+});
+
+export const segItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 30,
+  height: 30,
+  border: 'none',
+  borderRadius: '6px',
+  background: 'transparent',
+  color: vars.color.textMuted,
+  cursor: 'pointer',
+  transition: `all ${vars.transition.fast}`,
+  ':hover': {
+    color: vars.color.text,
+  },
+});
+
+export const segItemActive = style({
+  background: vars.color.surface,
+  color: vars.color.text,
+  boxShadow: vars.shadow.sm,
+  ':hover': {
+    color: vars.color.text,
+  },
+});

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -26,17 +26,23 @@ function applyTheme(effective: 'light' | 'dark') {
   }
 }
 
-export default function ThemeToggle() {
+const modes: ThemeMode[] = ['light', 'dark', 'system'];
+
+const modeConfig: Record<ThemeMode, { icon: typeof Sun; label: string; color: string }> = {
+  light: { icon: Sun, label: '亮色', color: '#F59E0B' },
+  dark: { icon: Moon, label: '暗色', color: '#818CF8' },
+  system: { icon: Monitor, label: '系统', color: '#34D399' },
+};
+
+export default function ThemeToggle({ expanded = false }: { expanded?: boolean }) {
   const [mode, setMode] = useState<ThemeMode>('light');
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
-    const initialMode: ThemeMode =
-      stored && ['light', 'dark', 'system'].includes(stored) ? stored : 'dark';
+    const initialMode: ThemeMode = stored && modes.includes(stored) ? stored : 'dark';
     setMode(initialMode);
     applyTheme(resolveEffectiveTheme(initialMode));
 
-    // Listen for system preference changes when in system mode
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = () => {
       if (localStorage.getItem(STORAGE_KEY) === 'system' || !localStorage.getItem(STORAGE_KEY)) {
@@ -47,36 +53,59 @@ export default function ThemeToggle() {
     return () => mql.removeEventListener('change', handler);
   }, []);
 
+  const select = useCallback((next: ThemeMode) => {
+    setMode(next);
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(resolveEffectiveTheme(next));
+  }, []);
+
   const cycle = useCallback(() => {
     setMode((prev) => {
-      const next: ThemeMode = prev === 'light' ? 'dark' : prev === 'dark' ? 'system' : 'light';
+      const idx = modes.indexOf(prev);
+      const next = modes[(idx + 1) % modes.length];
       localStorage.setItem(STORAGE_KEY, next);
       applyTheme(resolveEffectiveTheme(next));
       return next;
     });
   }, []);
 
-  const labels: Record<ThemeMode, string> = {
-    light: '亮色模式（点击切换到暗色）',
-    dark: '暗色模式（点击跟随系统）',
-    system: '跟随系统（点击切换到亮色）',
-  };
+  if (expanded) {
+    return (
+      <div className={css.segmented} role="radiogroup" aria-label="主题切换">
+        {modes.map((m) => {
+          const cfg = modeConfig[m];
+          const Icon = cfg.icon;
+          const active = m === mode;
+          return (
+            <button
+              key={m}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              className={`${css.segItem} ${active ? css.segItemActive : ''}`}
+              onClick={() => select(m)}
+              title={cfg.label}
+            >
+              <Icon size={15} color={cfg.color} />
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
 
-  const icons: Record<ThemeMode, React.ReactNode> = {
-    light: <Sun size={16} />,
-    dark: <Moon size={16} />,
-    system: <Monitor size={16} />,
-  };
+  const current = modeConfig[mode];
+  const Icon = current.icon;
 
   return (
     <button
       type="button"
       className={css.toggle}
       onClick={cycle}
-      aria-label={labels[mode]}
-      title={labels[mode]}
+      aria-label={`当前：${current.label}，点击切换`}
+      title={`当前：${current.label}，点击切换`}
     >
-      {icons[mode]}
+      <Icon size={16} color={current.color} />
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Replace letter-P logo with minimalist fountain pen nib SVG icon
- Add Caveat handwritten Google Font for brand title in sidebar
- Redesign theme toggle as icon-only segmented control with color indicators (gold/purple/green)
- Add distinct colors to sidebar nav icons in inactive state
- Update browser favicon (icon.svg) to match new pen nib logo
- Left-align theme toggle in expanded sidebar state

## Test plan
- [ ] Verify pen nib logo renders in sidebar (both expanded and collapsed states)
- [ ] Verify browser tab icon matches the pen nib design
- [ ] Verify Caveat handwritten font applies to "Publio" brand name
- [ ] Toggle between light/dark/system themes via segmented control
- [ ] Verify sidebar nav icons show distinct colors when inactive
- [ ] Test sidebar expand/collapse animation