### PR TITLE
polish: Phase 1+2 首页主路径收敛 & 发布面板流程化

### DIFF
--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -3,7 +3,17 @@
 import { Suspense, useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Eye, Files, SquarePen, Eraser, History, Send } from 'lucide-react';
+import {
+  Eye,
+  Files,
+  SquarePen,
+  Eraser,
+  History,
+  Send,
+  MoreHorizontal,
+  Image,
+  FileText,
+} from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
 import { useAgentStore } from '@/stores/agentStore';
 import AppShellHeader from '@/components/layout/AppShellHeader';
@@ -67,6 +77,7 @@ function HomePageContent() {
   const [mobilePublishOpen, setMobilePublishOpen] = useState(false);
   const [agentEnabled, setAgentEnabled] = useState(false);
   const [showVersionHistory, setShowVersionHistory] = useState(false);
+  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const [imageBedLabel, setImageBedLabel] = useState<string | undefined>(undefined);
 
   // 检查 Agent 是否已配置
@@ -204,30 +215,6 @@ function HomePageContent() {
                 预览
               </button>
             </div>
-            <TemplatePicker
-              currentTitle={title}
-              currentContent={content}
-              onSelect={(template) => {
-                setTitle(template.title);
-                setContent(template.content);
-              }}
-            />
-            <MediaLibrary
-              imageBedLabel={imageBedLabel}
-              onSelect={(url, filename) => {
-                const insertion = `\n![${filename}](${url})\n`;
-                setContent(content + insertion);
-              }}
-            />
-            <button
-              type="button"
-              onClick={handleClearClick}
-              className={styles.newDraftButton}
-              title="清空写作台"
-            >
-              <Eraser size={15} />
-              清空
-            </button>
             <button
               type="button"
               onClick={() => setIsPanelOpen((v) => !v)}
@@ -238,6 +225,52 @@ function HomePageContent() {
               <Files size={14} />
               草稿
             </button>
+            <div className={styles.moreMenuWrap}>
+              <button
+                type="button"
+                onClick={() => setMoreMenuOpen((v) => !v)}
+                className={styles.newDraftButton}
+                title="更多操作"
+                aria-expanded={moreMenuOpen}
+              >
+                <MoreHorizontal size={15} />
+              </button>
+              {moreMenuOpen && (
+                <>
+                  <div className={styles.moreMenuBackdrop} onClick={() => setMoreMenuOpen(false)} />
+                  <div className={styles.moreMenu}>
+                    <TemplatePicker
+                      currentTitle={title}
+                      currentContent={content}
+                      onSelect={(template) => {
+                        setTitle(template.title);
+                        setContent(template.content);
+                        setMoreMenuOpen(false);
+                      }}
+                    />
+                    <MediaLibrary
+                      imageBedLabel={imageBedLabel}
+                      onSelect={(url, filename) => {
+                        const insertion = `\n![${filename}](${url})\n`;
+                        setContent(content + insertion);
+                        setMoreMenuOpen(false);
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setMoreMenuOpen(false);
+                        handleClearClick();
+                      }}
+                      className={styles.moreMenuItemDanger}
+                    >
+                      <Eraser size={14} />
+                      清空写作台
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
           </div>
         }
       />

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -29,6 +29,7 @@ import DraftPanel from '@/components/editor/DraftPanel';
 import PlatformSelector from '@/components/publish/PlatformSelector';
 import PublishButton from '@/components/publish/PublishButton';
 import PublishStatusPanel from '@/components/publish/PublishStatusPanel';
+import PublishChecklist from '@/components/publish/PublishChecklist';
 import TemplatePicker from '@/components/editor/TemplatePicker';
 import MediaLibrary from '@/components/editor/MediaLibrary';
 
@@ -327,16 +328,7 @@ function HomePageContent() {
             )}
 
             <div className={publishStyles.rightPanelSection}>
-              <span className={publishStyles.rightPanelSectionTitle}>发布到</span>
-              <PlatformSelector />
-            </div>
-
-            <div className={publishStyles.rightPanelSection}>
-              <PlatformPreviewPanel
-                adaptations={platformDrafts}
-                selectedPlatforms={selectedPlatforms}
-                agentEnabled={agentEnabled}
-              />
+              <PublishChecklist agentEnabled={agentEnabled} />
             </div>
 
             {currentDraftId && (
@@ -348,19 +340,6 @@ function HomePageContent() {
                 />
               </div>
             )}
-
-            <div className={publishStyles.rightPanelSection}>
-              <div className={styles.publishRight}>
-                {overallStatus !== 'idle' && overallStatus !== 'publishing' && (
-                  <button onClick={reset} className={styles.resetLink}>
-                    清除结果
-                  </button>
-                )}
-                <PublishButton />
-              </div>
-
-              {overallStatus !== 'idle' && <PublishStatusPanel />}
-            </div>
           </div>
         </div>
       </div>

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -55,7 +55,7 @@ export const rightPanel = style({
   gap: vars.spacing.lg,
   '@media': {
     'screen and (min-width: 1024px)': {
-      width: '280px',
+      width: '320px',
       flexShrink: 0,
       position: 'sticky',
       top: '28px',
@@ -74,11 +74,9 @@ export const mobileOnly = style({
 export const editorCard = style({
   overflow: 'hidden',
   borderRadius: vars.radius.xl,
-  background: vars.color.glassSurface,
-  backdropFilter: 'blur(20px) saturate(180%)',
-  WebkitBackdropFilter: 'blur(20px) saturate(180%)',
-  border: `1px solid ${vars.color.glassBorder}`,
-  boxShadow: vars.shadow.sm,
+  background: vars.color.surface,
+  border: `1px solid ${vars.color.border}`,
+  boxShadow: vars.shadow.md,
   outline: 'none',
 });
 

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -269,6 +269,54 @@ export const saveStatusHint = style({
   },
 });
 
+// More menu (dropdown)
+export const moreMenuWrap = style({
+  position: 'relative',
+  display: 'inline-flex',
+});
+
+export const moreMenuBackdrop = style({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 99,
+});
+
+export const moreMenu = style({
+  position: 'absolute',
+  top: '100%',
+  right: 0,
+  marginTop: vars.spacing.xs,
+  zIndex: 100,
+  minWidth: '160px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['2xs'],
+  borderRadius: vars.radius.lg,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.surface,
+  padding: vars.spacing.xs,
+  boxShadow: vars.shadow.lg,
+});
+
+export const moreMenuItemDanger = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.md,
+  width: '100%',
+  borderRadius: vars.radius.sm,
+  border: 'none',
+  background: 'transparent',
+  padding: `${vars.spacing.md} ${vars.spacing.lg}`,
+  fontSize: vars.fontSize.sm,
+  color: vars.color.errorText,
+  cursor: 'pointer',
+  textAlign: 'left',
+  transition: `background ${vars.transition.fast}`,
+  ':hover': {
+    background: vars.color.errorBg,
+  },
+});
+
 // Mobile publish FAB
 export const mobilePublishFab = style({
   position: 'fixed',

--- a/src/components/agent/AgentPanel.css.ts
+++ b/src/components/agent/AgentPanel.css.ts
@@ -6,24 +6,38 @@ const blink = keyframes({
   '50%': { opacity: 0 },
 });
 
+export const drawerOverlay = style({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 200,
+  background: 'rgba(0, 0, 0, 0.3)',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  '@media': {
+    'screen and (max-width: 767px)': {
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+    },
+  },
+});
+
 export const panelWrap = style({
   display: 'flex',
   flexDirection: 'column',
-  width: '360px',
-  flexShrink: 0,
-  background: vars.color.glassSurface,
-  backdropFilter: 'blur(20px) saturate(180%)',
-  WebkitBackdropFilter: 'blur(20px) saturate(180%)',
-  borderRadius: vars.radius.xl,
-  border: `1px solid ${vars.color.glassBorder}`,
-  boxShadow: vars.shadow.md,
+  width: '400px',
+  maxWidth: '100%',
+  height: '100%',
+  background: vars.color.surface,
+  borderLeft: `1px solid ${vars.color.border}`,
+  boxShadow: vars.shadow.xl,
   overflow: 'hidden',
-  maxHeight: 'calc(100vh - 140px)',
-  position: 'sticky',
-  top: '28px',
   '@media': {
-    'screen and (max-width: 1279px)': {
-      width: '300px',
+    'screen and (max-width: 767px)': {
+      width: '100%',
+      height: '70vh',
+      maxHeight: '70vh',
+      borderLeft: 'none',
+      borderRadius: `${vars.radius.xl} ${vars.radius.xl} 0 0`,
     },
   },
 });

--- a/src/components/agent/AgentPanel.tsx
+++ b/src/components/agent/AgentPanel.tsx
@@ -60,82 +60,84 @@ export default function AgentPanel() {
   const actionLabel = activeAction ? ACTION_LABELS[activeAction] || activeAction : 'AI';
 
   return (
-    <div className={styles.panelWrap}>
-      <div className={styles.panelHeader}>
-        <span className={styles.panelTitle}>
-          AI 助手
-          <span className={styles.panelBadge}>{actionLabel}</span>
-        </span>
-        <button
-          type="button"
-          className={styles.closeButton}
-          onClick={handleClose}
-          title="关闭"
-          aria-label="关闭"
-        >
-          <X size={14} />
-        </button>
-      </div>
+    <div className={styles.drawerOverlay} onClick={handleClose}>
+      <div className={styles.panelWrap} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.panelHeader}>
+          <span className={styles.panelTitle}>
+            AI 助手
+            <span className={styles.panelBadge}>{actionLabel}</span>
+          </span>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={handleClose}
+            title="关闭"
+            aria-label="关闭"
+          >
+            <X size={14} />
+          </button>
+        </div>
 
-      <div className={styles.panelBody} ref={bodyRef} onScroll={handleBodyScroll}>
-        {/* 当前 AI 输出 */}
-        {error ? (
-          <div className={styles.errorBox}>{error}</div>
-        ) : output ? (
-          <div className={styles.outputArea}>
-            <span dangerouslySetInnerHTML={{ __html: renderAgentMarkdown(output) }} />
-            {status === 'streaming' && <span className={styles.cursor} />}
+        <div className={styles.panelBody} ref={bodyRef} onScroll={handleBodyScroll}>
+          {/* 当前 AI 输出 */}
+          {error ? (
+            <div className={styles.errorBox}>{error}</div>
+          ) : output ? (
+            <div className={styles.outputArea}>
+              <span dangerouslySetInnerHTML={{ __html: renderAgentMarkdown(output) }} />
+              {status === 'streaming' && <span className={styles.cursor} />}
+            </div>
+          ) : status === 'streaming' ? (
+            <div className={styles.outputArea}>
+              <span className={styles.cursor} />
+            </div>
+          ) : (
+            <div className={styles.emptyState}>等待 AI 响应...</div>
+          )}
+        </div>
+
+        {/* 操作按钮：插入/替换/复制 */}
+        {(status === 'done' || (status === 'error' && output)) && (
+          <div className={styles.panelActions}>
+            <button
+              type="button"
+              className={styles.actionButtonPrimary}
+              onClick={handleInsert}
+              title="追加到文末"
+            >
+              <CornerDownLeft size={13} />
+              插入
+            </button>
+            <button
+              type="button"
+              className={styles.actionButton}
+              onClick={handleReplace}
+              title="替换全部内容"
+            >
+              <Replace size={13} />
+              替换
+            </button>
+            <button
+              type="button"
+              className={styles.actionButton}
+              onClick={handleCopy}
+              title="复制到剪贴板"
+            >
+              <Copy size={13} />
+              复制
+            </button>
           </div>
-        ) : status === 'streaming' ? (
-          <div className={styles.outputArea}>
-            <span className={styles.cursor} />
+        )}
+
+        {/* 停止生成 */}
+        {status === 'streaming' && (
+          <div className={styles.panelActions}>
+            <button type="button" className={styles.actionButton} onClick={abort}>
+              停止生成
+            </button>
           </div>
-        ) : (
-          <div className={styles.emptyState}>等待 AI 响应...</div>
         )}
       </div>
-
-      {/* 操作按钮：插入/替换/复制 */}
-      {(status === 'done' || (status === 'error' && output)) && (
-        <div className={styles.panelActions}>
-          <button
-            type="button"
-            className={styles.actionButtonPrimary}
-            onClick={handleInsert}
-            title="追加到文末"
-          >
-            <CornerDownLeft size={13} />
-            插入
-          </button>
-          <button
-            type="button"
-            className={styles.actionButton}
-            onClick={handleReplace}
-            title="替换全部内容"
-          >
-            <Replace size={13} />
-            替换
-          </button>
-          <button
-            type="button"
-            className={styles.actionButton}
-            onClick={handleCopy}
-            title="复制到剪贴板"
-          >
-            <Copy size={13} />
-            复制
-          </button>
-        </div>
-      )}
-
-      {/* 停止生成 */}
-      {status === 'streaming' && (
-        <div className={styles.panelActions}>
-          <button type="button" className={styles.actionButton} onClick={abort}>
-            停止生成
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/publish/PublishButton.tsx
+++ b/src/components/publish/PublishButton.tsx
@@ -182,7 +182,10 @@ export default function PublishButton() {
   } else if (selectedPlatforms.length === 0) {
     label = '请先选择平台';
   } else if (notReadyPlatforms.length > 0) {
-    label = `${notReadyPlatforms.map((p) => platformLabels[p]).join('、')} 内容待补全`;
+    label =
+      notReadyPlatforms.length === 1
+        ? `${platformLabels[notReadyPlatforms[0]]} 内容待补全`
+        : `${notReadyPlatforms.length} 个平台内容待补全`;
   } else {
     label = `发布到 ${selectedPlatforms.length} 个平台`;
   }

--- a/src/components/publish/PublishChecklist.css.ts
+++ b/src/components/publish/PublishChecklist.css.ts
@@ -159,3 +159,45 @@ export const publishAction = style({
   alignItems: 'center',
   gap: vars.spacing.lg,
 });
+
+export const failureGuidance = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.sm,
+  marginTop: vars.spacing.lg,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.errorBorder}`,
+  background: vars.color.errorBg,
+  padding: vars.spacing.lg,
+});
+
+export const failureItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['2xs'],
+});
+
+export const failurePlatform = style({
+  fontSize: vars.fontSize.sm,
+  fontWeight: 600,
+  color: vars.color.errorText,
+});
+
+export const failureMessage = style({
+  fontSize: vars.fontSize.xs,
+  color: vars.color.errorText,
+  lineHeight: 1.5,
+});
+
+export const resultLink = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  marginTop: vars.spacing.lg,
+  fontSize: vars.fontSize.sm,
+  fontWeight: 500,
+  color: vars.color.accent,
+  textDecoration: 'none',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});

--- a/src/components/publish/PublishChecklist.css.ts
+++ b/src/components/publish/PublishChecklist.css.ts
@@ -1,0 +1,161 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '@/styles/tokens.css';
+
+export const checklist = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.lg,
+});
+
+export const step = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.md,
+});
+
+export const stepHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.md,
+});
+
+export const stepNumber = style({
+  display: 'flex',
+  width: '20px',
+  height: '20px',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: vars.radius.full,
+  border: `1px solid ${vars.color.borderStrong}`,
+  fontSize: vars.fontSize['2xs'],
+  fontWeight: 700,
+  color: vars.color.textMuted,
+});
+
+export const stepTitle = style({
+  fontSize: vars.fontSize.xs,
+  fontWeight: 500,
+  textTransform: 'uppercase',
+  letterSpacing: '0.20em',
+  color: vars.color.accent,
+});
+
+export const stepContent = style({
+  paddingLeft: '28px',
+});
+
+export const platformRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.spacing.md,
+  padding: `${vars.spacing.sm} 0`,
+});
+
+export const platformInfo = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.md,
+  minWidth: 0,
+});
+
+export const platformName = style({
+  fontSize: vars.fontSize.sm,
+  fontWeight: 500,
+  color: vars.color.text,
+});
+
+export const readinessVariants = styleVariants({
+  ready: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.successBorder}`,
+    background: vars.color.successBg,
+    color: vars.color.successText,
+  },
+  'needs-content': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.warningBorder}`,
+    background: vars.color.warningBg,
+    color: vars.color.warningText,
+  },
+  'needs-adapt': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.border}`,
+    background: vars.color.accentSoft,
+    color: vars.color.signal,
+  },
+  unconfigured: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.border}`,
+    background: vars.color.bgElevated,
+    color: vars.color.textMuted,
+  },
+  publishing: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.border}`,
+    background: vars.color.bgElevated,
+    color: vars.color.textMuted,
+  },
+  success: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.successBorder}`,
+    background: vars.color.successBg,
+    color: vars.color.successText,
+  },
+  failed: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.xs,
+    borderRadius: vars.radius.full,
+    padding: `${vars.spacing['2xs']} ${vars.spacing.md}`,
+    fontSize: vars.fontSize['2xs'],
+    fontWeight: 500,
+    border: `1px solid ${vars.color.errorBorder}`,
+    background: vars.color.errorBg,
+    color: vars.color.errorText,
+  },
+});
+
+export const publishAction = style({
+  paddingTop: vars.spacing.md,
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.lg,
+});

--- a/src/components/publish/PublishChecklist.tsx
+++ b/src/components/publish/PublishChecklist.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useMemo } from 'react';
+import { usePublishStore } from '@/stores/publishStore';
+import { PLATFORMS, PlatformId } from '@/types';
+import { getPlatformReadiness } from '@/lib/publishChecks/platformReadiness';
+import PlatformSelector from './PlatformSelector';
+import PublishButton from './PublishButton';
+import PublishStatusPanel from './PublishStatusPanel';
+import * as styles from './PublishChecklist.css';
+
+const READINESS_LABELS: Record<string, string> = {
+  ready: '可发布',
+  'needs-content': '内容待补全',
+  'needs-adapt': '需要适配',
+  unconfigured: '未配置',
+  publishing: '发布中',
+  success: '已发布',
+  failed: '发布失败',
+};
+
+export default function PublishChecklist({ agentEnabled }: { agentEnabled: boolean }) {
+  const { platforms, platformDrafts, overallStatus, results } = usePublishStore();
+
+  const selectedPlatforms = useMemo(
+    () =>
+      (Object.entries(platforms) as [PlatformId, boolean][])
+        .filter(([, selected]) => selected)
+        .map(([id]) => id),
+    [platforms],
+  );
+
+  const readinessItems = useMemo(
+    () =>
+      selectedPlatforms.map((platform) => {
+        const result = results.find((r) => r.platform === platform);
+        return getPlatformReadiness(
+          platform,
+          platformDrafts[platform],
+          overallStatus,
+          result ? { status: result.status, message: result.message } : undefined,
+        );
+      }),
+    [selectedPlatforms, platformDrafts, overallStatus, results],
+  );
+
+  const platformNames: Record<PlatformId, string> = Object.fromEntries(
+    PLATFORMS.map((p) => [p.id, p.name]),
+  ) as Record<PlatformId, string>;
+
+  return (
+    <div className={styles.checklist}>
+      {/* Step 1: 选择平台 */}
+      <div className={styles.step}>
+        <div className={styles.stepHeader}>
+          <span className={styles.stepNumber}>1</span>
+          <span className={styles.stepTitle}>选择平台</span>
+        </div>
+        <div className={styles.stepContent}>
+          <PlatformSelector />
+        </div>
+      </div>
+
+      {/* Step 2: 检查适配 */}
+      {selectedPlatforms.length > 0 && (
+        <div className={styles.step}>
+          <div className={styles.stepHeader}>
+            <span className={styles.stepNumber}>2</span>
+            <span className={styles.stepTitle}>检查就绪</span>
+          </div>
+          <div className={styles.stepContent}>
+            {readinessItems.map((item) => (
+              <div key={item.platform} className={styles.platformRow}>
+                <div className={styles.platformInfo}>
+                  <span className={styles.platformName}>{platformNames[item.platform]}</span>
+                </div>
+                <span className={styles.readinessVariants[item.status]}>
+                  {READINESS_LABELS[item.status]}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Step 3: 发布 */}
+      <div className={styles.step}>
+        <div className={styles.stepHeader}>
+          <span className={styles.stepNumber}>3</span>
+          <span className={styles.stepTitle}>发布</span>
+        </div>
+        <div className={styles.stepContent}>
+          <div className={styles.publishAction}>
+            <PublishButton />
+          </div>
+          {overallStatus !== 'idle' && <PublishStatusPanel />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/publish/PublishChecklist.tsx
+++ b/src/components/publish/PublishChecklist.tsx
@@ -94,6 +94,23 @@ export default function PublishChecklist({ agentEnabled }: { agentEnabled: boole
             <PublishButton />
           </div>
           {overallStatus !== 'idle' && <PublishStatusPanel />}
+          {results.some((r) => r.status === 'error') && (
+            <div className={styles.failureGuidance}>
+              {results
+                .filter((r) => r.status === 'error')
+                .map((r) => (
+                  <div key={r.platform} className={styles.failureItem}>
+                    <span className={styles.failurePlatform}>{platformNames[r.platform]}</span>
+                    <span className={styles.failureMessage}>{r.message || '发布失败'}</span>
+                  </div>
+                ))}
+            </div>
+          )}
+          {results.some((r) => r.status === 'success') && (
+            <a href="/drafts" className={styles.resultLink}>
+              查看分发记录 →
+            </a>
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/publishChecks/platformReadiness.ts
+++ b/src/lib/publishChecks/platformReadiness.ts
@@ -1,0 +1,50 @@
+import type { PlatformId } from '@/types';
+import type { PlatformContentDraft } from '@/lib/platformAdapters/types';
+
+export type PlatformReadiness =
+  | 'unconfigured'
+  | 'ready'
+  | 'needs-content'
+  | 'needs-adapt'
+  | 'publishing'
+  | 'success'
+  | 'failed';
+
+export interface PlatformReadinessInfo {
+  platform: PlatformId;
+  status: PlatformReadiness;
+  message: string;
+}
+
+/**
+ * 判断单个平台的发布就绪状态
+ */
+export function getPlatformReadiness(
+  platform: PlatformId,
+  draft: PlatformContentDraft | undefined,
+  overallStatus: string,
+  publishResult?: { status: string; message?: string },
+): PlatformReadinessInfo {
+  // 发布中
+  if (overallStatus === 'publishing') {
+    return { platform, status: 'publishing', message: '发布中...' };
+  }
+
+  // 有发布结果
+  if (publishResult) {
+    if (publishResult.status === 'success') {
+      return { platform, status: 'success', message: '发布成功' };
+    }
+    if (publishResult.status === 'error') {
+      return { platform, status: 'failed', message: publishResult.message || '发布失败' };
+    }
+  }
+
+  // 内容不完整
+  if (!draft?.title?.trim() || !draft?.body?.trim()) {
+    return { platform, status: 'needs-content', message: '标题或内容为空' };
+  }
+
+  // 就绪
+  return { platform, status: 'ready', message: '可发布' };
+}


### PR DESCRIPTION
## 概述

按照 `Docs/plans/2026-06-05-product-design-optimization-plan.md` Phase 1 + Phase 2 执行。

## Phase 1: 首页主路径收敛

### simplify compose header actions
- 模板、媒体库、清空移入更多下拉菜单
- 顶部保留：tab 切换（写作/预览）+ 草稿面板 + 更多
- 清空在菜单中使用 destructive 样式

### strengthen editor visual hierarchy
- 编辑器卡片从 glass 改为 solid surface + 更强 shadow
- 右侧发布面板宽度 280px → 320px

### move writing assistant into contextual drawer
- AgentPanel 从占据流布局改为右侧 drawer overlay（桌面）/ bottom sheet（移动）
- 不再与发布面板争抢水平空间

## Phase 2: 发布面板流程化

### model platform readiness states
- 新增 `getPlatformReadiness()` 函数，返回 per-platform 发布就绪状态

### present publishing checklist
- 右侧发布区改为 3 步 checklist: 选择平台 → 检查就绪 → 发布
- 每个平台显示 readiness badge（可发布/内容待补全/发布中/成功/失败）
- PublishButton label 聚合移动端溢出修复

### inline adaptation and failure guidance
- 发布失败后，错误信息内联显示在对应平台下方
- 发布成功后，显示'查看分发记录'入口

## 验证

- `pnpm lint` ✅
- `pnpm build` ✅