### PR TITLE
refactor: settings platform layout from accordion to split-pane

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,7 +7,6 @@ import {
   Eye,
   EyeOff,
   CheckCircle2,
-  ChevronDown,
   RefreshCw,
   Unplug,
   Zap,
@@ -116,7 +115,7 @@ function SettingsContent() {
   );
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   const [saved, setSaved] = useState(false);
-  const [expandedPlatform, setExpandedPlatform] = useState<string | null>(null);
+  const [selectedPlatform, setSelectedPlatform] = useState<string>(platformConfigs[0].id);
   const [errorMessage, setErrorMessage] = useState('');
   const [noticeMessage, setNoticeMessage] = useState('');
   const [loading, setLoading] = useState(!cachedData);
@@ -139,7 +138,7 @@ function SettingsContent() {
     if (connected) {
       const platformName = platformConfigs.find((p) => p.id === connected)?.name ?? connected;
       setNoticeMessage(`${platformName} 授权成功，连接已建立。`);
-      setExpandedPlatform(connected);
+      setSelectedPlatform(connected);
     } else if (error) {
       setErrorMessage(`授权失败：${decodeURIComponent(error)}`);
     }
@@ -375,88 +374,241 @@ function SettingsContent() {
 
       {activeSection === 'platforms' ? (
         <div id="platforms" className={styles.sectionAnchor}>
-          <div className={styles.platformList}>
-            {platformConfigs.map((platform) => {
-              const isExpanded = expandedPlatform === platform.id;
-              const { Icon } = platform;
-              const connectionProfile = connectionProfiles.find(
-                (profile) => profile.platform === platform.id,
-              );
-              const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
-              const record = connectionRecords[platform.id];
-              // 账号名：优先用最新 check 结果，其次用持久化 record
-              const connectedAccountName =
-                (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
-                (!checkStates[platform.id] && record?.accountName) ||
-                null;
-              const isConnected =
-                connectionProfile?.status === 'connected' && !disconnectStates[platform.id]?.done;
+          {/* Mobile: horizontal pill tabs */}
+          <nav className={styles.platformMobileTabs}>
+            {platformConfigs.map((platform) => (
+              <button
+                key={platform.id}
+                type="button"
+                className={styles.platformMobileTab({ active: selectedPlatform === platform.id })}
+                onClick={() => setSelectedPlatform(platform.id)}
+              >
+                {platform.name}
+              </button>
+            ))}
+          </nav>
 
-              return (
-                <SurfaceCard key={platform.id} tone="soft" className={styles.accordionCard}>
+          <div className={styles.platformLayout}>
+            {/* Desktop: sidebar list */}
+            <nav className={styles.platformSidebar}>
+              {platformConfigs.map((platform) => {
+                const { Icon } = platform;
+                const connectionProfile = connectionProfiles.find(
+                  (p) => p.platform === platform.id,
+                );
+                return (
                   <button
+                    key={platform.id}
                     type="button"
-                    aria-expanded={isExpanded}
-                    aria-controls={`${platform.id}-panel`}
-                    onClick={() => setExpandedPlatform(isExpanded ? null : platform.id)}
-                    className={styles.accordionTrigger}
+                    className={styles.platformSidebarItem({
+                      active: selectedPlatform === platform.id,
+                    })}
+                    onClick={() => setSelectedPlatform(platform.id)}
                   >
-                    <div className={styles.accordionIcon}>
-                      <Icon size={20} />
-                    </div>
-                    <div className={styles.accordionBody}>
-                      <p className={styles.accordionTitle}>{platform.name}</p>
-                      {isConnected && connectedAccountName ? (
-                        <p className={styles.accordionAccountName}>
-                          <CheckCircle2 size={11} />
-                          {connectedAccountName}
-                        </p>
-                      ) : connectionProfile && connectionProfile.missingKeys.length > 0 ? (
-                        <p className={styles.accordionMissingFields}>
-                          缺少：{connectionProfile.missingKeys.join(', ')}
-                        </p>
-                      ) : (
-                        <p className={styles.accordionSummary}>{platform.summary}</p>
-                      )}
-                    </div>
-                    <div className={styles.accordionToggle}>
-                      {connectionProfile ? (
-                        <span
-                          className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
-                        >
-                          {statusLabels[connectionProfile.status]}
-                        </span>
-                      ) : null}
-                      <span>{isExpanded ? '收起' : '展开'}</span>
-                      <ChevronDown
-                        size={16}
-                        style={{
-                          transition: 'transform 150ms',
-                          transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                        }}
-                      />
-                    </div>
+                    <span className={styles.sidebarItemIcon}>
+                      <Icon size={18} />
+                    </span>
+                    <span className={styles.sidebarItemBody}>
+                      <p className={styles.sidebarItemName}>{platform.name}</p>
+                      <p className={styles.sidebarItemStatus}>
+                        {connectionProfile ? statusLabels[connectionProfile.status] : '未配置'}
+                      </p>
+                    </span>
                   </button>
+                );
+              })}
+            </nav>
 
-                  {isExpanded ? (
-                    <div id={`${platform.id}-panel`} className={styles.accordionPanel}>
-                      {connectionProfile?.mode === 'oauth' ? (
-                        // ── OAuth 平台：两步引导 ──────────────────────────────
-                        <div className={styles.oauthSteps}>
-                          {/* 步骤 1：开发者凭证 */}
-                          <div className={styles.oauthStep}>
-                            <div className={styles.oauthStepHeader}>
-                              <span
-                                className={
-                                  connectionProfile.status === 'connected'
-                                    ? styles.oauthStepBadgeActive
-                                    : styles.oauthStepBadge
-                                }
-                              >
-                                1
-                              </span>
-                              <p className={styles.oauthStepTitle}>填写开发者凭证</p>
+            {/* Detail panel */}
+            <div className={styles.platformDetail}>
+              <SurfaceCard tone="soft">
+                <div className={styles.platformDetailInner}>
+                  {(() => {
+                    const platform = platformConfigs.find((p) => p.id === selectedPlatform)!;
+                    const { Icon } = platform;
+                    const connectionProfile = connectionProfiles.find(
+                      (p) => p.platform === platform.id,
+                    );
+                    const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
+                    const record = connectionRecords[platform.id];
+                    const connectedAccountName =
+                      (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
+                      (!checkStates[platform.id] && record?.accountName) ||
+                      null;
+                    const isConnected =
+                      connectionProfile?.status === 'connected' &&
+                      !disconnectStates[platform.id]?.done;
+
+                    return (
+                      <>
+                        <div className={styles.platformDetailHeader}>
+                          <span className={styles.accordionIcon}>
+                            <Icon size={22} />
+                          </span>
+                          <div>
+                            <p className={styles.accordionTitle}>{platform.name}</p>
+                            {isConnected && connectedAccountName ? (
+                              <p className={styles.accordionAccountName}>
+                                <CheckCircle2 size={11} />
+                                {connectedAccountName}
+                              </p>
+                            ) : (
+                              <p className={styles.accordionSummary}>{platform.summary}</p>
+                            )}
+                          </div>
+                          {connectionProfile ? (
+                            <span
+                              className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
+                            >
+                              {statusLabels[connectionProfile.status]}
+                            </span>
+                          ) : null}
+                        </div>
+
+                        {connectionProfile?.mode === 'oauth' ? (
+                          <div className={styles.oauthSteps}>
+                            <div className={styles.oauthStep}>
+                              <div className={styles.oauthStepHeader}>
+                                <span
+                                  className={
+                                    connectionProfile.status === 'connected'
+                                      ? styles.oauthStepBadgeActive
+                                      : styles.oauthStepBadge
+                                  }
+                                >
+                                  1
+                                </span>
+                                <p className={styles.oauthStepTitle}>填写开发者凭证</p>
+                              </div>
+                              <div className={styles.fieldList}>
+                                {platform.fields.map((field) => (
+                                  <div key={field.key} className={styles.fieldWrap}>
+                                    <label htmlFor={field.key} className={styles.fieldLabel}>
+                                      {field.label}
+                                    </label>
+                                    <div className={styles.fieldInputWrap}>
+                                      <input
+                                        id={field.key}
+                                        type={
+                                          field.type === 'password' && !showSecrets[field.key]
+                                            ? 'password'
+                                            : 'text'
+                                        }
+                                        value={values[field.key] || ''}
+                                        onChange={(event) =>
+                                          handleChange(field.key, event.target.value)
+                                        }
+                                        placeholder={field.placeholder}
+                                        className={styles.fieldInput}
+                                      />
+                                      {field.type === 'password' ? (
+                                        <button
+                                          type="button"
+                                          onClick={() => toggleSecret(field.key)}
+                                          aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
+                                          className={styles.eyeButton}
+                                        >
+                                          {showSecrets[field.key] ? (
+                                            <EyeOff size={16} />
+                                          ) : (
+                                            <Eye size={16} />
+                                          )}
+                                        </button>
+                                      ) : null}
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                              <p className={styles.fieldHint}>{platform.hint}</p>
                             </div>
+
+                            <div className={styles.oauthStep}>
+                              <div className={styles.oauthStepHeader}>
+                                <span
+                                  className={
+                                    connectionProfile.status === 'connected'
+                                      ? styles.oauthStepBadgeActive
+                                      : styles.oauthStepBadge
+                                  }
+                                >
+                                  2
+                                </span>
+                                <p className={styles.oauthStepTitle}>
+                                  {isVerifyOnly ? '验证连接' : '账号授权'}
+                                </p>
+                              </div>
+                              <p className={styles.oauthStepDesc}>
+                                {isVerifyOnly
+                                  ? connectionProfile.status === 'connected'
+                                    ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
+                                    : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
+                                  : connectionProfile.status === 'connected'
+                                    ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
+                                    : connectionProfile.missingKeys.length > 0
+                                      ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
+                                      : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
+                              </p>
+                              <CheckResult
+                                checkState={checkStates[platform.id]}
+                                connectionRecord={connectionRecords[platform.id]}
+                                disconnectDone={disconnectStates[platform.id]?.done}
+                              />
+                              <div className={styles.oauthAuthorizeRow}>
+                                <button
+                                  type="button"
+                                  className={styles.authorizeButton}
+                                  disabled={
+                                    connectionProfile.missingKeys.length > 0 ||
+                                    checkStates[platform.id]?.checking
+                                  }
+                                  onClick={() =>
+                                    void handleConnectionAction(
+                                      platform.id,
+                                      platform.name,
+                                      connectionProfile.mode,
+                                    )
+                                  }
+                                >
+                                  {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
+                                  {checkStates[platform.id]?.checking
+                                    ? '验证中…'
+                                    : isVerifyOnly
+                                      ? connectionProfile.status === 'connected'
+                                        ? '重新验证'
+                                        : '验证连接'
+                                      : connectionProfile.status === 'connected'
+                                        ? '重新授权'
+                                        : '一键授权'}
+                                </button>
+                                {connectionProfile.status === 'connected' && !isVerifyOnly ? (
+                                  <>
+                                    <button
+                                      type="button"
+                                      className={styles.checkButton}
+                                      disabled={checkStates[platform.id]?.checking}
+                                      onClick={() => void handleCheckConnection(platform.id)}
+                                    >
+                                      <RefreshCw size={13} />
+                                      {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className={styles.disconnectButton}
+                                      disabled={disconnectStates[platform.id]?.disconnecting}
+                                      onClick={() => void handleDisconnect(platform.id)}
+                                    >
+                                      <Unplug size={13} />
+                                      {disconnectStates[platform.id]?.disconnecting
+                                        ? '处理中…'
+                                        : '断开连接'}
+                                    </button>
+                                  </>
+                                ) : null}
+                              </div>
+                            </div>
+                          </div>
+                        ) : (
+                          <>
                             <div className={styles.fieldList}>
                               {platform.fields.map((field) => (
                                 <div key={field.key} className={styles.fieldWrap}>
@@ -464,20 +616,33 @@ function SettingsContent() {
                                     {field.label}
                                   </label>
                                   <div className={styles.fieldInputWrap}>
-                                    <input
-                                      id={field.key}
-                                      type={
-                                        field.type === 'password' && !showSecrets[field.key]
-                                          ? 'password'
-                                          : 'text'
-                                      }
-                                      value={values[field.key] || ''}
-                                      onChange={(event) =>
-                                        handleChange(field.key, event.target.value)
-                                      }
-                                      placeholder={field.placeholder}
-                                      className={styles.fieldInput}
-                                    />
+                                    {field.type === 'textarea' ? (
+                                      <textarea
+                                        id={field.key}
+                                        value={values[field.key] || ''}
+                                        onChange={(event) =>
+                                          handleChange(field.key, event.target.value)
+                                        }
+                                        placeholder={field.placeholder}
+                                        rows={4}
+                                        className={styles.fieldTextarea}
+                                      />
+                                    ) : (
+                                      <input
+                                        id={field.key}
+                                        type={
+                                          field.type === 'password' && !showSecrets[field.key]
+                                            ? 'password'
+                                            : 'text'
+                                        }
+                                        value={values[field.key] || ''}
+                                        onChange={(event) =>
+                                          handleChange(field.key, event.target.value)
+                                        }
+                                        placeholder={field.placeholder}
+                                        className={styles.fieldInput}
+                                      />
+                                    )}
                                     {field.type === 'password' ? (
                                       <button
                                         type="button"
@@ -497,176 +662,32 @@ function SettingsContent() {
                               ))}
                             </div>
                             <p className={styles.fieldHint}>{platform.hint}</p>
-                          </div>
-
-                          {/* 步骤 2：账号授权 / 验证连接 */}
-                          <div className={styles.oauthStep}>
-                            <div className={styles.oauthStepHeader}>
-                              <span
-                                className={
-                                  connectionProfile.status === 'connected'
-                                    ? styles.oauthStepBadgeActive
-                                    : styles.oauthStepBadge
+                            <div className={styles.oauthAuthorizeRow}>
+                              <button
+                                type="button"
+                                className={styles.checkButton}
+                                disabled={
+                                  checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']
                                 }
+                                onClick={() => void handleCheckConnection(platform.id)}
                               >
-                                2
-                              </span>
-                              <p className={styles.oauthStepTitle}>
-                                {isVerifyOnly ? '验证连接' : '账号授权'}
-                              </p>
+                                <RefreshCw size={13} />
+                                {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
+                              </button>
                             </div>
-                            <p className={styles.oauthStepDesc}>
-                              {isVerifyOnly
-                                ? connectionProfile.status === 'connected'
-                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
-                                  : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
-                                : connectionProfile.status === 'connected'
-                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
-                                  : connectionProfile.missingKeys.length > 0
-                                    ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
-                                    : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
-                            </p>
                             <CheckResult
                               checkState={checkStates[platform.id]}
                               connectionRecord={connectionRecords[platform.id]}
                               disconnectDone={disconnectStates[platform.id]?.done}
                             />
-                            <div className={styles.oauthAuthorizeRow}>
-                              <button
-                                type="button"
-                                className={styles.authorizeButton}
-                                disabled={
-                                  connectionProfile.missingKeys.length > 0 ||
-                                  checkStates[platform.id]?.checking
-                                }
-                                onClick={() =>
-                                  void handleConnectionAction(
-                                    platform.id,
-                                    platform.name,
-                                    connectionProfile.mode,
-                                  )
-                                }
-                              >
-                                {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
-                                {checkStates[platform.id]?.checking
-                                  ? '验证中…'
-                                  : isVerifyOnly
-                                    ? connectionProfile.status === 'connected'
-                                      ? '重新验证'
-                                      : '验证连接'
-                                    : connectionProfile.status === 'connected'
-                                      ? '重新授权'
-                                      : '一键授权'}
-                              </button>
-                              {connectionProfile.status === 'connected' && !isVerifyOnly ? (
-                                <>
-                                  <button
-                                    type="button"
-                                    className={styles.checkButton}
-                                    disabled={checkStates[platform.id]?.checking}
-                                    onClick={() => void handleCheckConnection(platform.id)}
-                                  >
-                                    <RefreshCw size={13} />
-                                    {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className={styles.disconnectButton}
-                                    disabled={disconnectStates[platform.id]?.disconnecting}
-                                    onClick={() => void handleDisconnect(platform.id)}
-                                  >
-                                    <Unplug size={13} />
-                                    {disconnectStates[platform.id]?.disconnecting
-                                      ? '处理中…'
-                                      : '断开连接'}
-                                  </button>
-                                </>
-                              ) : null}
-                            </div>
-                          </div>
-                        </div>
-                      ) : (
-                        // ── Manual 平台（知乎）：纯表单 + 测试连接 ───────────
-                        <>
-                          <div className={styles.fieldList}>
-                            {platform.fields.map((field) => (
-                              <div key={field.key} className={styles.fieldWrap}>
-                                <label htmlFor={field.key} className={styles.fieldLabel}>
-                                  {field.label}
-                                </label>
-                                <div className={styles.fieldInputWrap}>
-                                  {field.type === 'textarea' ? (
-                                    <textarea
-                                      id={field.key}
-                                      value={values[field.key] || ''}
-                                      onChange={(event) =>
-                                        handleChange(field.key, event.target.value)
-                                      }
-                                      placeholder={field.placeholder}
-                                      rows={4}
-                                      className={styles.fieldTextarea}
-                                    />
-                                  ) : (
-                                    <input
-                                      id={field.key}
-                                      type={
-                                        field.type === 'password' && !showSecrets[field.key]
-                                          ? 'password'
-                                          : 'text'
-                                      }
-                                      value={values[field.key] || ''}
-                                      onChange={(event) =>
-                                        handleChange(field.key, event.target.value)
-                                      }
-                                      placeholder={field.placeholder}
-                                      className={styles.fieldInput}
-                                    />
-                                  )}
-                                  {field.type === 'password' ? (
-                                    <button
-                                      type="button"
-                                      onClick={() => toggleSecret(field.key)}
-                                      aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
-                                      className={styles.eyeButton}
-                                    >
-                                      {showSecrets[field.key] ? (
-                                        <EyeOff size={16} />
-                                      ) : (
-                                        <Eye size={16} />
-                                      )}
-                                    </button>
-                                  ) : null}
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                          <p className={styles.fieldHint}>{platform.hint}</p>
-                          {/* 知乎：测试连接区域 */}
-                          <div className={styles.oauthAuthorizeRow}>
-                            <button
-                              type="button"
-                              className={styles.checkButton}
-                              disabled={
-                                checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']
-                              }
-                              onClick={() => void handleCheckConnection(platform.id)}
-                            >
-                              <RefreshCw size={13} />
-                              {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
-                            </button>
-                          </div>
-                          <CheckResult
-                            checkState={checkStates[platform.id]}
-                            connectionRecord={connectionRecords[platform.id]}
-                            disconnectDone={disconnectStates[platform.id]?.done}
-                          />
-                        </>
-                      )}
-                    </div>
-                  ) : null}
-                </SurfaceCard>
-              );
-            })}
+                          </>
+                        )}
+                      </>
+                    );
+                  })()}
+                </div>
+              </SurfaceCard>
+            </div>
           </div>
         </div>
       ) : null}

--- a/src/app/settings/settings.css.ts
+++ b/src/app/settings/settings.css.ts
@@ -609,3 +609,158 @@ export const authorizeButton = style({
     cursor: 'not-allowed',
   },
 });
+
+// ── Platform two-column layout ─────────────────────────────────────
+
+export const platformLayout = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.xl,
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      flexDirection: 'row',
+      gap: vars.spacing['2xl'],
+    },
+  },
+});
+
+export const platformSidebar = style({
+  display: 'none',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '220px',
+      flexShrink: 0,
+      gap: vars.spacing.xs,
+    },
+  },
+});
+
+export const platformSidebarItem = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: vars.spacing.lg,
+    width: '100%',
+    padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
+    borderRadius: vars.radius.lg,
+    border: 'none',
+    background: 'transparent',
+    textAlign: 'left',
+    cursor: 'pointer',
+    transition: 'background-color 150ms',
+    ':hover': {
+      background: vars.color.bgElevated,
+    },
+  },
+  variants: {
+    active: {
+      true: {
+        background: vars.color.bgElevated,
+        boxShadow: `inset 3px 0 0 ${vars.color.accent}`,
+      },
+    },
+  },
+  defaultVariants: { active: false },
+});
+
+export const sidebarItemIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  flexShrink: 0,
+});
+
+export const sidebarItemBody = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const sidebarItemName = style({
+  margin: 0,
+  fontSize: vars.fontSize.sm,
+  fontWeight: 500,
+  color: vars.color.text,
+});
+
+export const sidebarItemStatus = style({
+  margin: 0,
+  marginTop: '2px',
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textMuted,
+});
+
+export const platformDetail = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const platformDetailInner = style({
+  maxWidth: '560px',
+  padding: `${vars.spacing['2xl']} ${vars.spacing['2xl']}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['2xl'],
+});
+
+export const platformDetailHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.xl,
+});
+
+// Mobile platform tabs (horizontal, <1024px only)
+export const platformMobileTabs = style({
+  display: 'inline-flex',
+  alignSelf: 'flex-start',
+  maxWidth: '100%',
+  gap: vars.spacing['2xs'],
+  overflowX: 'auto',
+  padding: vars.spacing.xs,
+  borderRadius: vars.radius.full,
+  border: `1px solid ${vars.color.borderFaint}`,
+  background: vars.color.glassSurface,
+  backdropFilter: 'blur(16px) saturate(180%)',
+  WebkitBackdropFilter: 'blur(16px) saturate(180%)',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'none',
+    },
+  },
+  selectors: {
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+  },
+});
+
+export const platformMobileTab = recipe({
+  base: {
+    flexShrink: 0,
+    borderRadius: vars.radius.full,
+    border: 'none',
+    background: 'transparent',
+    padding: `${vars.spacing.md} ${vars.spacing.xl}`,
+    fontSize: vars.fontSize.sm,
+    fontWeight: 500,
+    color: vars.color.textMuted,
+    cursor: 'pointer',
+    transition: 'background-color 150ms, color 150ms',
+    ':hover': {
+      color: vars.color.text,
+      background: vars.color.bgElevated,
+    },
+  },
+  variants: {
+    active: {
+      true: {
+        background: vars.color.accent,
+        color: vars.color.surfaceDarkText,
+      },
+    },
+  },
+  defaultVariants: { active: false },
+});


### PR DESCRIPTION
## Changes

Refactored the platform connections section on the settings page from a single-column accordion layout to a two-column split-pane layout.

### Problem
- Accordion requires expanding/collapsing each platform individually — tedious
- Single-column full-width layout wastes horizontal space on desktop

### Solution
- Desktop (≥1024px): left sidebar list (220px) showing all platforms with status badges + right config panel
- Mobile (<1024px): horizontal pill tabs to switch platforms, panel below

### Files changed
- `src/app/settings/settings.css.ts` — new two-column layout styles
- `src/app/settings/page.tsx` — platforms section rewritten

### Verification
- `pnpm build` passes
- Desktop/mobile layouts switch correctly
- Platform config, connection checks, and save all work as before