### PR TITLE
polish: Phase 3 稿件库查找体验

### DIFF
--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -97,7 +97,7 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
   const [statusFilter, setStatusFilter] = useState<DraftStatus | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [tagFilter, setTagFilter] = useState('');
-  const [viewMode, setViewMode] = useState<ViewMode>('pipeline');
+  const [viewMode, setViewMode] = useState<ViewMode>('compact');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   useEffect(() => {
@@ -457,19 +457,7 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
                   {draft.title || '无标题'}
                 </Link>
                 <span className={styles.compactStatus}>{statusLabels[draft.status]}</span>
-                {!isEditMode && (
-                  <button
-                    type="button"
-                    className={styles.exportButton}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleExport(draft);
-                    }}
-                    title="导出为 Markdown"
-                  >
-                    <Download size={13} />
-                  </button>
-                )}
+                <span className={styles.compactTime}>{formatDraftTime(draft.updatedAt)}</span>
               </div>
             );
           })}
@@ -623,6 +611,3 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
     </div>
   );
 }
-
-// suppress unused import warning – formatDraftTime kept for future use
-void formatDraftTime;

--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -355,21 +355,21 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
           <div className={styles.viewToggle}>
             <button
               type="button"
-              className={styles.viewToggleButton({ active: viewMode === 'pipeline' })}
-              onClick={() => setViewMode('pipeline')}
-              aria-label="流水线视图"
-              title="流水线视图"
-            >
-              <Columns3 size={16} />
-            </button>
-            <button
-              type="button"
               className={styles.viewToggleButton({ active: viewMode === 'compact' })}
               onClick={() => setViewMode('compact')}
               aria-label="紧凑列表"
               title="紧凑列表"
             >
               <LayoutList size={16} />
+            </button>
+            <button
+              type="button"
+              className={styles.viewToggleButton({ active: viewMode === 'pipeline' })}
+              onClick={() => setViewMode('pipeline')}
+              aria-label="流水线视图（展开详情）"
+              title="流水线视图（展开详情）"
+            >
+              <Columns3 size={16} />
             </button>
           </div>
           <FilterChipGroup

--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -14,6 +14,7 @@ import {
   LayoutList,
   Columns3,
   ChevronDown,
+  SlidersHorizontal,
 } from 'lucide-react';
 import type { ContentDraft, DraftSource, DraftStatus } from '@/lib/drafts/types';
 import FilterChipGroup from '@/components/ui/FilterChipGroup';
@@ -99,6 +100,7 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
   const [tagFilter, setTagFilter] = useState('');
   const [viewMode, setViewMode] = useState<ViewMode>('compact');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
 
   useEffect(() => {
     if (!isEditMode) {
@@ -352,6 +354,16 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
+          <button
+            type="button"
+            className={styles.importButton}
+            onClick={() => setMobileFilterOpen(true)}
+            title="筛选"
+            aria-label="打开筛选面板"
+          >
+            <SlidersHorizontal size={14} />
+            筛选
+          </button>
           <div className={styles.viewToggle}>
             <button
               type="button"
@@ -378,6 +390,24 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
             onChange={setStatusFilter}
             className={styles.filterBar}
           />
+        </div>
+      )}
+
+      {/* Mobile filter sheet */}
+      {mobileFilterOpen && (
+        <div className={styles.mobileFilterOverlay} onClick={() => setMobileFilterOpen(false)}>
+          <div className={styles.mobileFilterSheet} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.mobileFilterHandle} />
+            <p className={styles.mobileFilterTitle}>筛选</p>
+            <FilterChipGroup
+              options={STATUS_FILTER_OPTIONS}
+              value={statusFilter}
+              onChange={(v) => {
+                setStatusFilter(v);
+                setMobileFilterOpen(false);
+              }}
+            />
+          </div>
         </div>
       )}
 

--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -441,7 +441,28 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
           );
         })()}
 
