### PR TITLE
polish: Phase 4 设置页可用性状态

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -177,6 +177,7 @@ function SettingsContent() {
   }, []);
 
   const isDirty = Object.keys(values).some((key) => values[key] !== initialValues[key]);
+  const dirtyCount = Object.keys(values).filter((key) => values[key] !== initialValues[key]).length;
 
   function handleChange(key: string, value: string) {
     setValues((prev) => ({ ...prev, [key]: value }));
@@ -868,7 +869,7 @@ function SettingsContent() {
       {isDirty && !loading && (
         <button type="button" className={styles.floatingSave} onClick={handleSave}>
           <Save size={16} />
-          保存设置
+          保存 {dirtyCount} 项修改
         </button>
       )}
     </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -736,7 +736,20 @@ function SettingsContent() {
               </div>
             </SurfaceCard>
             <SurfaceCard>
-              <PromptEditor />
+              <details>
+                <summary
+                  className={styles.accordionTrigger}
+                  style={{ cursor: 'pointer', listStyle: 'none' }}
+                >
+                  <div className={styles.accordionBody}>
+                    <p className={styles.accordionTitle}>Prompt 高级设置</p>
+                    <p className={styles.accordionSummary}>自定义 AI 改写和适配的提示词模板</p>
+                  </div>
+                </summary>
+                <div className={styles.accordionPanel}>
+                  <PromptEditor />
+                </div>
+              </details>
             </SurfaceCard>
           </div>
         </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -118,6 +118,10 @@ function SettingsContent() {
     Record<PlatformId, PlatformConnectionRecord>
   >({} as Record<PlatformId, PlatformConnectionRecord>);
   const [activeSection, setActiveSection] = useState<SectionId>('platforms');
+  const [agentTestResult, setAgentTestResult] = useState<{ ok: boolean; message: string } | null>(
+    null,
+  );
+  const [agentTesting, setAgentTesting] = useState(false);
   const connectionProfiles = getPlatformConnectionProfiles(values);
 
   // 检测 OAuth callback 后的 ?connected= 参数
@@ -279,6 +283,24 @@ function SettingsContent() {
       }, 2000);
     } catch {
       setDisconnectStates((prev) => ({ ...prev, [platformId]: { disconnecting: false } }));
+    }
+  }
+
+  async function handleTestAgent() {
+    setAgentTesting(true);
+    setAgentTestResult(null);
+    try {
+      const res = await fetch('/api/agent/status');
+      const data = await res.json();
+      if (data.available) {
+        setAgentTestResult({ ok: true, message: `连接成功 (${data.model || data.provider})` });
+      } else {
+        setAgentTestResult({ ok: false, message: '未配置或连接不可用，请检查 API 地址和密钥' });
+      }
+    } catch {
+      setAgentTestResult({ ok: false, message: '网络错误，无法测试连接' });
+    } finally {
+      setAgentTesting(false);
     }
   }
 
@@ -733,6 +755,23 @@ function SettingsContent() {
                   </li>
                   <li>发布预览面板出现「AI 适配」按钮</li>
                 </ul>
+                <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <button
+                    type="button"
+                    className={styles.checkButton}
+                    onClick={handleTestAgent}
+                    disabled={agentTesting}
+                  >
+                    {agentTesting ? '测试中...' : '测试连接'}
+                  </button>
+                  {agentTestResult && (
+                    <span
+                      className={agentTestResult.ok ? styles.checkResultOk : styles.checkResultFail}
+                    >
+                      {agentTestResult.message}
+                    </span>
+                  )}
+                </div>
               </div>
             </SurfaceCard>
             <SurfaceCard>


### PR DESCRIPTION
## 概述

按照 `Docs/plans/2026-06-05-product-design-optimization-plan.md` Phase 4 执行。

## 变更内容

### show configuration readiness states + dirty save
- 浮动保存按钮文案改为「保存 N 项修改」，明确 dirty count
- 平台状态 badge（connected/available/manual-required）+ 缺少凭证提示已有，无需改动

### collapse advanced configuration fields
- PromptEditor 用 `<details>` 默认折叠，标题为「Prompt 高级设置」
- 减少非高级用户的视觉噪音

### add inline connection checks
- AI Agent 区域新增「测试连接」按钮
- 调用 /api/agent/status，结果内联显示（成功：模型名；失败：原因）

## 验证

- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test`: 唯一失败的 sanitizeHtmlSecurity 是 main 已有问题，与本 PR 无关