### PR TITLE
feat: AI news enhancements — digest, filtering, RSS feed, X/arXiv sources

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 const nextConfig: NextConfig = {
   async headers() {
+    const isDev = process.env.NODE_ENV === 'development';
     return [
       {
         source: '/(.*)',
@@ -18,7 +19,7 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'",
+              `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: blob: https:",
               "connect-src 'self'",

--- a/src/app/api/drafts/route.ts
+++ b/src/app/api/drafts/route.ts
@@ -40,6 +40,7 @@ export async function POST(request: NextRequest | Request) {
         ? body.scheduledAt.trim()
         : undefined;
     const platforms = Array.isArray(body.platforms) ? body.platforms : undefined;
+    const tags = Array.isArray(body.tags) ? body.tags : undefined;
 
     if (!title || !content) {
       return apiError('标题和内容不能为空');
@@ -60,6 +61,7 @@ export async function POST(request: NextRequest | Request) {
       contentGoal,
       scheduledAt,
       platforms,
+      tags,
     });
 
     return apiResponse({ draft }, 201);

--- a/src/app/feed/published.xml/route.ts
+++ b/src/app/feed/published.xml/route.ts
@@ -1,0 +1,79 @@
+import { getSyncHistoryStore } from '@/lib/sync/registry';
+import { getDraftRegistry } from '@/lib/drafts/registry';
+import { getSiteUrl } from '@/lib/config';
+
+export const dynamic = 'force-dynamic';
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function toRfc822(dateStr: string): string {
+  return new Date(dateStr).toUTCString();
+}
+
+export async function GET() {
+  try {
+    const siteUrl = getSiteUrl();
+    const tasks = getSyncHistoryStore()
+      .listTasks()
+      .filter((t) => t.status === 'completed')
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+      .slice(0, 50);
+
+    const draftRegistry = getDraftRegistry();
+
+    const items = tasks
+      .map((task) => {
+        if (!task.draftId) return null;
+        const draft = draftRegistry.getDraft(task.draftId);
+        if (!draft) return null;
+
+        const receipt = task.receipts.find((r) => r.url);
+        const link = receipt?.url ?? `${siteUrl}/sync-tasks/${task.id}`;
+        const excerpt = draft.content.slice(0, 200).replace(/\n/g, ' ').trim();
+
+        return `    <item>
+      <title>${escapeXml(draft.title)}</title>
+      <link>${escapeXml(link)}</link>
+      <description>${escapeXml(excerpt)}</description>
+      <pubDate>${toRfc822(task.createdAt)}</pubDate>
+      <guid isPermaLink="${receipt?.url ? 'true' : 'false'}">${escapeXml(link)}</guid>
+    </item>`;
+      })
+      .filter(Boolean)
+      .join('\n');
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Publio - 已发布内容</title>
+    <link>${escapeXml(siteUrl)}</link>
+    <description>通过 Publio 分发的已发布内容</description>
+    <language>zh-CN</language>
+    <atom:link href="${escapeXml(`${siteUrl}/feed/published.xml`)}" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+    return new Response(xml, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
+  } catch {
+    return new Response(
+      '<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"><channel></channel></rss>',
+      {
+        status: 500,
+        headers: { 'Content-Type': 'text/xml; charset=utf-8' },
+      },
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="zh-CN" className={`${inter.variable} ${caveat.variable}`} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Publio RSS Feed"
+          href="/feed/published.xml"
+        />
       </head>
       <body className={inter.className}>
         <a href="#main-content" className={styles.skipLink}>

--- a/src/components/news/AiNewsPageClient.tsx
+++ b/src/components/news/AiNewsPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import TopicDeskHeader from '@/components/news/TopicDeskHeader';
@@ -8,11 +8,26 @@ import TopicSignalCard from '@/components/news/TopicSignalCard';
 import SignalInbox from '@/components/news/SignalInbox';
 import TopicLibrary from '@/components/news/TopicLibrary';
 import SignalReviewPanel from '@/components/news/SignalReviewPanel';
+import FilterChipGroup from '@/components/ui/FilterChipGroup';
 import type { AiNewsDeskCandidate } from '@/lib/aiNews';
 import { buildResearchDraftMarkdown } from '@/lib/newsDraft';
 import { createDraft } from '@/lib/drafts/client';
 import { useAgentStore } from '@/stores/agentStore';
 import type { AgentStreamEvent } from '@/lib/agent/types';
+import type { AiNewsSourceType } from '@/lib/ai-news/types';
+
+const SOURCE_TYPE_OPTIONS = [
+  { value: 'all', label: '全部来源' },
+  { value: 'media', label: '媒体' },
+  { value: 'official', label: '官方' },
+  { value: 'community', label: '社区' },
+] as const;
+
+const SCORE_OPTIONS = [
+  { value: 'all', label: '全部分数' },
+  { value: 'high', label: '高分 (≥70)' },
+  { value: 'medium', label: '中等 (40-69)' },
+] as const;
 import EmptyState from '@/components/feedback/EmptyState';
 import { Newspaper } from 'lucide-react';
 import TopicRecommendationPanel from '@/components/copilot/TopicRecommendationPanel';
@@ -117,6 +132,8 @@ export default function AiNewsPageClient() {
   // Maps clusterId → draftId for topics the user has sent to the writing desk
   const [topicDraftMap, setTopicDraftMap] = useState<Record<string, string>>({});
   const [briefOpenMap, setBriefOpenMap] = useState<Map<string, boolean>>(cachedBriefOpenMap);
+  const [sourceTypeFilter, setSourceTypeFilter] = useState<string>('all');
+  const [scoreFilter, setScoreFilter] = useState<string>('all');
   const hasDeskDataRef = useRef(false);
 
   // Tab state: 选题台 vs 资讯 Inbox vs 选题库
@@ -130,6 +147,34 @@ export default function AiNewsPageClient() {
   const cacheResearch = useAgentStore((s) => s.cacheResearch);
 
   const allCandidates = [...todayCandidates, ...followCandidates];
+
+  const filteredToday = useMemo(() => {
+    if (sourceTypeFilter === 'all' && scoreFilter === 'all') return todayCandidates;
+    return todayCandidates.filter((c) => {
+      if (
+        sourceTypeFilter !== 'all' &&
+        c.primarySignal.sourceType !== (sourceTypeFilter as AiNewsSourceType)
+      )
+        return false;
+      if (scoreFilter === 'high' && c.totalScore < 70) return false;
+      if (scoreFilter === 'medium' && (c.totalScore < 40 || c.totalScore >= 70)) return false;
+      return true;
+    });
+  }, [todayCandidates, sourceTypeFilter, scoreFilter]);
+
+  const filteredFollow = useMemo(() => {
+    if (sourceTypeFilter === 'all' && scoreFilter === 'all') return followCandidates;
+    return followCandidates.filter((c) => {
+      if (
+        sourceTypeFilter !== 'all' &&
+        c.primarySignal.sourceType !== (sourceTypeFilter as AiNewsSourceType)
+      )
+        return false;
+      if (scoreFilter === 'high' && c.totalScore < 70) return false;
+      if (scoreFilter === 'medium' && (c.totalScore < 40 || c.totalScore >= 70)) return false;
+      return true;
+    });
+  }, [followCandidates, sourceTypeFilter, scoreFilter]);
 
   // Check agent availability on mount
   useEffect(() => {
@@ -408,6 +453,20 @@ export default function AiNewsPageClient() {
         <TopicLibrary />
       ) : (
         <div className={styles.contentWrap}>
+          {(sourceTypeFilter !== 'all' || scoreFilter !== 'all' || allCandidates.length > 0) && (
+            <div className={styles.filterRow}>
+              <FilterChipGroup
+                options={SOURCE_TYPE_OPTIONS}
+                value={sourceTypeFilter}
+                onChange={setSourceTypeFilter}
+              />
+              <FilterChipGroup
+                options={SCORE_OPTIONS}
+                value={scoreFilter}
+                onChange={setScoreFilter}
+              />
+            </div>
+          )}
           {refreshError ? (
             <div className={styles.refreshErrorBanner} role="status" aria-live="polite">
               <p className={styles.refreshErrorKicker}>刷新未更新</p>
@@ -452,7 +511,7 @@ export default function AiNewsPageClient() {
             <div className={styles.candidateSections}>
               <CandidateSection
                 title="今天能发"
-                items={todayCandidates}
+                items={filteredToday}
                 offset={0}
                 topicDraftMap={topicDraftMap}
                 briefOpenMap={briefOpenMap}
@@ -468,8 +527,8 @@ export default function AiNewsPageClient() {
               />
               <CandidateSection
                 title="还能追"
-                items={followCandidates}
-                offset={todayCandidates.length}
+                items={filteredFollow}
+                offset={filteredToday.length}
                 topicDraftMap={topicDraftMap}
                 briefOpenMap={briefOpenMap}
                 onBriefToggle={(clusterId, open) => {

--- a/src/components/news/news.css.ts
+++ b/src/components/news/news.css.ts
@@ -493,3 +493,11 @@ export const scoreBarsGrid = style({
   flex: 1,
   minWidth: '160px',
 });
+
+export const filterRow = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '12px',
+  alignItems: 'center',
+  marginBottom: vars.spacing.lg,
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -13,6 +13,8 @@ export async function register() {
     const { checkDueDrafts } = await import('@/lib/scheduler/checkDueDrafts');
     const { fetchAndPersistRssSignals, getRssFetchIntervalMs } =
       await import('@/lib/scheduler/fetchRssFeeds');
+    const { generateDailyDigest, getDigestIntervalMs } =
+      await import('@/lib/scheduler/generateDailyDigest');
 
     registerTask({
       name: 'check-due-drafts',
@@ -26,6 +28,13 @@ export async function register() {
       intervalMs: getRssFetchIntervalMs(),
       handler: fetchAndPersistRssSignals,
       runOnStart: true,
+    });
+
+    registerTask({
+      name: 'generate-daily-digest',
+      intervalMs: getDigestIntervalMs(),
+      handler: generateDailyDigest,
+      runOnStart: false,
     });
 
     startScheduler();

--- a/src/lib/ai-news/index.ts
+++ b/src/lib/ai-news/index.ts
@@ -245,11 +245,23 @@ export async function fetchAiNewsSignals(hours = 24) {
   }));
   const allSources = [...AI_NEWS_SOURCES, ...customSources];
 
-  const results = await Promise.allSettled(
-    allSources.map((source) => fetchSourceSignals(source, cutoffTime)),
-  );
+  const [rssResults, xResult, arxivResult] = await Promise.all([
+    Promise.allSettled(allSources.map((source) => fetchSourceSignals(source, cutoffTime))),
+    import('@/lib/ai-news/sources/x')
+      .then((m) => m.fetchXSignals(hours))
+      .catch(() => [] as NormalizedAiNewsSignal[]),
+    import('@/lib/ai-news/sources/arxiv')
+      .then((m) => m.fetchArxivSignals(hours))
+      .catch(() => [] as NormalizedAiNewsSignal[]),
+  ]);
 
-  return results.flatMap((result) => (result.status === 'fulfilled' ? result.value : []));
+  const rssSignals = rssResults.flatMap((result) =>
+    result.status === 'fulfilled' ? result.value : [],
+  );
+  const xSignals = Array.isArray(xResult) ? xResult : [];
+  const arxivSignals = Array.isArray(arxivResult) ? arxivResult : [];
+
+  return [...rssSignals, ...xSignals, ...arxivSignals];
 }
 
 export function buildAiNewsDeskFromSignals(

--- a/src/lib/ai-news/persistSignals.ts
+++ b/src/lib/ai-news/persistSignals.ts
@@ -2,7 +2,9 @@ import { getSignalRegistry } from '@/lib/signals/registry';
 import type { CreateSignalInput } from '@/lib/signals/types';
 import type { NormalizedAiNewsSignal } from '@/lib/ai-news/types';
 
-function mapSourceType(aiNewsSourceType: string): 'rss' {
+function mapSourceType(aiNewsSourceType: string): CreateSignalInput['sourceType'] {
+  if (aiNewsSourceType === 'x') return 'x';
+  if (aiNewsSourceType === 'arxiv') return 'arxiv';
   return 'rss';
 }
 

--- a/src/lib/ai-news/sources/arxiv.ts
+++ b/src/lib/ai-news/sources/arxiv.ts
@@ -1,0 +1,89 @@
+import { fetchTextWithTimeout } from '@/lib/ai-news/requestTimeout';
+import { extractItems, extractTagValue, extractLink } from '@/lib/ai-news/normalize';
+import { extractEntityTokens, inferTopicTags } from '@/lib/ai-news/normalize';
+import { logger } from '@/lib/logger';
+import type { NormalizedAiNewsSignal, AiNewsSourceType } from '@/lib/ai-news/types';
+
+const ARXIV_FEEDS = [
+  { category: 'cs.AI', name: 'arXiv AI' },
+  { category: 'cs.CL', name: 'arXiv NLP' },
+  { category: 'cs.LG', name: 'arXiv ML' },
+];
+
+function hashId(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = ((hash << 5) - hash + char) | 0;
+  }
+  return `arxiv-${Math.abs(hash).toString(36)}`;
+}
+
+export async function fetchArxivSignals(hours = 24): Promise<NormalizedAiNewsSignal[]> {
+  const cutoffTime = Date.now() - hours * 60 * 60 * 1000;
+  const fetchedAt = new Date().toISOString();
+  const signals: NormalizedAiNewsSignal[] = [];
+
+  const results = await Promise.allSettled(
+    ARXIV_FEEDS.map(async (feed) => {
+      try {
+        const xml = await fetchTextWithTimeout(`http://export.arxiv.org/rss/${feed.category}`, {
+          timeoutMs: 15000,
+        });
+
+        const items = extractItems(xml);
+
+        for (const item of items) {
+          const rawLink = extractLink(item) ?? '';
+          const title = (extractTagValue(item, 'title') ?? '').replace(/<[^>]+>/g, '').trim();
+          const description = (extractTagValue(item, 'description') ?? '')
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+
+          if (!title || !rawLink) continue;
+
+          const link = rawLink
+            .replace(/\/abs\//, '/abs/')
+            .split('?')[0]
+            .split('v')[0];
+          const arxivId = link.split('/abs/').pop() ?? '';
+          if (!arxivId) continue;
+
+          // arXiv RSS doesn't include reliable publish dates; use current time minus offset
+          const publishedAt = new Date(
+            Math.max(cutoffTime, Date.now() - hours * 30 * 60 * 1000),
+          ).toISOString();
+
+          signals.push({
+            id: hashId(arxivId),
+            title: title.slice(0, 200),
+            canonicalTitle: title.slice(0, 80).toLowerCase(),
+            summary: description.slice(0, 500) || title,
+            link,
+            sourceWeight: 4,
+            sourceName: feed.name,
+            sourceType: 'arxiv' as AiNewsSourceType,
+            sourceDomain: 'arxiv.org',
+            publishedAt,
+            fetchedAt,
+            entityTokens: extractEntityTokens(title, description.slice(0, 200)),
+            topicTags: inferTopicTags(title, description.slice(0, 200)),
+            isOfficialSource: false,
+          });
+        }
+      } catch (err) {
+        logger.warn(
+          `arXiv fetch failed for ${feed.category}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }),
+  );
+
+  const failed = results.filter((r) => r.status === 'rejected').length;
+  if (failed > 0) {
+    logger.warn(`arXiv source: ${failed}/${ARXIV_FEEDS.length} feeds failed`);
+  }
+
+  return signals;
+}

--- a/src/lib/ai-news/sources/x.ts
+++ b/src/lib/ai-news/sources/x.ts
@@ -1,0 +1,103 @@
+import { TwitterApi } from 'twitter-api-v2';
+import { getXConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import { extractEntityTokens, inferTopicTags } from '@/lib/ai-news/normalize';
+import type { NormalizedAiNewsSignal, AiNewsSourceType } from '@/lib/ai-news/types';
+
+interface KolAccount {
+  handle: string;
+  name: string;
+  weight: number;
+  sourceType: AiNewsSourceType;
+}
+
+const KOL_ACCOUNTS: KolAccount[] = [
+  { handle: 'OpenAI', name: 'OpenAI', weight: 5, sourceType: 'official' },
+  { handle: 'AnthropicAI', name: 'Anthropic', weight: 5, sourceType: 'official' },
+  { handle: 'GoogleDeepMind', name: 'DeepMind', weight: 5, sourceType: 'official' },
+  { handle: 'ylecun', name: 'Yann LeCun', weight: 4, sourceType: 'community' },
+  { handle: 'AndrewYNg', name: 'Andrew Ng', weight: 4, sourceType: 'community' },
+  { handle: 'kaborogepa', name: 'Jim Fan', weight: 4, sourceType: 'community' },
+  { handle: 'swaborogek', name: 'Andrej Karpathy', weight: 4, sourceType: 'community' },
+  { handle: 'goodfellow_ian', name: 'Ian Goodfellow', weight: 4, sourceType: 'community' },
+  { handle: 'kaborogepa', name: 'Sam Altman', weight: 5, sourceType: 'official' },
+  { handle: 'GoogleAI', name: 'Google AI', weight: 5, sourceType: 'official' },
+];
+
+function hashId(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = ((hash << 5) - hash + char) | 0;
+  }
+  return `x-${Math.abs(hash).toString(36)}`;
+}
+
+export async function fetchXSignals(hours = 24): Promise<NormalizedAiNewsSignal[]> {
+  const config = getXConfig();
+  if (!config.apiKey || !config.apiSecret || !config.accessToken || !config.accessTokenSecret) {
+    return [];
+  }
+
+  const client = new TwitterApi({
+    appKey: config.apiKey,
+    appSecret: config.apiSecret,
+    accessToken: config.accessToken,
+    accessSecret: config.accessTokenSecret,
+  });
+
+  const cutoffTime = Date.now() - hours * 60 * 60 * 1000;
+  const fetchedAt = new Date().toISOString();
+  const signals: NormalizedAiNewsSignal[] = [];
+
+  const results = await Promise.allSettled(
+    KOL_ACCOUNTS.map(async (account) => {
+      try {
+        const user = await client.v2.userByUsername(account.handle);
+        if (!user.data?.id) return;
+
+        const timeline = await client.v2.userTimeline(user.data.id, {
+          max_results: 10,
+          exclude: ['replies', 'retweets'],
+          'tweet.fields': ['created_at', 'text'],
+        });
+
+        for (const tweet of timeline.tweets ?? []) {
+          const publishedAt = new Date(tweet.created_at!).toISOString();
+          if (Date.parse(publishedAt) < cutoffTime) continue;
+
+          const text = tweet.text ?? '';
+          if (text.length < 20) continue;
+
+          signals.push({
+            id: hashId(tweet.id),
+            title: text.slice(0, 100).replace(/\n/g, ' '),
+            canonicalTitle: text.slice(0, 80).toLowerCase().replace(/\n/g, ' '),
+            summary: text,
+            link: `https://x.com/${account.handle}/status/${tweet.id}`,
+            sourceWeight: account.weight,
+            sourceName: account.name,
+            sourceType: 'x' as AiNewsSourceType,
+            sourceDomain: 'x.com',
+            publishedAt,
+            fetchedAt,
+            entityTokens: extractEntityTokens(text.slice(0, 100), ''),
+            topicTags: inferTopicTags(text.slice(0, 100), ''),
+            isOfficialSource: account.sourceType === 'official',
+          });
+        }
+      } catch (err) {
+        logger.warn(
+          `X fetch failed for @${account.handle}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }),
+  );
+
+  const failed = results.filter((r) => r.status === 'rejected').length;
+  if (failed > 0) {
+    logger.warn(`X source: ${failed}/${KOL_ACCOUNTS.length} accounts failed`);
+  }
+
+  return signals;
+}

--- a/src/lib/ai-news/sources/x.ts
+++ b/src/lib/ai-news/sources/x.ts
@@ -17,10 +17,10 @@ const KOL_ACCOUNTS: KolAccount[] = [
   { handle: 'GoogleDeepMind', name: 'DeepMind', weight: 5, sourceType: 'official' },
   { handle: 'ylecun', name: 'Yann LeCun', weight: 4, sourceType: 'community' },
   { handle: 'AndrewYNg', name: 'Andrew Ng', weight: 4, sourceType: 'community' },
-  { handle: 'kaborogepa', name: 'Jim Fan', weight: 4, sourceType: 'community' },
-  { handle: 'swaborogek', name: 'Andrej Karpathy', weight: 4, sourceType: 'community' },
+  { handle: 'DrJimFan', name: 'Jim Fan', weight: 4, sourceType: 'community' },
+  { handle: 'karpathy', name: 'Andrej Karpathy', weight: 4, sourceType: 'community' },
   { handle: 'goodfellow_ian', name: 'Ian Goodfellow', weight: 4, sourceType: 'community' },
-  { handle: 'kaborogepa', name: 'Sam Altman', weight: 5, sourceType: 'official' },
+  { handle: 'sama', name: 'Sam Altman', weight: 5, sourceType: 'official' },
   { handle: 'GoogleAI', name: 'Google AI', weight: 5, sourceType: 'official' },
 ];
 

--- a/src/lib/ai-news/types.ts
+++ b/src/lib/ai-news/types.ts
@@ -1,4 +1,4 @@
-export type AiNewsSourceType = 'media' | 'official' | 'community';
+export type AiNewsSourceType = 'media' | 'official' | 'community' | 'x' | 'arxiv';
 
 export interface AiNewsSource {
   name: string;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -32,3 +32,7 @@ export function getXConfig() {
     accessTokenSecret: process.env.X_ACCESS_TOKEN_SECRET || '',
   };
 }
+
+export function getSiteUrl() {
+  return process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+}

--- a/src/lib/drafts/store.ts
+++ b/src/lib/drafts/store.ts
@@ -58,6 +58,7 @@ export function createDraftStore(options: DraftStoreOptions = {}) {
         ...(input.contentGoal ? { contentGoal: input.contentGoal } : {}),
         ...(input.scheduledAt ? { scheduledAt: input.scheduledAt } : {}),
         ...(input.platforms ? { platforms: input.platforms } : {}),
+        ...(input.tags ? { tags: input.tags } : {}),
         createdAt: timestamp,
         updatedAt: timestamp,
       };

--- a/src/lib/drafts/types.ts
+++ b/src/lib/drafts/types.ts
@@ -40,6 +40,7 @@ export interface CreateDraftInput {
   contentGoal?: string;
   scheduledAt?: string;
   platforms?: PlatformId[];
+  tags?: string[];
 }
 
 export type UpdateDraftInput = Partial<

--- a/src/lib/scheduler/generateDailyDigest.ts
+++ b/src/lib/scheduler/generateDailyDigest.ts
@@ -1,0 +1,88 @@
+import { fetchAiNewsSignals, buildAiNewsDeskFromSignals } from '@/lib/ai-news';
+import { getDraftRegistry } from '@/lib/drafts/registry';
+import { logger } from '@/lib/logger';
+
+const TOP_N = 5;
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function generateDailyDigest() {
+  const now = new Date();
+  const dateStr = formatDate(now);
+  const digestTag = `daily-digest-${dateStr}`;
+
+  const registry = getDraftRegistry();
+  const existing = registry.listDrafts().find((d) => d.tags?.includes(digestTag));
+  if (existing) {
+    logger.info(`Daily digest for ${dateStr} already exists (${existing.id})`);
+    return;
+  }
+
+  const signals = await fetchAiNewsSignals(24);
+  if (signals.length === 0) {
+    logger.info('No signals found, skipping daily digest');
+    return;
+  }
+
+  const desk = buildAiNewsDeskFromSignals(signals, now, 40);
+  const allCandidates = [...desk.todayCandidates, ...desk.followCandidates]
+    .sort((a, b) => b.totalScore - a.totalScore)
+    .slice(0, TOP_N);
+
+  if (allCandidates.length === 0) {
+    logger.info('No candidates scored, skipping daily digest');
+    return;
+  }
+
+  const sections = allCandidates.map((c, i) => {
+    const score = Math.round(c.totalScore);
+    const sources = c.signals.map((s) => s.sourceName).filter((v, j, a) => a.indexOf(v) === j);
+    const mainLink = c.primarySignal.link;
+
+    let section = `## ${i + 1}. ${c.title}\n\n`;
+    section += `**精选指数**: ${score} | **来源数**: ${c.coverageCount} | **信源**: ${sources.slice(0, 3).join('、')}\n\n`;
+
+    if (c.primarySignal.summary) {
+      section += `${c.primarySignal.summary}\n\n`;
+    }
+
+    if (c.whyNow) {
+      section += `> **为什么值得关注**: ${c.whyNow}\n>\n`;
+    }
+
+    if (c.researchBrief.recommendedAngles.length > 0) {
+      const angle = c.researchBrief.recommendedAngles[0];
+      section += `> **推荐写法**: ${angle.label} — ${angle.reason}\n>\n`;
+    }
+
+    section += `[阅读原文](${mainLink})\n`;
+    return section;
+  });
+
+  const intro = [
+    `# AI 日报 · ${dateStr}\n`,
+    `> ${desk.totalSignals} 条信源，精选 ${allCandidates.length} 条值得关注的话题。\n`,
+    `---\n`,
+  ].join('\n');
+
+  const footer = `\n---\n\n*由 Publio 自动生成 · ${now.toLocaleString('zh-CN')}*`;
+
+  const content = intro + sections.join('\n---\n\n') + footer;
+
+  const draft = registry.createDraft({
+    title: `AI 日报 · ${dateStr}`,
+    content,
+    source: 'ai-news',
+    tags: ['daily-digest', digestTag],
+  });
+
+  logger.info(
+    `Daily digest created: ${draft.id} (${allCandidates.length} topics, ${signals.length} signals)`,
+  );
+}
+
+export function getDigestIntervalMs() {
+  return 24 * 60 * 60 * 1000;
+}

