### PR TITLE
feat: LLM Chinese summaries and score badge

### DIFF
--- a/src/components/news/TopicSignalCard.tsx
+++ b/src/components/news/TopicSignalCard.tsx
@@ -60,6 +60,7 @@ export default function TopicSignalCard({
             <div className={styles.metaLeft}>
               {/* 序号 */}
               <span className={styles.indexBadge}>{indexLabel}</span>
+              <span className={styles.scoreBadge}>精选 {item.totalScore}</span>
               <span className={styles.topicTag}>{item.topicTags[0] || '行业动态'}</span>
               <span className={styles.metaDot}>·</span>
               <a

--- a/src/components/news/news.css.ts
+++ b/src/components/news/news.css.ts
@@ -238,6 +238,17 @@ export const indexBadge = style({
   color: vars.color.signal,
 });
 
+export const scoreBadge = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  borderRadius: vars.radius.lg,
+  padding: '4px 10px',
+  fontSize: '12px',
+  fontWeight: 600,
+  color: vars.color.accent,
+  background: vars.color.accentSoft,
+});
+
 export const topicTag = style({
   fontSize: '13px',
   fontWeight: 500,

--- a/src/lib/ai-news/index.ts
+++ b/src/lib/ai-news/index.ts
@@ -73,8 +73,9 @@ function buildCandidate(
   cluster: ReturnType<typeof scoreAiNewsCluster>,
   llmWhyItMatters?: string,
   llmScoreReason?: string,
+  llmSummary?: string,
 ): AiNewsDeskCandidate {
-  const researchBrief = buildResearchBrief(cluster, llmWhyItMatters, llmScoreReason);
+  const researchBrief = buildResearchBrief(cluster, llmWhyItMatters, llmScoreReason, llmSummary);
 
   return {
     ...cluster,
@@ -340,7 +341,12 @@ export async function buildAiNewsDesk(hours = 24, poolSize = 40, displaySize = 1
         totalScore: mixedScore,
         _llmRecommendation: recommendation,
         _llmScoreReason: result.value.scoreReason,
-      } as typeof cluster & { _llmRecommendation?: string | null; _llmScoreReason?: string | null };
+        _llmSummary: result.value.summary,
+      } as typeof cluster & {
+        _llmRecommendation?: string | null;
+        _llmScoreReason?: string | null;
+        _llmSummary?: string | null;
+      };
     });
 
     logger.info('LLM enhancement completed');
@@ -350,14 +356,17 @@ export async function buildAiNewsDesk(hours = 24, poolSize = 40, displaySize = 1
     diversifyCandidates(
       llmEnhanced
         .map((cluster) => {
-          const { _llmRecommendation, _llmScoreReason, ...rest } = cluster as typeof cluster & {
-            _llmRecommendation?: string | null;
-            _llmScoreReason?: string | null;
-          };
+          const { _llmRecommendation, _llmScoreReason, _llmSummary, ...rest } =
+            cluster as typeof cluster & {
+              _llmRecommendation?: string | null;
+              _llmScoreReason?: string | null;
+              _llmSummary?: string | null;
+            };
           return buildCandidate(
             rest,
             _llmRecommendation ?? undefined,
             _llmScoreReason ?? undefined,
+            _llmSummary ?? undefined,
           );
         })
         .sort(sortCandidates),

--- a/src/lib/ai-news/llm.ts
+++ b/src/lib/ai-news/llm.ts
@@ -111,22 +111,50 @@ export async function llmGenerateRecommendation(
   return callLLM(RECOMMENDATION_SYSTEM_PROMPT, userPrompt);
 }
 
+const SUMMARY_SYSTEM_PROMPT = `你是一个 AI 新闻编辑。为一条新闻聚合写一段精炼的中文摘要。
+
+要求：
+- 综合 2-3 个来源的核心信息，形成连贯摘要
+- 突出关键事实（谁做了什么、有什么影响、具体数据）
+- 省略公关辞令和空洞描述
+- 中文输出，150 字以内`;
+
+export async function llmGenerateSummary(cluster: ScoredAiNewsCluster): Promise<string | null> {
+  const signals = cluster.signals.slice(0, 3);
+  const signalInfo = signals
+    .map((s) => `【${s.sourceName}】${s.title}${s.summary ? `\n${s.summary.slice(0, 200)}` : ''}`)
+    .join('\n\n');
+
+  const userPrompt = `标题：${cluster.title}
+聚合数：${cluster.coverageCount} 条报道
+
+来源：
+${signalInfo}
+
+写摘要。`;
+
+  return callLLM(SUMMARY_SYSTEM_PROMPT, userPrompt);
+}
+
 export interface LlmEnhancement {
   score: number | null;
   scoreReason: string | null;
   recommendation: string | null;
+  summary: string | null;
 }
 
 export async function enhanceClusterWithLLM(cluster: ScoredAiNewsCluster): Promise<LlmEnhancement> {
-  const [scoringResult, recommendation] = await Promise.all([
+  const [scoringResult, recommendation, summary] = await Promise.all([
     llmScoreCluster(cluster),
     llmGenerateRecommendation(cluster),
+    llmGenerateSummary(cluster),
   ]);
 
   return {
     score: scoringResult?.score ?? null,
     scoreReason: scoringResult?.reason ?? null,
     recommendation,
+    summary,
   };
 }
 

--- a/src/lib/ai-news/research.ts
+++ b/src/lib/ai-news/research.ts
@@ -173,6 +173,7 @@ export function buildResearchBrief(
   cluster: ScoredAiNewsCluster,
   llmWhyItMatters?: string,
   llmScoreReason?: string,
+  llmSummary?: string,
 ): ResearchBrief {
   const primary = cluster.primarySignal;
   const leadImageUrl =
@@ -184,7 +185,7 @@ export function buildResearchBrief(
     bucket: cluster.bucket,
     imageUrl: leadImageUrl,
     articleImages: primary.articleImages,
-    whatHappened: buildWhatHappened(cluster),
+    whatHappened: llmSummary || buildWhatHappened(cluster),
     whyItMatters: llmWhyItMatters || buildWhyItMatters(cluster),
     whoIsAffected: buildAffectedAudience(cluster),
     recommendedAngles: buildAngles(cluster),
@@ -193,8 +194,9 @@ export function buildResearchBrief(
     evidence: buildEvidence(cluster),
     scores: cluster.scores,
     totalScore: cluster.totalScore,
-    llmGenerated: !!llmWhyItMatters,
+    llmGenerated: !!llmWhyItMatters || !!llmSummary,
     llmScoreReason,
+    llmSummary,
   };
 }
 

--- a/src/lib/ai-news/types.ts
+++ b/src/lib/ai-news/types.ts
@@ -103,6 +103,7 @@ export interface ResearchBrief {
   totalScore: number;
   llmGenerated?: boolean;
   llmScoreReason?: string;
+  llmSummary?: string;
 }
 
 export interface AiNewsDeskCandidate extends ScoredAiNewsCluster {


### PR DESCRIPTION
## Summary

- **LLM Chinese summaries**: Generate concise Chinese summaries for each news candidate using LLM, replacing truncated original text in the research brief's `whatHappened` field
- **Score badge**: Display "精选 XX" score badge in card header alongside the topic tag (AI HOT style)

### Changes
- `src/lib/ai-news/llm.ts` — Add `llmGenerateSummary()` with summary-specific prompt, all 3 LLM calls (score, recommendation, summary) now run in parallel
- `src/lib/ai-news/research.ts` — `buildResearchBrief` accepts optional `llmSummary`, uses it for `whatHappened`
- `src/lib/ai-news/types.ts` — `ResearchBrief` adds `llmSummary` field
- `src/lib/ai-news/index.ts` — Pipeline passes LLM summary through to candidates
- `src/components/news/TopicSignalCard.tsx` — Score badge in header
- `src/components/news/news.css.ts` — `scoreBadge` style

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (332 tests)
- [ ] Without Agent: cards show score badge, `whatHappened` uses rule-based text
- [ ] With Agent: `whatHappened` shows LLM-generated Chinese summary
- [ ] Score badge visible on each card next to topic tag