-      {viewMode === 'compact' ? (
+      {filteredDrafts.length === 0 && (searchQuery || statusFilter !== 'all' || tagFilter) ? (
+        <EmptyState
+          icon={<FileText size={24} />}
+          title="没有找到匹配的稿件"
+          description={
+            searchQuery ? `没有包含"${searchQuery}"的稿件。` : '当前筛选条件下没有稿件。'
+          }
+          action={
+            <button
+              type="button"
+              className={styles.primaryLink}
+              onClick={() => {
+                setSearchQuery('');
+                setStatusFilter('all');
+                setTagFilter('');
+              }}
+            >
+              清除筛选
+            </button>
+          }
+        />
+      ) : viewMode === 'compact' ? (
         <div className={styles.compactList}>
           {pagedDrafts.map((draft) => {
             const isSelected = selected.has(draft.id);

--- a/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
+++ b/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
@@ -132,19 +132,14 @@ describe('DraftLibraryClient', () => {
 
     render(createElement(DraftLibraryClient, { isEditMode: false, onExitEditMode: vi.fn() }));
 
-    // Title appears in the pipeline step label
+    // Title appears in the compact row (default view is compact)
     await waitFor(() => {
       expect(screen.getAllByText('AI 话题稿件').length).toBeGreaterThan(0);
     });
-    // Status label for 'ready' draft
-    expect(screen.getByText('待同步，去编辑')).toBeInTheDocument();
-    // Source label for manual draft
-    expect(screen.getByText('手动创建')).toBeInTheDocument();
-    // Sync task status label for 'partial'
-    expect(screen.getByText('部分完成')).toBeInTheDocument();
-    expect(screen.getByText('发布记录已内联显示')).toBeInTheDocument();
+    // Status label for 'ready' draft (compact view shows status text)
+    expect(screen.getAllByText('待同步').length).toBeGreaterThan(0);
     // Link to edit draft
-    expect(screen.getByRole('link', { name: '待同步，去编辑' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'AI 话题稿件' })).toHaveAttribute(
       'href',
       '/?draftId=draft-1',
     );

--- a/src/components/drafts/drafts.css.ts
+++ b/src/components/drafts/drafts.css.ts
@@ -906,3 +906,42 @@ export const loadMoreCount = style({
   textAlign: 'center',
   paddingTop: vars.spacing.xs,
 });
+
+// Mobile filter sheet
+export const mobileFilterOverlay = style({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 200,
+  background: 'rgba(0, 0, 0, 0.4)',
+  display: 'none',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  '@media': {
+    'screen and (max-width: 759px)': {
+      display: 'flex',
+    },
+  },
+});
+
+export const mobileFilterSheet = style({
+  width: '100%',
+  background: vars.color.surface,
+  borderRadius: `${vars.radius.xl} ${vars.radius.xl} 0 0`,
+  padding: `${vars.spacing['2xl']} ${vars.spacing.xl}`,
+  paddingBottom: 'calc(20px + env(safe-area-inset-bottom))',
+});
+
+export const mobileFilterHandle = style({
+  width: '36px',
+  height: vars.spacing.xs,
+  borderRadius: vars.spacing['2xs'],
+  background: vars.color.borderStrong,
+  margin: `0 auto ${vars.spacing.xl}`,
+});
+
+export const mobileFilterTitle = style({
+  margin: `0 0 ${vars.spacing.xl}`,
+  fontSize: vars.fontSize.lg,
+  fontWeight: 600,
+  color: vars.color.text,
+});


### PR DESCRIPTION
## 概述

按照 `Docs/plans/2026-06-05-product-design-optimization-plan.md` Phase 3 执行。

## 变更内容

### simplify desktop draft rows
- 默认视图从 pipeline 改为 compact，优先扫读效率
- Compact 行结构：标题 + 状态 badge + 更新时间
- 移除逐行导出按钮（通过编辑模式批量操作）

### move pipeline details into expansion
- Pipeline 视图重新定位为「展开详情」模式，非默认
- 视图切换按钮顺序调整：紧凑列表优先

### compact mobile library filters
- 新增「筛选」按钮，移动端点击打开 bottom sheet
- Filter chips 在 sheet 内展示，选择后自动关闭
- 桌面端 filter chips 仍然 inline 显示

### add actionable empty states
- 搜索/筛选无结果：显示搜索词 + 「清除筛选」按钮
- 无草稿状态保持不变（已有 EmptyState 组件）

## 验证

- `pnpm lint` ✅
- `pnpm build` ✅