--- a/src/lib/signals/types.ts
+++ b/src/lib/signals/types.ts
@@ -2,7 +2,7 @@ import type { PlatformId } from '@/types';
 
 export type SignalStatus = 'new' | 'saved' | 'dismissed' | 'converted';
 
-export type SignalSourceType = 'rss' | 'url' | 'manual' | 'import';
+export type SignalSourceType = 'rss' | 'url' | 'manual' | 'import' | 'x' | 'arxiv';
 
 export interface SignalScore {
   freshness: number;


### PR DESCRIPTION
## Summary

- **Daily digest auto-generation**: Scheduled task generates a Markdown digest draft from top-scoring AI news candidates every 24h, with dedup by date
- **Multi-view filtering**: Source type (media/official/community) and score (high/medium) filter chips on the AI news page
- **RSS output feed**: `/feed/published.xml` exposes completed sync tasks as RSS 2.0, with autodiscovery link in layout
- **X + arXiv sources**: Parallel-fetch X KOL timelines and arXiv RSS feeds alongside existing RSS sources, with graceful fallback when credentials are missing
- **CSP fix**: Conditionally add `unsafe-eval` to script-src in development mode to restore React Refresh

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (332 tests)
- [ ] Verify daily digest draft appears in `.publio-data/` after scheduler fires
- [ ] Verify filter chips on `/ai-news` page filter candidates correctly
- [ ] Visit `/feed/published.xml` and confirm valid RSS XML
- [ ] With X credentials configured, confirm X signals appear in `/api/ai-news` response
- [ ] Without X/arXiv credentials, confirm pipeline still returns RSS signals (graceful degradation)
- [ ] Confirm dev mode buttons work (CSP fix)