### PR TITLE
refactor: simplify AI news page to single unified list

### DIFF
--- a/src/app/api/ai-news/route.ts
+++ b/src/app/api/ai-news/route.ts
@@ -25,8 +25,7 @@ export async function GET() {
         generatedAt: '',
         totalSignals: 0,
         totalCandidates: 0,
-        todayCandidates: [],
-        followCandidates: [],
+        candidates: [],
         selectedResearch: null,
         signalIds: [],
       });
@@ -42,8 +41,7 @@ export async function GET() {
       generatedAt: '',
       totalSignals: 0,
       totalCandidates: 0,
-      todayCandidates: [],
-      followCandidates: [],
+      candidates: [],
       selectedResearch: null,
       signalIds: [],
     });

--- a/src/components/news/AiNewsPageClient.tsx
+++ b/src/components/news/AiNewsPageClient.tsx
@@ -5,9 +5,6 @@ import { useRouter } from 'next/navigation';
 
 import TopicDeskHeader from '@/components/news/TopicDeskHeader';
 import TopicSignalCard from '@/components/news/TopicSignalCard';
-import SignalInbox from '@/components/news/SignalInbox';
-import TopicLibrary from '@/components/news/TopicLibrary';
-import SignalReviewPanel from '@/components/news/SignalReviewPanel';
 import FilterChipGroup from '@/components/ui/FilterChipGroup';
 import type { AiNewsDeskCandidate } from '@/lib/aiNews';
 import { buildResearchDraftMarkdown } from '@/lib/newsDraft';
@@ -15,12 +12,18 @@ import { createDraft } from '@/lib/drafts/client';
 import { useAgentStore } from '@/stores/agentStore';
 import type { AgentStreamEvent } from '@/lib/agent/types';
 import type { AiNewsSourceType } from '@/lib/ai-news/types';
