### PR TITLE
Refresh brand mark

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,9 +1,4 @@
 <svg width="64" height="64" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect width="32" height="32" rx="8" fill="#F5EDE4"/>
-  <!-- 笔尖主体 -->
-  <path d="M13 4Q9 16 16 29Q23 16 19 4Z" fill="#D97757"/>
-  <!-- 呼吸孔 -->
-  <circle cx="16" cy="11" r="2" fill="white" opacity="0.85"/>
-  <!-- 中缝 -->
-  <line x1="16" y1="13" x2="16" y2="29" stroke="white" stroke-width="0.8" opacity="0.5"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9 6H17.25C21.55 6 24 8.55 24 12.25C24 16.05 21.35 18.45 17.05 18.45H13.25V26H9V6ZM13.25 9.65V14.85H16.75C18.7 14.85 19.8 13.85 19.8 12.25C19.8 10.65 18.7 9.65 16.75 9.65H13.25Z" fill="#D97757"/>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { Inter, Caveat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import '@/styles/globals.css';
 import { darkTheme } from '@/styles/tokens.css';
 import Sidebar from '@/components/layout/Sidebar';
@@ -15,13 +15,6 @@ const inter = Inter({
   display: 'swap',
 });
 
-const caveat = Caveat({
-  subsets: ['latin'],
-  weight: ['500', '600', '700'],
-  variable: '--font-caveat',
-  display: 'swap',
-});
-
 export const metadata: Metadata = {
   title: 'Publio',
   description: 'Publish Markdown content to multiple platforms in one workflow.',
@@ -31,7 +24,7 @@ const themeScript = `(function(){try{var c='${darkTheme}',s=localStorage.getItem
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="zh-CN" className={`${inter.variable} ${caveat.variable}`} suppressHydrationWarning>
+    <html lang="zh-CN" className={inter.variable} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>

--- a/src/components/layout/Logo.css.ts
+++ b/src/components/layout/Logo.css.ts
@@ -1,7 +1,5 @@
-import { vars } from '@/styles/tokens.css';
 import { style } from '@vanilla-extract/css';
 
 export const logoSvg = style({
   display: 'block',
-  color: '#D97757',
 });

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -11,12 +11,13 @@ export default function Logo({ size = 28 }: { size?: number }) {
       aria-hidden="true"
       className={styles.logoSvg}
     >
-      {/* 笔尖主体 */}
-      <path d="M13 4Q9 16 16 29Q23 16 19 4Z" fill="currentColor" />
-      {/* 呼吸孔 */}
-      <circle cx="16" cy="11" r="2" fill="white" opacity="0.85" />
-      {/* 中缝 */}
-      <line x1="16" y1="13" x2="16" y2="29" stroke="white" strokeWidth="0.8" opacity="0.5" />
+      <rect width="32" height="32" rx="8" fill="#F5EDE4" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M9 6H17.25C21.55 6 24 8.55 24 12.25C24 16.05 21.35 18.45 17.05 18.45H13.25V26H9V6ZM13.25 9.65V14.85H16.75C18.7 14.85 19.8 13.85 19.8 12.25C19.8 10.65 18.7 9.65 16.75 9.65H13.25Z"
+        fill="#D97757"
+      />
     </svg>
   );
 }

--- a/src/components/layout/Sidebar.css.ts
+++ b/src/components/layout/Sidebar.css.ts
@@ -80,9 +80,9 @@ export const brandLogo = style({
 });
 
 export const brandName = style({
-  fontSize: '20px',
-  fontWeight: 700,
-  fontFamily: 'var(--font-caveat), cursive',
+  fontSize: '18px',
+  fontWeight: 650,
+  fontFamily: 'var(--font-inter), sans-serif',
   color: '#D97757',
   lineHeight: 1,
   opacity: 0,


### PR DESCRIPTION
## Summary
- Replace the sidebar logo and browser tab icon with the selected minimal P mark.
- Update the sidebar wordmark from the handwritten font to an Inter-based geometric style.
- Remove the unused Caveat font load.

## Validation
- pnpm lint
- pnpm build
- git diff --check
