### PR TITLE
feat: LLM-enhanced scoring and recommendation for AI news

### DIFF
--- a/src/lib/ai-news/index.ts
+++ b/src/lib/ai-news/index.ts
@@ -13,6 +13,8 @@ import { buildResearchBrief } from '@/lib/ai-news/research';
 import { scoreAiNewsCluster } from '@/lib/ai-news/score';
 import { AI_NEWS_SOURCES } from '@/lib/ai-news/sources';
 import { getEnabledCustomSources } from '@/lib/rss-sources/store';
+import { enhanceClusterWithLLM, isLlmAvailable } from '@/lib/ai-news/llm';
+import { logger } from '@/lib/logger';
 import type {
   AiNewsDesk,
   AiNewsDeskCandidate,
@@ -67,8 +69,12 @@ async function fetchSourceSignals(source: AiNewsSource, cutoffTime: number) {
     });
 }
 
-function buildCandidate(cluster: ReturnType<typeof scoreAiNewsCluster>): AiNewsDeskCandidate {
-  const researchBrief = buildResearchBrief(cluster);
+function buildCandidate(
+  cluster: ReturnType<typeof scoreAiNewsCluster>,
+  llmWhyItMatters?: string,
+  llmScoreReason?: string,
+): AiNewsDeskCandidate {
+  const researchBrief = buildResearchBrief(cluster, llmWhyItMatters, llmScoreReason);
 
   return {
     ...cluster,
@@ -298,11 +304,62 @@ export async function buildAiNewsDesk(hours = 24, poolSize = 40, displaySize = 1
     ...desk.followCandidates,
   ]);
   const generatedAt = new Date(desk.generatedAt);
+
+  // Re-score after image hydration
+  const scoredCandidates = hydratedCandidates
+    .map((candidate) => scoreAiNewsCluster(candidate, generatedAt))
+    .sort((a, b) => {
+      if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore;
+      return Date.parse(b.latestPublishedAt) - Date.parse(a.latestPublishedAt);
+    })
+    .slice(0, poolSize);
+
+  // LLM enhancement for top candidates
+  let llmEnhanced = scoredCandidates;
+  if (isLlmAvailable()) {
+    logger.info('LLM enhancement started', { candidateCount: scoredCandidates.length });
+
+    const llmResults = await Promise.allSettled(
+      scoredCandidates.map((cluster) => enhanceClusterWithLLM(cluster)),
+    );
+
+    llmEnhanced = scoredCandidates.map((cluster, i) => {
+      const result = llmResults[i];
+      if (result.status !== 'fulfilled' || !result.value) return cluster;
+
+      const { score: llmScore, recommendation } = result.value;
+
+      // Mix LLM score with rule-based score: 60% LLM + 40% rules
+      const mixedScore =
+        llmScore !== null
+          ? Math.round(llmScore * 0.6 + cluster.totalScore * 0.4)
+          : cluster.totalScore;
+
+      return {
+        ...cluster,
+        totalScore: mixedScore,
+        _llmRecommendation: recommendation,
+        _llmScoreReason: result.value.scoreReason,
+      } as typeof cluster & { _llmRecommendation?: string | null; _llmScoreReason?: string | null };
+    });
+
+    logger.info('LLM enhancement completed');
+  }
+
   const candidates = shuffleCandidates(
     diversifyCandidates(
-      hydratedCandidates
-        .map((candidate) => scoreAiNewsCluster(candidate, generatedAt))
-        .map((candidate) => buildCandidate(candidate))
+      llmEnhanced
+        .map((cluster) => {
+          const { _llmRecommendation, _llmScoreReason, ...rest } = cluster as typeof cluster & {
+            _llmRecommendation?: string | null;
+            _llmScoreReason?: string | null;
+          };
+          return buildCandidate(
+            rest,
+            _llmRecommendation ?? undefined,
+            _llmScoreReason ?? undefined,
+          );
+        })
         .sort(sortCandidates),
       displaySize,
     ),

--- a/src/lib/ai-news/llm.ts
+++ b/src/lib/ai-news/llm.ts
@@ -1,0 +1,135 @@
+import { getAgentConfig, isAgentConfigured } from '@/lib/agent/config';
+import { createLLMProvider } from '@/lib/agent/provider';
+import type { ChatMessage } from '@/lib/agent/types';
+import type { ScoredAiNewsCluster } from '@/lib/ai-news/types';
+import { logger } from '@/lib/logger';
+
+const LLM_TIMEOUT_MS = 15_000;
+
+async function callLLM(systemPrompt: string, userPrompt: string): Promise<string | null> {
+  if (!isAgentConfigured()) return null;
+
+  const config = getAgentConfig();
+  if (!config) return null;
+
+  const provider = createLLMProvider(config, config.provider);
+  const messages: ChatMessage[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userPrompt },
+  ];
+
+  const chunks: string[] = [];
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+
+  try {
+    for await (const token of provider.stream({
+      messages,
+      temperature: 0.3,
+      maxTokens: 512,
+    })) {
+      chunks.push(token);
+    }
+    return chunks.join('').trim();
+  } catch (err) {
+    logger.warn('LLM call failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+const SCORING_SYSTEM_PROMPT = `你是一个 AI 新闻编辑，负责为中文 AI 从业者评估新闻价值。
+你需要对一条新闻聚合（可能包含多条来源报道）打分，并给出简短理由。
+
+评分标准（0-100）：
+- 热度：事件在社区/社交媒体的讨论量和传播速度
+- 信息密度：这条新闻包含多少"可行动的"信息，而非泛泛的公关稿
+- 实用价值：对中文 AI 从业者（开发者、产品经理、内容创作者）有多大参考意义
+
+输出格式（严格遵守）：
+分数|理由
+例如：82|这是首个将AI助手作为攻击面的供应链攻击案例，对使用Claude Code和Cursor的开发者有直接安全影响。
+
+只输出一行，不要其他内容。`;
+
+export async function llmScoreCluster(
+  cluster: ScoredAiNewsCluster,
+): Promise<{ score: number; reason: string } | null> {
+  const signals = cluster.signals.slice(0, 3);
+  const signalInfo = signals
+    .map((s, i) => `${i + 1}. [${s.sourceName}] ${s.title}\n   ${s.summary?.slice(0, 150) ?? ''}`)
+    .join('\n');
+
+  const userPrompt = `新闻标题：${cluster.title}
+来源数量：${cluster.coverageCount} 条（官方 ${cluster.officialSourceCount}，媒体 ${cluster.mediaSourceCount}）
+规则引擎评分：${cluster.totalScore}
+
+信号列表：
+${signalInfo}
+
+请打分并给出理由。`;
+
+  const result = await callLLM(SCORING_SYSTEM_PROMPT, userPrompt);
+  if (!result) return null;
+
+  const pipeIndex = result.indexOf('|');
+  if (pipeIndex === -1) return null;
+
+  const scoreStr = result.slice(0, pipeIndex).trim();
+  const reason = result.slice(pipeIndex + 1).trim();
+
+  const score = parseInt(scoreStr, 10);
+  if (!Number.isFinite(score) || score < 0 || score > 100) return null;
+
+  return { score, reason };
+}
+
+const RECOMMENDATION_SYSTEM_PROMPT = `你是一个面向中文 AI 从业者的新闻编辑。
+为一条新闻写 1-2 句推荐理由，帮助读者快速判断"这条新闻跟我有什么关系"。
+
+要求：
+- 提供判断视角，不复述内容
+- 直接说价值：对谁有用、能用来做什么、为什么现在值得关注
+- 风格简洁有力，不要"值得注意的是"这类套话
+- 中文输出，不超过 80 字`;
+
+export async function llmGenerateRecommendation(
+  cluster: ScoredAiNewsCluster,
+): Promise<string | null> {
+  const signals = cluster.signals.slice(0, 2);
+  const signalInfo = signals.map((s) => `[${s.sourceName}] ${s.title}`).join('、');
+
+  const userPrompt = `标题：${cluster.title}
+来源：${signalInfo}
+聚合数：${cluster.coverageCount} 条报道
+
+写推荐理由。`;
+
+  return callLLM(RECOMMENDATION_SYSTEM_PROMPT, userPrompt);
+}
+
+export interface LlmEnhancement {
+  score: number | null;
+  scoreReason: string | null;
+  recommendation: string | null;
+}
+
+export async function enhanceClusterWithLLM(cluster: ScoredAiNewsCluster): Promise<LlmEnhancement> {
+  const [scoringResult, recommendation] = await Promise.all([
+    llmScoreCluster(cluster),
+    llmGenerateRecommendation(cluster),
+  ]);
+
+  return {
+    score: scoringResult?.score ?? null,
+    scoreReason: scoringResult?.reason ?? null,
+    recommendation,
+  };
+}
+
+export function isLlmAvailable(): boolean {
+  return isAgentConfigured();
+}

--- a/src/lib/ai-news/research.ts
+++ b/src/lib/ai-news/research.ts
@@ -169,7 +169,11 @@ function buildWhatHappened(cluster: ScoredAiNewsCluster): string {
   return `${base}${summaryPart}${statPart}`;
 }
 
-export function buildResearchBrief(cluster: ScoredAiNewsCluster): ResearchBrief {
+export function buildResearchBrief(
+  cluster: ScoredAiNewsCluster,
+  llmWhyItMatters?: string,
+  llmScoreReason?: string,
+): ResearchBrief {
   const primary = cluster.primarySignal;
   const leadImageUrl =
     primary.imageUrl || cluster.signals.find((signal) => signal.imageUrl)?.imageUrl;
@@ -181,7 +185,7 @@ export function buildResearchBrief(cluster: ScoredAiNewsCluster): ResearchBrief 
     imageUrl: leadImageUrl,
     articleImages: primary.articleImages,
     whatHappened: buildWhatHappened(cluster),
-    whyItMatters: buildWhyItMatters(cluster),
+    whyItMatters: llmWhyItMatters || buildWhyItMatters(cluster),
     whoIsAffected: buildAffectedAudience(cluster),
     recommendedAngles: buildAngles(cluster),
     background: buildBackground(cluster),
@@ -189,6 +193,8 @@ export function buildResearchBrief(cluster: ScoredAiNewsCluster): ResearchBrief 
     evidence: buildEvidence(cluster),
     scores: cluster.scores,
     totalScore: cluster.totalScore,
+    llmGenerated: !!llmWhyItMatters,
+    llmScoreReason,
   };
 }
 

--- a/src/lib/ai-news/types.ts
+++ b/src/lib/ai-news/types.ts
@@ -101,6 +101,8 @@ export interface ResearchBrief {
   evidence: ResearchEvidence[];
   scores: AiNewsScores;
   totalScore: number;
+  llmGenerated?: boolean;
+  llmScoreReason?: string;
 }
 
 export interface AiNewsDeskCandidate extends ScoredAiNewsCluster {


### PR DESCRIPTION
## Summary

- **LLM scoring**: Re-scores top candidates using LLM, mixing 60% LLM + 40% rule-based score for stability
- **LLM recommendation**: Generates personalized `whyItMatters` text per candidate, replacing template-based text
- **Graceful degradation**: Falls back to pure rule engine when Agent is not configured or LLM calls fail/times out (15s limit)

### How it works

In the pre-computed background pipeline (`buildAiNewsDesk`), after clustering and rule-based scoring:
1. Checks if Agent is configured (`isAgentConfigured()`)
2. For each candidate, concurrently calls LLM for scoring + recommendation
3. LLM score mixed with rule score (60/40) to prevent instability
4. LLM recommendation replaces template `whyItMatters` when available

### New file
- `src/lib/ai-news/llm.ts` — `callLLM` helper, `llmScoreCluster`, `llmGenerateRecommendation`, `enhanceClusterWithLLM`

### Modified files
- `src/lib/ai-news/index.ts` — LLM enhancement step in `buildAiNewsDesk`
- `src/lib/ai-news/types.ts` — `ResearchBrief` adds `llmGenerated` and `llmScoreReason` fields
- `src/lib/ai-news/research.ts` — `buildResearchBrief` accepts optional LLM results

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (332 tests)
- [ ] Without Agent configured: pipeline produces identical results to before (pure rule engine)
- [ ] With Agent configured: candidates show LLM-generated recommendation reasons
- [ ] With Agent configured: scores reflect LLM+rules mix
- [ ] LLM timeout/failure: pipeline continues with rule-based fallback