### PR TITLE
polish: Phase 5 移动端单任务模式

### DIFF
--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -361,16 +361,7 @@ function HomePageContent() {
           <div className={styles.mobileSheet} onClick={(e) => e.stopPropagation()}>
             <div className={styles.mobileSheetHandle} />
             <div className={styles.mobileSheetTitle}>发布设置</div>
-            <PlatformSelector />
-            <PlatformPreviewPanel
-              adaptations={platformDrafts}
-              selectedPlatforms={selectedPlatforms}
-              agentEnabled={agentEnabled}
-            />
-            <div style={{ marginTop: 16 }}>
-              <PublishButton />
-            </div>
-            {overallStatus !== 'idle' && <PublishStatusPanel />}
+            <PublishChecklist agentEnabled={agentEnabled} />
           </div>
         </div>
       )}

--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -50,11 +50,12 @@ export const editorSection = style({
 });
 
 export const rightPanel = style({
-  display: 'flex',
+  display: 'none',
   flexDirection: 'column',
   gap: vars.spacing.lg,
   '@media': {
     'screen and (min-width: 1024px)': {
+      display: 'flex',
       width: '320px',
       flexShrink: 0,
       position: 'sticky',

--- a/src/components/editor/editor.css.ts
+++ b/src/components/editor/editor.css.ts
@@ -664,6 +664,15 @@ export const immersiveEntryBtn = style({
   ':hover': {
     color: vars.color.text,
   },
+  '@media': {
+    'screen and (max-width: 1023px)': {
+      background: vars.color.accentSoft,
+      color: vars.color.accent,
+      padding: `${vars.spacing.sm} ${vars.spacing.lg}`,
+      fontSize: vars.fontSize.sm,
+      fontWeight: 500,
+    },
+  },
 });
 
 // --- Editor Mode Toggle ---


### PR DESCRIPTION
## 概述

按照 `Docs/plans/2026-06-05-product-design-optimization-plan.md` Phase 5 执行。

## 变更内容

### introduce compose bottom sheets
- 右侧发布面板在移动端（< 1024px）隐藏，仅桌面端展示
- 移动端通过 FAB → bottom sheet 访问发布流程
- Sheet 内使用 PublishChecklist（与桌面一致的 3 步流程）
- 移除 sheet 中的重复组件渲染

### emphasize focused writing mode
- 沉浸写作按钮在移动端增强：accent 背景色、更大尺寸、更粗字重
- 让移动端用户更容易发现和进入专注写作模式
- 桌面端保持原有的 ghost 按钮风格

## 说明

Phase 5 中'浮动按钮安全区域'和'首页简化主路径'已在之前提交中实现：
- FAB 已通过 `calc(68px + env(safe-area-inset-bottom))` 处理安全区域
- 首页移动端已仅显示编辑器 + FAB（右侧面板现已隐藏）

## 验证

- `pnpm lint` ✅
- `pnpm build` ✅