### PR TITLE
Fix popup outside-click behavior

### DIFF
--- a/src/components/drafts/DraftLibraryClient.tsx
+++ b/src/components/drafts/DraftLibraryClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
   FileText,
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import type { ContentDraft, DraftSource, DraftStatus } from '@/lib/drafts/types';
 import FilterChipGroup from '@/components/ui/FilterChipGroup';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import type { SyncTask, SyncTaskStatus } from '@/lib/sync/types';
 import { deleteDraft, createDraft, updateDraft } from '@/lib/drafts/client';
 import {
@@ -101,6 +102,8 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
   const [viewMode, setViewMode] = useState<ViewMode>('compact');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
+  const filterPopoverRef = useRef<HTMLDivElement>(null);
+  const mobileFilterSheetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isEditMode) {
@@ -112,6 +115,10 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
   }, [statusFilter, searchQuery, tagFilter]);
+
+  useClickOutside([filterPopoverRef, mobileFilterSheetRef], mobileFilterOpen, () =>
+    setMobileFilterOpen(false),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -354,16 +361,33 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
-          <button
-            type="button"
-            className={styles.importButton}
-            onClick={() => setMobileFilterOpen(true)}
-            title="筛选"
-            aria-label="打开筛选面板"
-          >
-            <SlidersHorizontal size={14} />
-            筛选
-          </button>
+          <div ref={filterPopoverRef} className={styles.filterPopoverWrap}>
+            <button
+              type="button"
+              className={styles.importButton}
+              onClick={() => setMobileFilterOpen((open) => !open)}
+              title="筛选"
+              aria-expanded={mobileFilterOpen}
+              aria-label="打开筛选面板"
+            >
+              <SlidersHorizontal size={14} />
+              筛选
+            </button>
+            {mobileFilterOpen && (
+              <div className={styles.filterPopover}>
+                <p className={styles.filterPopoverTitle}>筛选状态</p>
+                <FilterChipGroup
+                  options={STATUS_FILTER_OPTIONS}
+                  value={statusFilter}
+                  onChange={(v) => {
+                    setStatusFilter(v);
+                    setMobileFilterOpen(false);
+                  }}
+                  className={styles.filterBar}
+                />
+              </div>
+            )}
+          </div>
           <div className={styles.viewToggle}>
             <button
               type="button"
@@ -384,19 +408,17 @@ export default function DraftLibraryClient({ isEditMode, onExitEditMode }: Props
               <Columns3 size={16} />
             </button>
           </div>
-          <FilterChipGroup
-            options={STATUS_FILTER_OPTIONS}
-            value={statusFilter}
-            onChange={setStatusFilter}
-            className={styles.filterBar}
-          />
         </div>
       )}
 
       {/* Mobile filter sheet */}
       {mobileFilterOpen && (
         <div className={styles.mobileFilterOverlay} onClick={() => setMobileFilterOpen(false)}>
-          <div className={styles.mobileFilterSheet} onClick={(e) => e.stopPropagation()}>
+          <div
+            ref={mobileFilterSheetRef}
+            className={styles.mobileFilterSheet}
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className={styles.mobileFilterHandle} />
             <p className={styles.mobileFilterTitle}>筛选</p>
             <FilterChipGroup

--- a/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
+++ b/src/components/drafts/__tests__/DraftLibraryClient.test.tsx
@@ -63,6 +63,9 @@ vi.mock('@/components/drafts/drafts.css', () => ({
   syncStatusLabelVariants: () => 'syncStatusLabelVariants',
   toolbar: 'toolbar',
   searchInput: 'searchInput',
+  filterPopoverWrap: 'filterPopoverWrap',
+  filterPopover: 'filterPopover',
+  filterPopoverTitle: 'filterPopoverTitle',
   filterBar: 'filterBar',
   filterChip: (variants: { active?: boolean }) =>
     variants?.active ? 'filterChip-active' : 'filterChip',

--- a/src/components/drafts/drafts.css.ts
+++ b/src/components/drafts/drafts.css.ts
@@ -684,27 +684,42 @@ export const tagChip = recipe({
 });
 
 // 状态筛选栏
-export const filterBar = style({
-  display: 'flex',
-  gap: vars.spacing.sm,
-  gridColumn: '1 / -1',
-  overflowX: 'auto',
-  paddingBottom: vars.spacing['2xs'],
-  WebkitOverflowScrolling: 'touch',
-  scrollbarWidth: 'none',
-  selectors: {
-    '&::-webkit-scrollbar': {
-      display: 'none',
-    },
-  },
+export const filterPopoverWrap = style({
+  position: 'relative',
+});
+
+export const filterPopover = style({
+  display: 'none',
   '@media': {
     'screen and (min-width: 760px)': {
-      gridColumn: 'auto',
-      overflowX: 'visible',
-      flexWrap: 'wrap',
-      paddingBottom: 0,
+      position: 'absolute',
+      top: 'calc(100% + 8px)',
+      right: 0,
+      zIndex: 30,
+      display: 'grid',
+      gap: vars.spacing.md,
+      minWidth: 320,
+      maxWidth: 420,
+      padding: vars.spacing['lg-xl'],
+      borderRadius: vars.radius.xl,
+      border: `1px solid ${vars.color.border}`,
+      background: vars.color.surface,
+      boxShadow: vars.shadow.lg,
     },
   },
+});
+
+export const filterPopoverTitle = style({
+  margin: 0,
+  fontSize: vars.fontSize.sm,
+  fontWeight: 600,
+  color: vars.color.text,
+});
+
+export const filterBar = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: vars.spacing.sm,
 });
 
 export const filterChip = recipe({

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -16,6 +16,7 @@ import { useSlashCommands } from '@/hooks/useSlashCommands';
 import { useAgentStream } from '@/hooks/useAgentStream';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useImmersiveMode } from '@/hooks/useImmersiveMode';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import SlashCommandMenu from './SlashCommandMenu';
 import EditorModeToggle from './EditorModeToggle';
 import * as styles from './editor.css';
@@ -41,6 +42,8 @@ export default function MarkdownEditor({
   const slash = useSlashCommands(content, setContent, { agentEnabled });
   const agent = useAgentStream();
   const immersive = useImmersiveMode();
+
+  useClickOutside(editorWrapRef, slash.visible, slash.hide);
 
   useEffect(() => {
     function syncHeight() {

--- a/src/components/publish/ModerationWarning.tsx
+++ b/src/components/publish/ModerationWarning.tsx
@@ -29,8 +29,8 @@ export default function ModerationWarning({
   }, {});
 
   return (
-    <div className={styles.moderationOverlay}>
-      <div className={styles.moderationDialog}>
+    <div className={styles.moderationOverlay} onClick={onCancel}>
+      <div className={styles.moderationDialog} onClick={(e) => e.stopPropagation()}>
         <div className={styles.moderationHeader}>
           <ShieldAlert size={20} />
           <span>内容安全检查</span>

--- a/src/components/publish/PublishProgressOverlay.tsx
+++ b/src/components/publish/PublishProgressOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { X, Loader2, CheckCircle2, XCircle } from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { usePublishStore } from '@/stores/publishStore';
 import type { SyncTask, SyncReceiptStatus } from '@/lib/sync/types';
 import type { PlatformId } from '@/types';
@@ -59,6 +60,7 @@ export default function PublishProgressOverlay() {
     usePublishStore();
   const [syncTask, setSyncTask] = useState<SyncTask | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   const isDone = syncTask ? syncTask.receipts.every((r) => isTerminalStatus(r.status)) : false;
 
@@ -100,10 +102,12 @@ export default function PublishProgressOverlay() {
     closeProgressOverlay();
   }
 
+  useClickOutside(overlayRef, isProgressOverlayOpen, handleClose);
+
   if (!isProgressOverlayOpen || !lastSyncTaskId) return null;
 
   return (
-    <div className={styles.overlay} role="status" aria-live="polite">
+    <div ref={overlayRef} className={styles.overlay} role="status" aria-live="polite">
       <div className={styles.header}>
         <span className={styles.headerTitle}>分发进度</span>
         <button

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+
+type OutsideRef<T extends HTMLElement> = RefObject<T | null>;
+
+export function useClickOutside<T extends HTMLElement>(
+  refs: OutsideRef<T> | OutsideRef<T>[],
+  active: boolean,
+  onClickOutside: () => void,
+) {
+  useEffect(() => {
+    if (!active) return;
+
+    const refList = Array.isArray(refs) ? refs : [refs];
+
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target as Node;
+      if (refList.some((ref) => ref.current?.contains(target))) return;
+      onClickOutside();
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [active, onClickOutside, refs]);
+}


### PR DESCRIPTION
## Summary
- Add shared outside-click handling for popup-like UI
- Show the draft filter controls in a popover from the filter button
- Close moderation warnings, publish progress, slash command menu, and draft filter popups when clicking outside

## Validation
- pnpm lint
- pnpm build

## Notes
- Full test run still hits the existing sanitize-html security test failure unrelated to these UI changes.