### PR TITLE
polish: make page headers sticky

### DIFF
--- a/src/app/page.css.ts
+++ b/src/app/page.css.ts
@@ -59,7 +59,7 @@ export const rightPanel = style({
       width: '320px',
       flexShrink: 0,
       position: 'sticky',
-      top: '28px',
+      top: '84px',
     },
   },
 });

--- a/src/app/settings/settings.css.ts
+++ b/src/app/settings/settings.css.ts
@@ -12,7 +12,7 @@ export const pageWrap = style({
 // Section anchor nav
 export const sectionNav = style({
   position: 'sticky',
-  top: 0,
+  top: '56px',
   zIndex: 10,
   display: 'flex',
   gap: vars.spacing['2xs'],
@@ -91,7 +91,7 @@ export const floatingSave = style({
 });
 
 export const sectionAnchor = style({
-  scrollMarginTop: '56px',
+  scrollMarginTop: '112px',
 });
 
 export const accordionCard = style({

--- a/src/components/layout/AppShellHeader.css.ts
+++ b/src/components/layout/AppShellHeader.css.ts
@@ -2,59 +2,102 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/styles/tokens.css';
 
 export const header = style({
-  width: '100%',
-  paddingTop: vars.spacing.xs,
-  paddingBottom: vars.spacing.xl,
-  marginBottom: vars.spacing.md,
+  position: 'sticky',
+  top: 0,
+  zIndex: 40,
+  height: '80px',
+  width: 'auto',
+  margin: `calc(-1 * ${vars.spacing.xl}) calc(-1 * ${vars.spacing.xl}) ${vars.spacing['2xl']}`,
+  padding: `0 ${vars.spacing.xl}`,
+  borderBottom: `1px solid ${vars.color.glassBorder}`,
+  background: vars.color.glassSurface,
+  backdropFilter: 'blur(16px) saturate(180%)',
+  WebkitBackdropFilter: 'blur(16px) saturate(180%)',
+  '@media': {
+    'screen and (min-width: 640px)': {
+      margin: `calc(-1 * ${vars.spacing['2xl']}) calc(-1 * ${vars.spacing['3xl']}) ${vars.spacing['2xl']}`,
+      padding: `0 ${vars.spacing['3xl']}`,
+    },
+    'screen and (min-width: 1024px)': {
+      margin: '-28px -36px 28px',
+      padding: '0 36px',
+    },
+  },
 });
 
 export const inner = style({
   display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'stretch',
+  height: '100%',
+  alignItems: 'center',
+  justifyContent: 'space-between',
   gap: vars.spacing.xl,
-  '@media': {
-    'screen and (min-width: 640px)': {
-      flexDirection: 'row',
-      alignItems: 'flex-end',
-      justifyContent: 'space-between',
-    },
-  },
 });
 
 export const textBlock = style({
-  maxWidth: '56rem',
+  display: 'flex',
   minWidth: 0,
+  maxWidth: '56rem',
+  flex: 1,
+  flexDirection: 'column',
+  justifyContent: 'center',
 });
 
 export const kicker = style({
-  fontSize: vars.fontSize.xs,
-  fontWeight: 500,
+  margin: 0,
+  fontSize: vars.fontSize['2xs'],
+  fontWeight: 600,
   letterSpacing: vars.tracking.kicker,
+  lineHeight: 1.1,
   color: vars.color.textMuted,
+  textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  '@media': {
+    'screen and (max-width: 639px)': {
+      display: 'none',
+    },
+  },
 });
 
 export const title = style({
-  marginTop: vars.spacing.sm,
-  fontSize: vars.fontSize['3xl'],
+  margin: 0,
+  marginTop: vars.spacing.xs,
+  fontSize: vars.fontSize['2xl'],
   fontWeight: 600,
-  lineHeight: 1.2,
+  lineHeight: 1.15,
   color: vars.color.text,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  '@media': {
+    'screen and (min-width: 640px)': {
+      fontSize: vars.fontSize['3xl'],
+    },
+  },
 });
 
 export const description = style({
-  marginTop: vars.spacing.md,
+  margin: 0,
+  marginTop: vars.spacing.xs,
   maxWidth: '48rem',
-  fontSize: vars.fontSize.sm,
-  lineHeight: 1.75,
+  fontSize: vars.fontSize.xs,
+  lineHeight: 1.35,
   color: vars.color.textMuted,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  '@media': {
+    'screen and (max-width: 639px)': {
+      display: 'none',
+    },
+  },
 });
 
 export const action = style({
+  display: 'flex',
   minWidth: 0,
-  '@media': {
-    'screen and (min-width: 640px)': {
-      flexShrink: 0,
-    },
-  },
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'flex-end',
 });

--- a/src/components/layout/Sidebar.css.ts
+++ b/src/components/layout/Sidebar.css.ts
@@ -120,12 +120,12 @@ export const navItemBase = style({
   position: 'relative',
   selectors: {
     [`${sidebarVariants.expanded} &`]: {
-      width: '100%',
+      width: `calc(100% - ${vars.spacing.xl})`,
       height: 'auto',
       justifyContent: 'flex-start',
       borderRadius: vars.radius.md,
       padding: `${vars.spacing['md-lg']} ${vars.spacing.lg}`,
-      alignSelf: 'stretch',
+      alignSelf: 'center',
     },
   },
 });

--- a/src/styles/globals.css.ts
+++ b/src/styles/globals.css.ts
@@ -40,6 +40,7 @@ globalStyle('html', {
 
 globalStyle('body', {
   minHeight: '100vh',
+  margin: 0,
   color: vars.color.text,
   fontFamily: vars.font.sans,
   background: `


### PR DESCRIPTION
## Summary
- Make page headers sticky with a compact 80px bar aligned flush to the content edges
- Tune header text/action layout for single-line display and overflow handling
- Offset secondary sticky elements and add spacing to expanded sidebar nav items

## Verification
- pnpm lint
- rm -rf .next && pnpm build

## Notes
- pnpm verify currently stops at src/lib/__tests__/sanitizeHtmlSecurity.test.ts because sanitize-html returns raw xmp content; unrelated to this layout change.