+import EmptyState from '@/components/feedback/EmptyState';
+import { Newspaper } from 'lucide-react';
+import TopicRecommendationPanel from '@/components/copilot/TopicRecommendationPanel';
+import * as styles from './news.css';
 
 const SOURCE_TYPE_OPTIONS = [
   { value: 'all', label: '全部来源' },
   { value: 'media', label: '媒体' },
   { value: 'official', label: '官方' },
   { value: 'community', label: '社区' },
+  { value: 'x', label: 'X' },
+  { value: 'arxiv', label: 'arXiv' },
 ] as const;
 
 const SCORE_OPTIONS = [
@@ -28,12 +31,7 @@ const SCORE_OPTIONS = [
   { value: 'high', label: '高分 (≥70)' },
   { value: 'medium', label: '中等 (40-69)' },
 ] as const;
-import EmptyState from '@/components/feedback/EmptyState';
-import { Newspaper } from 'lucide-react';
-import TopicRecommendationPanel from '@/components/copilot/TopicRecommendationPanel';
-import * as styles from './news.css';
 
-// localStorage key for tracking which topic clusters have drafts in this session
 const TOPIC_DRAFT_MAP_KEY = 'publio-topic-draft-map';
 
 function loadTopicDraftMap(): Record<string, string> {
@@ -58,8 +56,7 @@ interface AiNewsResponse {
   generatedAt?: string;
   totalSignals?: number;
   totalCandidates?: number;
-  todayCandidates?: AiNewsDeskCandidate[];
-  followCandidates?: AiNewsDeskCandidate[];
+  candidates?: AiNewsDeskCandidate[];
   message?: string;
 }
 
@@ -91,7 +88,9 @@ function formatRelativeHours(value: string) {
     const minutes = Math.max(1, Math.round(diffMs / (1000 * 60)));
     return `${minutes} 分钟前`;
   }
-  return `${diffHours.toFixed(1)} 小时前`;
+  if (diffHours < 24) return `${diffHours.toFixed(1)} 小时前`;
+  const days = Math.round(diffHours / 24);
+  return `${days} 天前`;
 }
 
 function buildSectionLabel(index: number) {
@@ -105,50 +104,38 @@ function normalizeCandidate(candidate: AiNewsDeskCandidate | null | undefined) {
   return candidate;
 }
 
-// 模块级缓存：tab 切换回来时直接复用，不重复抓取；整页刷新后清空重新抓取
 interface NewsState {
-  todayCandidates: AiNewsDeskCandidate[];
-  followCandidates: AiNewsDeskCandidate[];
+  candidates: AiNewsDeskCandidate[];
   generatedAt: string;
   totalSignals: number;
   totalCandidates: number;
 }
 let cachedNewsState: NewsState | null = null;
-// 模块级缓存：保持卡片底稿展开/折叠状态，tab 切换回来时不重置
 const cachedBriefOpenMap: Map<string, boolean> = new Map();
 
 export default function AiNewsPageClient() {
   const router = useRouter();
-  const [todayCandidates, setTodayCandidates] = useState<AiNewsDeskCandidate[]>([]);
-  const [followCandidates, setFollowCandidates] = useState<AiNewsDeskCandidate[]>([]);
+  const [candidates, setCandidates] = useState<AiNewsDeskCandidate[]>([]);
   const [generatedAt, setGeneratedAt] = useState('');
   const [totalSignals, setTotalSignals] = useState(0);
-  const [totalCandidates, setTotalCandidates] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [draftError, setDraftError] = useState('');
-  // Maps clusterId → draftId for topics the user has sent to the writing desk
   const [topicDraftMap, setTopicDraftMap] = useState<Record<string, string>>({});
   const [briefOpenMap, setBriefOpenMap] = useState<Map<string, boolean>>(cachedBriefOpenMap);
   const [sourceTypeFilter, setSourceTypeFilter] = useState<string>('all');
   const [scoreFilter, setScoreFilter] = useState<string>('all');
-  const hasDeskDataRef = useRef(false);
+  const hasDataRef = useRef(false);
 
-  // Tab state: 选题台 vs 资讯 Inbox vs 选题库
-  const [viewTab, setViewTab] = useState<'desk' | 'inbox' | 'topics'>('desk');
-
-  // Deep research state
   const [agentEnabled, setAgentEnabled] = useState(false);
   const [deepResearchLoading, setDeepResearchLoading] = useState<Record<string, boolean>>({});
   const [deepResearchContent, setDeepResearchContent] = useState<Record<string, string>>({});
   const researchCache = useAgentStore((s) => s.researchCache);
   const cacheResearch = useAgentStore((s) => s.cacheResearch);
 
-  const allCandidates = [...todayCandidates, ...followCandidates];
-
-  const filteredToday = useMemo(() => {
-    if (sourceTypeFilter === 'all' && scoreFilter === 'all') return todayCandidates;
-    return todayCandidates.filter((c) => {
+  const filteredCandidates = useMemo(() => {
+    if (sourceTypeFilter === 'all' && scoreFilter === 'all') return candidates;
+    return candidates.filter((c) => {
       if (
         sourceTypeFilter !== 'all' &&
         c.primarySignal.sourceType !== (sourceTypeFilter as AiNewsSourceType)
@@ -158,23 +145,8 @@ export default function AiNewsPageClient() {
       if (scoreFilter === 'medium' && (c.totalScore < 40 || c.totalScore >= 70)) return false;
       return true;
     });
-  }, [todayCandidates, sourceTypeFilter, scoreFilter]);
+  }, [candidates, sourceTypeFilter, scoreFilter]);
 
-  const filteredFollow = useMemo(() => {
-    if (sourceTypeFilter === 'all' && scoreFilter === 'all') return followCandidates;
-    return followCandidates.filter((c) => {
-      if (
-        sourceTypeFilter !== 'all' &&
-        c.primarySignal.sourceType !== (sourceTypeFilter as AiNewsSourceType)
-      )
-        return false;
-      if (scoreFilter === 'high' && c.totalScore < 70) return false;
-      if (scoreFilter === 'medium' && (c.totalScore < 40 || c.totalScore >= 70)) return false;
-      return true;
-    });
-  }, [followCandidates, sourceTypeFilter, scoreFilter]);
-
-  // Check agent availability on mount
   useEffect(() => {
     fetch('/api/agent/status')
       .then((r) => r.json())
@@ -182,20 +154,19 @@ export default function AiNewsPageClient() {
       .catch(() => setAgentEnabled(false));
   }, []);
 
-  // Restore cached research results (TTL: 1h)
   useEffect(() => {
     const TTL = 60 * 60 * 1000;
     const restored: Record<string, string> = {};
     for (const [title, entry] of Object.entries(researchCache)) {
       if (Date.now() - entry.cachedAt > TTL) continue;
-      const match = allCandidates.find((c) => c.title === title);
+      const match = candidates.find((c) => c.title === title);
       if (match) restored[match.clusterId] = entry.analysis.raw;
     }
     if (Object.keys(restored).length > 0) {
       setDeepResearchContent((prev) => ({ ...prev, ...restored }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allCandidates.length]);
+  }, [candidates.length]);
 
   const handleDeepResearch = useCallback(
     async (item: AiNewsDeskCandidate) => {
@@ -260,7 +231,6 @@ export default function AiNewsPageClient() {
           }
         }
 
-        // Cache result
         cacheResearch({
           raw: accumulated,
           clusterTitle: item.title,
@@ -284,7 +254,6 @@ export default function AiNewsPageClient() {
         source: 'ai-news',
         topicClusterId: clusterId,
       });
-      // Track the mapping so this card shows "已加入" if the user comes back
       const updated = { ...loadTopicDraftMap(), [clusterId]: draft.id };
       saveTopicDraftMap(updated);
       setTopicDraftMap(updated);
@@ -335,27 +304,20 @@ export default function AiNewsPageClient() {
       const response = await fetch('/api/ai-news', { cache: 'no-store' });
       const data: AiNewsResponse = await response.json();
 
-      if (!response.ok || !data.ok || !data.todayCandidates || !data.followCandidates) {
+      if (!response.ok || !data.ok || !data.candidates) {
         throw new Error(data.message || '新闻加载失败，请稍后重试。');
       }
 
-      const nextTodayCandidates = data.todayCandidates
+      const nextCandidates = data.candidates
         .map((candidate) => normalizeCandidate(candidate))
         .filter((candidate): candidate is AiNewsDeskCandidate => candidate !== null);
 
-      const nextFollowCandidates = data.followCandidates
-        .map((candidate) => normalizeCandidate(candidate))
-        .filter((candidate): candidate is AiNewsDeskCandidate => candidate !== null);
-
-      setTodayCandidates(nextTodayCandidates);
-      setFollowCandidates(nextFollowCandidates);
+      setCandidates(nextCandidates);
       setGeneratedAt(data.generatedAt || '');
       setTotalSignals(data.totalSignals || 0);
-      setTotalCandidates(data.totalCandidates || 0);
-      hasDeskDataRef.current = nextTodayCandidates.length > 0 || nextFollowCandidates.length > 0;
+      hasDataRef.current = nextCandidates.length > 0;
       cachedNewsState = {
-        todayCandidates: nextTodayCandidates,
-        followCandidates: nextFollowCandidates,
+        candidates: nextCandidates,
         generatedAt: data.generatedAt || '',
         totalSignals: data.totalSignals || 0,
         totalCandidates: data.totalCandidates || 0,
@@ -368,17 +330,13 @@ export default function AiNewsPageClient() {
   };
 
   useEffect(() => {
-    // Restore topic→draft mappings from localStorage
     setTopicDraftMap(loadTopicDraftMap());
 
     if (cachedNewsState) {
-      setTodayCandidates(cachedNewsState.todayCandidates);
-      setFollowCandidates(cachedNewsState.followCandidates);
+      setCandidates(cachedNewsState.candidates);
       setGeneratedAt(cachedNewsState.generatedAt);
       setTotalSignals(cachedNewsState.totalSignals);
-      setTotalCandidates(cachedNewsState.totalCandidates);
-      hasDeskDataRef.current =
-        cachedNewsState.todayCandidates.length > 0 || cachedNewsState.followCandidates.length > 0;
+      hasDataRef.current = cachedNewsState.candidates.length > 0;
     } else {
       void loadNews();
     }
@@ -387,17 +345,12 @@ export default function AiNewsPageClient() {
 
   return (
     <div className={styles.pageWrap}>
-      <TopicDeskHeader
-        generatedAt={formatDeskTime(generatedAt)}
-        todayCount={todayCandidates.length}
-        followCount={followCandidates.length}
-      />
+      <TopicDeskHeader generatedAt={formatDeskTime(generatedAt)} totalCount={candidates.length} />
 
-      {agentEnabled && allCandidates.length > 0 && (
+      {agentEnabled && candidates.length > 0 && (
         <TopicRecommendationPanel
-          clusters={allCandidates}
+          clusters={candidates}
           onSelectTopic={(title) => {
-            // Navigate to editor with the recommended topic title
             void writeDraftAndOpenEditor(
               title,
               `> 选题来源：AI 推荐\n\n开始围绕「${title}」撰写内容...`,
@@ -407,117 +360,70 @@ export default function AiNewsPageClient() {
         />
       )}
 
-      <div className={styles.tabRow}>
-        <button
-          className={styles.tabButton({ active: viewTab === 'desk' })}
-          onClick={() => setViewTab('desk')}
-        >
-          选题台
-        </button>
-        <button
-          className={styles.tabButton({ active: viewTab === 'inbox' })}
-          onClick={() => setViewTab('inbox')}
-        >
-          资讯 Inbox
-        </button>
-        <button
-          className={styles.tabButton({ active: viewTab === 'topics' })}
-          onClick={() => setViewTab('topics')}
-        >
-          选题库
-        </button>
-      </div>
+      {(sourceTypeFilter !== 'all' || scoreFilter !== 'all' || candidates.length > 0) && (
+        <div className={styles.filterRow}>
+          <FilterChipGroup
+            options={SOURCE_TYPE_OPTIONS}
+            value={sourceTypeFilter}
+            onChange={setSourceTypeFilter}
+          />
+          <FilterChipGroup options={SCORE_OPTIONS} value={scoreFilter} onChange={setScoreFilter} />
+        </div>
+      )}
 
-      {viewTab === 'inbox' ? (
-        <>
-          <SignalInbox />
-          {agentEnabled && <SignalReviewPanel />}
-        </>
-      ) : viewTab === 'topics' ? (
-        <TopicLibrary />
+      {draftError ? (
+        <div className={styles.refreshErrorBanner} role="status" aria-live="polite">
+          <p className={styles.refreshErrorKicker}>转稿未完成</p>
+          <p className={styles.refreshErrorText}>{draftError}</p>
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className={styles.skeletonList}>
+          {[0, 1].map((i) => (
+            <div key={i} className={styles.skeletonCard}>
+              <div className={styles.skeletonInner}>
+                <div className={styles.skeletonLineShort} />
+                <div className={styles.skeletonLineTall} />
+                <div className={styles.skeletonLineFull} />
+                <div className={styles.skeletonLineMid} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : error && candidates.length === 0 ? (
+        <div className={styles.stateCard}>
+          <p className={styles.stateTitle}>新闻加载失败</p>
+          <p className={styles.stateText}>{error}</p>
+        </div>
+      ) : candidates.length === 0 ? (
+        <EmptyState
+          icon={<Newspaper size={24} />}
+          title="暂无内容"
+          description="数据正在准备中，系统每 30 分钟自动抓取最新 AI 话题信号，请稍后访问。"
+        />
       ) : (
-        <div className={styles.contentWrap}>
-          {(sourceTypeFilter !== 'all' || scoreFilter !== 'all' || allCandidates.length > 0) && (
-            <div className={styles.filterRow}>
-              <FilterChipGroup
-                options={SOURCE_TYPE_OPTIONS}
-                value={sourceTypeFilter}
-                onChange={setSourceTypeFilter}
-              />
-              <FilterChipGroup
-                options={SCORE_OPTIONS}
-                value={scoreFilter}
-                onChange={setScoreFilter}
-              />
-            </div>
-          )}
-          {draftError ? (
-            <div className={styles.refreshErrorBanner} role="status" aria-live="polite">
-              <p className={styles.refreshErrorKicker}>转稿未完成</p>
-              <p className={styles.refreshErrorText}>{draftError}</p>
-            </div>
-          ) : null}
-
-          {loading ? (
-            <div className={styles.skeletonList}>
-              {[0, 1].map((i) => (
-                <div key={i} className={styles.skeletonCard}>
-                  <div className={styles.skeletonInner}>
-                    <div className={styles.skeletonLineShort} />
-                    <div className={styles.skeletonLineTall} />
-                    <div className={styles.skeletonLineFull} />
-                    <div className={styles.skeletonLineMid} />
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : error && allCandidates.length === 0 ? (
-            <div className={styles.stateCard}>
-              <p className={styles.stateTitle}>新闻抓取失败</p>
-              <p className={styles.stateText}>{error}</p>
-            </div>
-          ) : allCandidates.length === 0 ? (
-            <EmptyState
-              icon={<Newspaper size={24} />}
-              title="选题桌暂无内容"
-              description="数据正在准备中，系统每 30 分钟自动抓取最新 AI 话题信号，请稍后访问。"
+        <div className={styles.candidateSection}>
+          {filteredCandidates.map((item, index) => (
+            <TopicSignalCard
+              key={item.clusterId}
+              item={item}
+              indexLabel={buildSectionLabel(index)}
+              relativeLabel={formatRelativeHours(item.latestPublishedAt)}
+              formattedDate={formatDateTime(item.latestPublishedAt)}
+              draftId={topicDraftMap[item.clusterId]}
+              showBrief={briefOpenMap.get(item.clusterId) ?? false}
+              onBriefToggle={(open) => {
+                cachedBriefOpenMap.set(item.clusterId, open);
+                setBriefOpenMap(new Map(cachedBriefOpenMap));
+              }}
+              onCreateDraft={createSingleNewsDraft}
+              agentEnabled={agentEnabled}
+              onDeepResearch={handleDeepResearch}
+              deepResearchContent={deepResearchContent[item.clusterId]}
+              deepResearchLoading={deepResearchLoading[item.clusterId] ?? false}
             />
-          ) : (
-            <div className={styles.candidateSections}>
-              <CandidateSection
-                title="今天能发"
-                items={filteredToday}
-                offset={0}
-                topicDraftMap={topicDraftMap}
-                briefOpenMap={briefOpenMap}
-                onBriefToggle={(clusterId, open) => {
-                  cachedBriefOpenMap.set(clusterId, open);
-                  setBriefOpenMap(new Map(cachedBriefOpenMap));
-                }}
-                onCreateDraft={createSingleNewsDraft}
-                agentEnabled={agentEnabled}
-                onDeepResearch={handleDeepResearch}
-                deepResearchContent={deepResearchContent}
-                deepResearchLoading={deepResearchLoading}
-              />
-              <CandidateSection
-                title="还能追"
-                items={filteredFollow}
-                offset={filteredToday.length}
-                topicDraftMap={topicDraftMap}
-                briefOpenMap={briefOpenMap}
-                onBriefToggle={(clusterId, open) => {
-                  cachedBriefOpenMap.set(clusterId, open);
-                  setBriefOpenMap(new Map(cachedBriefOpenMap));
-                }}
-                onCreateDraft={createSingleNewsDraft}
-                agentEnabled={agentEnabled}
-                onDeepResearch={handleDeepResearch}
-                deepResearchContent={deepResearchContent}
-                deepResearchLoading={deepResearchLoading}
-              />
-            </div>
-          )}
+          ))}
         </div>
       )}
     </div>
@@ -526,54 +432,4 @@ export default function AiNewsPageClient() {
 
 function formatDeskTime(value: string) {
   return value ? formatDateTime(value) : '准备中';
-}
-
-function CandidateSection({
-  title,
-  items,
-  offset,
-  topicDraftMap,
-  briefOpenMap,
-  onBriefToggle,
-  onCreateDraft,
-  agentEnabled,
-  onDeepResearch,
-  deepResearchContent,
-  deepResearchLoading,
-}: {
-  title: string;
-  items: AiNewsDeskCandidate[];
-  offset: number;
-  topicDraftMap: Record<string, string>;
-  briefOpenMap: Map<string, boolean>;
-  onBriefToggle: (clusterId: string, open: boolean) => void;
-  onCreateDraft: (item: AiNewsDeskCandidate) => void;
-  agentEnabled: boolean;
-  onDeepResearch: (item: AiNewsDeskCandidate) => void;
-  deepResearchContent: Record<string, string>;
-  deepResearchLoading: Record<string, boolean>;
-}) {
-  if (items.length === 0) return null;
-
-  return (
-    <section className={styles.candidateSection}>
-      {items.map((item, index) => (
-        <TopicSignalCard
-          key={item.clusterId}
-          item={item}
-          indexLabel={buildSectionLabel(offset + index)}
-          relativeLabel={formatRelativeHours(item.latestPublishedAt)}
-          formattedDate={formatDateTime(item.latestPublishedAt)}
-          draftId={topicDraftMap[item.clusterId]}
-          showBrief={briefOpenMap.get(item.clusterId) ?? false}
-          onBriefToggle={(open) => onBriefToggle(item.clusterId, open)}
-          onCreateDraft={onCreateDraft}
-          agentEnabled={agentEnabled}
-          onDeepResearch={onDeepResearch}
-          deepResearchContent={deepResearchContent[item.clusterId]}
-          deepResearchLoading={deepResearchLoading[item.clusterId] ?? false}
-        />
-      ))}
-    </section>
-  );
 }

--- a/src/components/news/TopicDeskHeader.tsx
+++ b/src/components/news/TopicDeskHeader.tsx
@@ -2,20 +2,15 @@ import AppShellHeader from '@/components/layout/AppShellHeader';
 
 interface TopicDeskHeaderProps {
   generatedAt: string;
-  todayCount: number;
-  followCount: number;
+  totalCount: number;
 }
 
-export default function TopicDeskHeader({
-  generatedAt,
-  todayCount,
-  followCount,
-}: TopicDeskHeaderProps) {
+export default function TopicDeskHeader({ generatedAt, totalCount }: TopicDeskHeaderProps) {
   return (
     <AppShellHeader
-      kicker="Topic desk"
-      title="选题工作台"
-      description={`把最近 24 小时的 AI 信息压成可判断的选题列表。${generatedAt ? `最近更新：${generatedAt}。` : ''}今天能发 ${todayCount} 条，还能追 ${followCount} 条。`}
+      kicker="AI News"
+      title="AI 热点资讯"
+      description={`聚合全球 AI 信息源，为中文从业者筛选最有价值的话题。${generatedAt ? `最近更新：${generatedAt}。` : ''}当前 ${totalCount} 条。`}
     />
   );
 }

--- a/src/lib/ai-news/index.ts
+++ b/src/lib/ai-news/index.ts
@@ -282,17 +282,13 @@ export function buildAiNewsDeskFromSignals(
     .sort(sortCandidates)
     .slice(0, poolSize);
 
-  const todayCandidates = candidates.filter((candidate) => candidate.bucket === 'today');
-  const followCandidates = candidates.filter((candidate) => candidate.bucket === 'follow');
-  const selectedResearch =
-    todayCandidates[0]?.researchBrief ?? followCandidates[0]?.researchBrief ?? null;
+  const selectedResearch = candidates[0]?.researchBrief ?? null;
 
   return {
     generatedAt: now.toISOString(),
     totalSignals: signals.length,
     totalCandidates: candidates.length,
-    todayCandidates,
-    followCandidates,
+    candidates,
     selectedResearch,
   };
 }
@@ -300,10 +296,7 @@ export function buildAiNewsDeskFromSignals(
 export async function buildAiNewsDesk(hours = 24, poolSize = 40, displaySize = 10) {
   const signals = await fetchAiNewsSignals(hours);
   const desk = buildAiNewsDeskFromSignals(signals, new Date(), poolSize);
-  const hydratedCandidates = await hydrateCandidateImages([
-    ...desk.todayCandidates,
-    ...desk.followCandidates,
-  ]);
+  const hydratedCandidates = await hydrateCandidateImages(desk.candidates);
   const generatedAt = new Date(desk.generatedAt);
 
   // Re-score after image hydration
@@ -330,7 +323,6 @@ export async function buildAiNewsDesk(hours = 24, poolSize = 40, displaySize = 1
 
       const { score: llmScore, recommendation } = result.value;
 
-      // Mix LLM score with rule-based score: 60% LLM + 40% rules
       const mixedScore =
         llmScore !== null
           ? Math.round(llmScore * 0.6 + cluster.totalScore * 0.4)
@@ -373,22 +365,18 @@ export async function buildAiNewsDesk(hours = 24, poolSize = 40, displaySize = 1
       displaySize,
     ),
   );
-  const todayCandidates = candidates.filter((candidate) => candidate.bucket === 'today');
-  const followCandidates = candidates.filter((candidate) => candidate.bucket === 'follow');
   const selectedResearch =
     (desk.selectedResearch
       ? candidates.find(
           (candidate) => candidate.researchBrief.candidateId === desk.selectedResearch?.candidateId,
         )?.researchBrief
       : null) ??
-    todayCandidates[0]?.researchBrief ??
-    followCandidates[0]?.researchBrief ??
+    candidates[0]?.researchBrief ??
     null;
 
   return {
     ...desk,
-    todayCandidates,
-    followCandidates,
+    candidates,
     selectedResearch,
   };
 }

--- a/src/lib/ai-news/types.ts
+++ b/src/lib/ai-news/types.ts
@@ -117,7 +117,6 @@ export interface AiNewsDesk {
   generatedAt: string;
   totalSignals: number;
   totalCandidates: number;
-  todayCandidates: AiNewsDeskCandidate[];
-  followCandidates: AiNewsDeskCandidate[];
+  candidates: AiNewsDeskCandidate[];
   selectedResearch: ResearchBrief | null;
 }

--- a/src/lib/scheduler/fetchRssFeeds.ts
+++ b/src/lib/scheduler/fetchRssFeeds.ts
@@ -27,19 +27,16 @@ function atomicWriteJson(filePath: string, data: unknown) {
 export async function preComputeAiNewsDesk() {
   logger.info('Pre-computing AI news desk started');
 
-  const desk = await buildAiNewsDesk(24, 40, 10);
+  const desk = await buildAiNewsDesk(72, 40, 10);
 
-  const allNormalizedSignals = [...desk.todayCandidates, ...desk.followCandidates].flatMap(
-    (candidate) => candidate.signals,
-  );
+  const allNormalizedSignals = desk.candidates.flatMap((candidate) => candidate.signals);
   const signalIds = persistSignalsFromDesk(allNormalizedSignals);
 
   const data = {
     generatedAt: desk.generatedAt,
     totalSignals: desk.totalSignals,
     totalCandidates: desk.totalCandidates,
-    todayCandidates: desk.todayCandidates,
-    followCandidates: desk.followCandidates,
+    candidates: desk.candidates,
     selectedResearch: desk.selectedResearch,
     signalIds,
   };

--- a/src/lib/scheduler/generateDailyDigest.ts
+++ b/src/lib/scheduler/generateDailyDigest.ts
@@ -20,14 +20,14 @@ export async function generateDailyDigest() {
     return;
   }
 
-  const signals = await fetchAiNewsSignals(24);
+  const signals = await fetchAiNewsSignals(72);
   if (signals.length === 0) {
     logger.info('No signals found, skipping daily digest');
     return;
   }
 
   const desk = buildAiNewsDeskFromSignals(signals, now, 40);
-  const allCandidates = [...desk.todayCandidates, ...desk.followCandidates]
+  const allCandidates = [...desk.candidates]
     .sort((a, b) => b.totalScore - a.totalScore)
     .slice(0, TOP_N);
 


### PR DESCRIPTION
## Summary

- Merge today/follow buckets into a single flat candidate list
- Replace three tabs (选题台/资讯Inbox/选题库) with single "AI热点资讯" view
- Extend time window from 24h to 72h
- Add X and arXiv to source type filter options
- Remove tab navigation UI entirely
- Net deletion: -276 lines, +109 lines

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (332 tests)
- [ ] AI news page shows single flat list with no tabs
- [ ] Header shows "AI 热点资讯" with total count
- [ ] Source filter includes X and arXiv options
- [ ] Score filter works on unified list