### PR TITLE
Fix sanitize-html advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "sanitize-html": "^2.17.3",
+    "sanitize-html": "^2.17.4",
     "twitter-api-v2": "^1.18.0",
     "zustand": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       sanitize-html:
-        specifier: ^2.17.3
-        version: 2.17.3
+        specifier: ^2.17.4
+        version: 2.17.4
       twitter-api-v2:
         specifier: ^1.18.0
         version: 1.29.0
@@ -1722,6 +1722,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -2505,6 +2508,9 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -3147,8 +3153,8 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
-  sanitize-html@2.17.3:
-    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
+  sanitize-html@2.17.4:
+    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5238,6 +5244,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.21: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -6266,6 +6274,10 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.21
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -7210,12 +7222,13 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  sanitize-html@2.17.3:
+  sanitize-html@2.17.4:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
       htmlparser2: 10.1.0
       is-plain-object: 5.0.0
+      launder: 1.7.1
       parse-srcset: 1.0.2
       postcss: 8.5.14
 

--- a/src/components/calendar/CalendarPageClient.tsx
+++ b/src/components/calendar/CalendarPageClient.tsx
@@ -66,13 +66,13 @@ export default function CalendarPageClient() {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
   });
-
-  const today = new Date();
+  const today = useMemo(() => new Date(), []);
 
   useEffect(() => {
     async function loadEvents() {
       setLoading(true);
       try {
+        const fallbackDate = formatDate(new Date());
         const [draftsRes, syncRes] = await Promise.all([
           fetch('/api/drafts', { cache: 'no-store' }),
           fetch('/api/sync-tasks', { cache: 'no-store' }),
@@ -98,7 +98,7 @@ export default function CalendarPageClient() {
                 title: d.title || '未命名稿件',
                 date: d.id.match(/\d+/)?.[0]
                   ? new Date(Number(d.id.match(/\d+/)?.[0])).toISOString().slice(0, 10)
-                  : formatDate(today),
+                  : fallbackDate,
                 type: 'draft',
               });
             }
@@ -153,6 +153,7 @@ export default function CalendarPageClient() {
   };
 
   const goToday = () => {
+    const today = new Date();
     setCurrentDate(new Date(today.getFullYear(), today.getMonth(), 1));
   };
 

--- a/src/components/feedback/Toast.tsx
+++ b/src/components/feedback/Toast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-react';
 import * as css from './Toast.css';
 import { useToastStore, type ToastType } from '@/stores/toastStore';
@@ -23,15 +23,15 @@ function ToastItem({ id, type, message }: ToastItemProps) {
   const [exiting, setExiting] = useState(false);
   const Icon = ICONS[type];
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setExiting(true);
     setTimeout(() => removeToast(id), 200);
-  };
+  }, [id, removeToast]);
 
   useEffect(() => {
     const timer = setTimeout(handleClose, 4000);
     return () => clearTimeout(timer);
-  }, [id]);
+  }, [handleClose]);
 
   return (
     <div className={css.toast({ type, exiting })}>

--- a/src/lib/__tests__/sanitizeHtmlSecurity.test.ts
+++ b/src/lib/__tests__/sanitizeHtmlSecurity.test.ts
@@ -1,0 +1,10 @@
+import sanitizeHtml from 'sanitize-html';
+import { describe, expect, test } from 'vitest';
+
+describe('sanitize-html security behavior', () => {
+  test('drops disallowed xmp raw-text content instead of re-emitting live markup', () => {
+    expect(sanitizeHtml('<xmp><script>alert(1)</script></xmp>')).toBe('');
+    expect(sanitizeHtml('<xmp><img src=x onerror=alert(1)></xmp>')).toBe('');
+    expect(sanitizeHtml('<xmp><svg><script>alert(1)</script></svg></xmp>')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Upgrade `sanitize-html` to `^2.17.4` to address the `xmp` raw-text sanitizer bypass advisory.
- Add a regression test covering disallowed `xmp` payloads so the bypass cannot silently reappear.
- Clean up the existing React hook dependency warnings in the calendar and toast components.

## Validation

- `pnpm verify`
- `pnpm lint` reports no warnings or errors
- 65 Vitest files passed, 333 tests passed
- Next.js production build completed successfully