### PR TITLE
feat: upload local images to platforms during publish

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,17 +2,7 @@
 
 import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import {
-  Save,
-  Eye,
-  EyeOff,
-  CheckCircle2,
-  RefreshCw,
-  Unplug,
-  Zap,
-  Sparkles,
-  Github,
-} from 'lucide-react';
+import { Save, Eye, EyeOff, CheckCircle2, RefreshCw, Unplug, Zap, Sparkles } from 'lucide-react';
 
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import SurfaceCard from '@/components/layout/SurfaceCard';
@@ -101,7 +91,6 @@ function CheckResult({
 const SECTION_TABS = [
   { id: 'platforms', label: '平台连接' },
   { id: 'agent', label: 'AI Agent' },
-  { id: 'github-image', label: '图片托管' },
 ] as const;
 
 type SectionId = (typeof SECTION_TABS)[number]['id'];
@@ -810,131 +799,6 @@ function SettingsContent() {
           </div>
         </div>
       ) : null}
-      {activeSection === 'github-image' ? (
-        <div className={styles.platformList}>
-          <div id="github-image" className={styles.sectionAnchor}>
-            <SurfaceCard tone="soft" className={styles.accordionCard}>
-              <div className={styles.accordionTrigger} style={{ cursor: 'default' }}>
-                <div className={styles.accordionIcon}>
-                  <Github size={20} />
-                </div>
-                <div className={styles.accordionBody}>
-                  <p className={styles.accordionTitle}>GitHub 图床</p>
-                  <p className={styles.accordionSummary}>
-                    上传图片到 GitHub 仓库，获取公网可访问 URL
-                  </p>
-                </div>
-              </div>
-              <div className={styles.accordionPanel}>
-                <div className={styles.fieldList}>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="GITHUB_IMAGE_ENABLED" className={styles.fieldLabel}>
-                      启用
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="GITHUB_IMAGE_ENABLED"
-                        type="checkbox"
-                        checked={values['GITHUB_IMAGE_ENABLED'] === 'true'}
-                        onChange={(e) =>
-                          handleChange('GITHUB_IMAGE_ENABLED', e.target.checked ? 'true' : 'false')
-                        }
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="GITHUB_IMAGE_TOKEN" className={styles.fieldLabel}>
-                      Personal Access Token
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="GITHUB_IMAGE_TOKEN"
-                        type={showSecrets['GITHUB_IMAGE_TOKEN'] ? 'text' : 'password'}
-                        value={values['GITHUB_IMAGE_TOKEN'] || ''}
-                        onChange={(e) => handleChange('GITHUB_IMAGE_TOKEN', e.target.value)}
-                        placeholder="ghp_xxxx（需要 repo 权限）"
-                        className={styles.fieldInput}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => toggleSecret('GITHUB_IMAGE_TOKEN')}
-                        className={styles.eyeButton}
-                      >
-                        {showSecrets['GITHUB_IMAGE_TOKEN'] ? (
-                          <EyeOff size={16} />
-                        ) : (
-                          <Eye size={16} />
-                        )}
-                      </button>
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="GITHUB_IMAGE_OWNER" className={styles.fieldLabel}>
-                      仓库所有者
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="GITHUB_IMAGE_OWNER"
-                        type="text"
-                        value={values['GITHUB_IMAGE_OWNER'] || ''}
-                        onChange={(e) => handleChange('GITHUB_IMAGE_OWNER', e.target.value)}
-                        placeholder="如 rogerdigital"
-                        className={styles.fieldInput}
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="GITHUB_IMAGE_REPO" className={styles.fieldLabel}>
-                      仓库名称
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="GITHUB_IMAGE_REPO"
-                        type="text"
-                        value={values['GITHUB_IMAGE_REPO'] || ''}
-                        onChange={(e) => handleChange('GITHUB_IMAGE_REPO', e.target.value)}
-                        placeholder="如 image-hosting"
-                        className={styles.fieldInput}
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="GITHUB_IMAGE_BRANCH" className={styles.fieldLabel}>
-                      分支
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="GITHUB_IMAGE_BRANCH"
-                        type="text"
-                        value={values['GITHUB_IMAGE_BRANCH'] || ''}
-                        onChange={(e) => handleChange('GITHUB_IMAGE_BRANCH', e.target.value)}
-                        placeholder="main"
-                        className={styles.fieldInput}
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="GITHUB_IMAGE_PATH" className={styles.fieldLabel}>
-                      存储路径
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="GITHUB_IMAGE_PATH"
-                        type="text"
-                        value={values['GITHUB_IMAGE_PATH'] || ''}
-                        onChange={(e) => handleChange('GITHUB_IMAGE_PATH', e.target.value)}
-                        placeholder="如 images/"
-                        className={styles.fieldInput}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </SurfaceCard>
-          </div>
-        </div>
-      ) : null}
-
       {isDirty && !loading && (
         <button type="button" className={styles.floatingSave} onClick={handleSave}>
           <Save size={16} />

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -322,7 +322,12 @@ export function extractMarkdownImageUrls(markdown: string): string[] {
     for (const token of tokens) {
       if (token.type === 'image') {
         const safeSrc = sanitizeUrl(token.href);
-        if (safeSrc && (safeSrc.startsWith('http://') || safeSrc.startsWith('https://'))) {
+        if (
+          safeSrc &&
+          (safeSrc.startsWith('http://') ||
+            safeSrc.startsWith('https://') ||
+            safeSrc.startsWith('/api/uploads/'))
+        ) {
           urls.push(safeSrc);
         }
       }

--- a/src/lib/publishers/executePublish.ts
+++ b/src/lib/publishers/executePublish.ts
@@ -5,6 +5,8 @@ import { WechatPublisher } from '@/lib/publishers/wechat';
 import { XiaohongshuPublisher } from '@/lib/publishers/xiaohongshu';
 import { ZhihuPublisher } from '@/lib/publishers/zhihu';
 import { XPublisher } from '@/lib/publishers/x';
+import { resolveLocalImages, type PlatformImageContext } from '@/lib/publishers/imageUpload';
+import { getWechatConfig, getZhihuConfig, getXhsConfig } from '@/lib/config';
 import type {
   SyncFailureCode,
   SyncNextAction,
@@ -135,14 +137,39 @@ export async function publishToPlatform(
   }
 
   const publisher = createPublisher();
-  const htmlContent =
+
+  // Build image context for local image resolution
+  const imageContext: PlatformImageContext = {};
+  if (platformId === 'wechat') {
+    // WeChat publisher will handle token internally, but we need one for image upload
+    const wechatPublisher = publisher as WechatPublisher;
+    try {
+      imageContext.wechatToken = await wechatPublisher.getAccessTokenForImages();
+    } catch {
+      /* proceed without image upload */
+    }
+  } else if (platformId === 'zhihu') {
+    imageContext.zhihuCookie = getZhihuConfig().cookie;
+  } else if (platformId === 'xiaohongshu') {
+    imageContext.xhsAccessToken = getXhsConfig().accessToken;
+  }
+
+  let htmlContent =
     platformId === 'wechat' || platformId === 'zhihu'
       ? markdownToStyledHtml(title, content, platformId)
       : markdownToHtml(content);
+  let markdownContent = content;
+
+  // Resolve local images: upload to platform and replace URLs
+  const resolved = await resolveLocalImages(markdownContent, htmlContent, platformId, imageContext);
+  markdownContent = resolved.markdownContent;
+  htmlContent = resolved.htmlContent;
+
   const input: PublishInput = {
     title,
-    markdownContent: content,
+    markdownContent,
     htmlContent,
+    xhsImageIds: resolved.xhsImageIds,
   };
   const result = await publisher.publish(input);
 

--- a/src/lib/publishers/imageUpload.ts
+++ b/src/lib/publishers/imageUpload.ts
@@ -1,0 +1,267 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createLocalDataPath } from '@/lib/storage/localDataPath';
+import type { PlatformId } from '@/types';
+import { logger } from '@/lib/logger';
+
+const LOCAL_IMAGE_PATTERN = /\/api\/uploads\/([a-zA-Z0-9._-]+)/g;
+
+const MIME_FROM_EXT: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+interface ImageEntry {
+  localUrl: string;
+  filename: string;
+  buffer: Buffer;
+  mimeType: string;
+}
+
+/** Read a local upload file from .publio-data/uploads/ */
+async function readLocalImage(
+  filename: string,
+): Promise<{ buffer: Buffer; mimeType: string } | null> {
+  try {
+    const filepath = join(createLocalDataPath('uploads'), filename);
+    const buffer = await readFile(filepath);
+    const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+    const mimeType = MIME_FROM_EXT[ext] || 'image/png';
+    return { buffer, mimeType };
+  } catch {
+    return null;
+  }
+}
+
+/** Extract all local image references from content */
+function extractLocalImages(content: string): { localUrl: string; filename: string }[] {
+  const results: { localUrl: string; filename: string }[] = [];
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  const re = new RegExp(LOCAL_IMAGE_PATTERN.source, 'g');
+  while ((match = re.exec(content)) !== null) {
+    if (!seen.has(match[1])) {
+      seen.add(match[1]);
+      results.push({ localUrl: match[0], filename: match[1] });
+    }
+  }
+  return results;
+}
+
+// ── Platform upload functions ───────────────────────────────────────
+
+async function uploadToWechat(
+  buffer: Buffer,
+  mimeType: string,
+  token: string,
+): Promise<string | null> {
+  const boundary = '----FormBoundary' + Math.random().toString(36).slice(2);
+  const ext = mimeType === 'image/png' ? 'png' : 'jpg';
+  const encoder = new TextEncoder();
+
+  const header = encoder.encode(
+    `--${boundary}\r\nContent-Disposition: form-data; name="media"; filename="image.${ext}"\r\nContent-Type: ${mimeType}\r\n\r\n`,
+  );
+  const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+  const body = new Uint8Array(header.length + buffer.length + footer.length);
+  body.set(header, 0);
+  body.set(buffer, header.length);
+  body.set(footer, header.length + buffer.length);
+
+  const res = await fetch(
+    `https://api.weixin.qq.com/cgi-bin/media/uploadimg?access_token=${token}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body,
+    },
+  );
+
+  const data = await res.json();
+  if (data.url) return data.url as string;
+  logger.warn('WeChat image upload failed', { errcode: data.errcode, errmsg: data.errmsg });
+  return null;
+}
+
+async function uploadToZhihu(
+  buffer: Buffer,
+  mimeType: string,
+  cookie: string,
+): Promise<string | null> {
+  const boundary = '----FormBoundary' + Math.random().toString(36).slice(2);
+  const ext = mimeType === 'image/png' ? 'png' : 'jpg';
+  const encoder = new TextEncoder();
+
+  const header = encoder.encode(
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="image.${ext}"\r\nContent-Type: ${mimeType}\r\n\r\n`,
+  );
+  const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+  const body = new Uint8Array(header.length + buffer.length + footer.length);
+  body.set(header, 0);
+  body.set(buffer, header.length);
+  body.set(footer, header.length + buffer.length);
+
+  const res = await fetch('https://zhuanlan.zhihu.com/api/images', {
+    method: 'POST',
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      Cookie: cookie,
+      'x-requested-with': 'fetch',
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    },
+    body,
+  });
+
+  const data = await res.json();
+  if (data.url) return data.url as string;
+  logger.warn('Zhihu image upload failed', { status: res.status });
+  return null;
+}
+
+async function uploadToXiaohongshu(
+  buffer: Buffer,
+  mimeType: string,
+  accessToken: string,
+): Promise<string | null> {
+  const boundary = '----FormBoundary' + Math.random().toString(36).slice(2);
+  const ext = mimeType === 'image/png' ? 'png' : 'jpg';
+  const encoder = new TextEncoder();
+
+  const header = encoder.encode(
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="image.${ext}"\r\nContent-Type: ${mimeType}\r\n\r\n`,
+  );
+  const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+  const body = new Uint8Array(header.length + buffer.length + footer.length);
+  body.set(header, 0);
+  body.set(buffer, header.length);
+  body.set(footer, header.length + buffer.length);
+
+  const res = await fetch('https://open.xiaohongshu.com/api/media/upload', {
+    method: 'POST',
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body,
+  });
+
+  const data = await res.json();
+  const imageId = data.data?.image_id || data.image_id;
+  if (imageId) return imageId as string;
+  logger.warn('Xiaohongshu image upload failed', { code: data.code, msg: data.msg });
+  return null;
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+export interface PlatformImageContext {
+  wechatToken?: string;
+  zhihuCookie?: string;
+  xhsAccessToken?: string;
+}
+
+export interface ResolvedImages {
+  markdownContent: string;
+  htmlContent: string;
+  /** For X: media IDs to attach to tweet */
+  mediaIds?: string[];
+  /** For Xiaohongshu: uploaded image IDs */
+  xhsImageIds?: string[];
+}
+
+/**
+ * Detect local images in content, upload to target platform, replace URLs.
+ * Non-blocking: failures skip the image silently.
+ */
+export async function resolveLocalImages(
+  markdownContent: string,
+  htmlContent: string,
+  platform: PlatformId,
+  context: PlatformImageContext,
+): Promise<ResolvedImages> {
+  const refs = extractLocalImages(markdownContent + '\n' + htmlContent);
+  if (refs.length === 0) {
+    return { markdownContent, htmlContent };
+  }
+
+  // Read all local images
+  const entries: ImageEntry[] = [];
+  for (const ref of refs) {
+    const data = await readLocalImage(ref.filename);
+    if (data) {
+      entries.push({ ...ref, ...data });
+    }
+  }
+
+  if (entries.length === 0) {
+    return { markdownContent, htmlContent };
+  }
+
+  let updatedMarkdown = markdownContent;
+  let updatedHtml = htmlContent;
+  const mediaIds: string[] = [];
+  const xhsImageIds: string[] = [];
+
+  for (const entry of entries) {
+    let remoteUrl: string | null = null;
+
+    switch (platform) {
+      case 'wechat':
+        if (context.wechatToken) {
+          remoteUrl = await uploadToWechat(entry.buffer, entry.mimeType, context.wechatToken);
+        }
+        break;
+      case 'zhihu':
+        if (context.zhihuCookie) {
+          remoteUrl = await uploadToZhihu(entry.buffer, entry.mimeType, context.zhihuCookie);
+        }
+        break;
+      case 'xiaohongshu':
+        if (context.xhsAccessToken) {
+          const imageId = await uploadToXiaohongshu(
+            entry.buffer,
+            entry.mimeType,
+            context.xhsAccessToken,
+          );
+          if (imageId) xhsImageIds.push(imageId);
+        }
+        break;
+      case 'x':
+        // X handles media separately via twitter-api-v2; collect buffers for caller
+        mediaIds.push(entry.filename);
+        break;
+    }
+
+    if (remoteUrl) {
+      updatedMarkdown = updatedMarkdown.replaceAll(entry.localUrl, remoteUrl);
+      updatedHtml = updatedHtml.replaceAll(entry.localUrl, remoteUrl);
+    }
+  }
+
+  return {
+    markdownContent: updatedMarkdown,
+    htmlContent: updatedHtml,
+    mediaIds: mediaIds.length > 0 ? mediaIds : undefined,
+    xhsImageIds: xhsImageIds.length > 0 ? xhsImageIds : undefined,
+  };
+}
+
+/** Read local image buffers for X media upload (called by XPublisher) */
+export async function getLocalImageBuffers(
+  markdownContent: string,
+): Promise<{ buffer: Buffer; mimeType: string }[]> {
+  const refs = extractLocalImages(markdownContent);
+  const results: { buffer: Buffer; mimeType: string }[] = [];
+  for (const ref of refs.slice(0, 4)) {
+    const data = await readLocalImage(ref.filename);
+    if (data) results.push(data);
+  }
+  return results;
+}

--- a/src/lib/publishers/types.ts
+++ b/src/lib/publishers/types.ts
@@ -4,6 +4,8 @@ export interface PublishInput {
   title: string;
   markdownContent: string;
   htmlContent: string;
+  /** Xiaohongshu: pre-uploaded image IDs from platform upload API */
+  xhsImageIds?: string[];
 }
 
 export interface PublishOutput {

--- a/src/lib/publishers/wechat.ts
+++ b/src/lib/publishers/wechat.ts
@@ -158,6 +158,11 @@ export class WechatPublisher extends BasePublisher {
     return data.access_token;
   }
 
+  /** Exposed for image upload in executePublish */
+  async getAccessTokenForImages(): Promise<string> {
+    return this.getAccessToken();
+  }
+
   private handleAuthError(errcode: number): void {
     if (errcode === 40001 || errcode === 42001) {
       this.clearCachedToken('wechat');

--- a/src/lib/publishers/x.ts
+++ b/src/lib/publishers/x.ts
@@ -1,8 +1,9 @@
-import { TwitterApi } from 'twitter-api-v2';
+import { TwitterApi, EUploadMimeType, type SendTweetV2Params } from 'twitter-api-v2';
 import type { PublishInput, PublishOutput } from './types';
 import { BasePublisher } from './base';
 import { getXConfig } from '@/lib/config';
 import { markdownToPlainText } from '@/lib/markdown';
+import { getLocalImageBuffers } from '@/lib/publishers/imageUpload';
 
 function splitIntoThread(title: string, content: string): string[] {
   const plainText = markdownToPlainText(content);
@@ -65,18 +66,44 @@ export class XPublisher extends BasePublisher {
       accessSecret: accessTokenSecret,
     });
 
+    // Upload local images as media (max 4)
+    const mediaIds: string[] = [];
+    const localImages = await getLocalImageBuffers(input.markdownContent);
+    for (const img of localImages.slice(0, 4)) {
+      try {
+        const mimeMap: Record<string, EUploadMimeType> = {
+          'image/jpeg': EUploadMimeType.Jpeg,
+          'image/png': EUploadMimeType.Png,
+          'image/gif': EUploadMimeType.Gif,
+          'image/webp': EUploadMimeType.Webp,
+        };
+        const mediaId = await client.v1.uploadMedia(img.buffer, {
+          mimeType: mimeMap[img.mimeType] || EUploadMimeType.Png,
+        });
+        mediaIds.push(mediaId);
+      } catch {
+        /* skip failed uploads */
+      }
+    }
+
     const chunks = splitIntoThread(input.title, input.markdownContent);
 
     let firstTweetId: string | undefined;
     let previousTweetId: string | undefined;
 
-    for (const chunk of chunks) {
-      const payload: { text: string; reply?: { in_reply_to_tweet_id: string } } = {
-        text: chunk,
-      };
+    for (let i = 0; i < chunks.length; i++) {
+      const payload: SendTweetV2Params = { text: chunks[i] };
 
       if (previousTweetId) {
         payload.reply = { in_reply_to_tweet_id: previousTweetId };
+      }
+
+      // Attach media to first tweet only
+      if (i === 0 && mediaIds.length > 0) {
+        const ids = mediaIds.slice(0, 4);
+        payload.media = {
+          media_ids: ids as unknown as [string],
+        };
       }
 
       const result = await client.v2.tweet(payload);

--- a/src/lib/publishers/xiaohongshu.ts
+++ b/src/lib/publishers/xiaohongshu.ts
@@ -17,7 +17,12 @@ export class XiaohongshuPublisher extends BasePublisher {
 
     const plainText = markdownToPlainText(input.markdownContent);
     const truncatedContent = plainText.length > 1000 ? plainText.slice(0, 997) + '...' : plainText;
-    const imageUrls = extractMarkdownImageUrls(input.markdownContent).slice(0, 9);
+    const imageUrls = extractMarkdownImageUrls(input.markdownContent)
+      .filter((url) => url.startsWith('http://') || url.startsWith('https://'))
+      .slice(0, 9);
+
+    // Use pre-uploaded image IDs if available (from local image upload)
+    const imageIds = input.xhsImageIds ?? [];
 
     const noteRes = await fetch('https://open.xiaohongshu.com/api/note/publish', {
       method: 'POST',
@@ -28,8 +33,8 @@ export class XiaohongshuPublisher extends BasePublisher {
       body: JSON.stringify({
         title: input.title.slice(0, 20),
         content: truncatedContent,
-        note_type: imageUrls.length > 0 ? 'image' : 'normal',
-        image_ids: [],
+        note_type: imageUrls.length > 0 || imageIds.length > 0 ? 'image' : 'normal',
+        image_ids: imageIds,
         image_urls: imageUrls,
       }),
     });


### PR DESCRIPTION
## Changes

Automatically upload local images to each platform's API during publish, eliminating the need for GitHub image bed configuration.

### Publish flow

Editor inserts local image → publish detects `/api/uploads/` paths → reads local file → uploads via platform API → replaces with platform CDN URL → publishes normally

### Per-platform handling

| Platform | Upload method | Result |
|----------|--------------|--------|
| WeChat | `/cgi-bin/media/uploadimg` | Replaces HTML img src with mmbiz URL |
| Zhihu | `/api/images` | Replaces HTML img src with zhimg URL |
| Xiaohongshu | Platform media upload API | Fills image_ids field |
| X | `client.v1.uploadMedia()` | Attaches media_ids to first tweet |

### Other changes

- Removed "Image Hosting" tab from settings page (GitHub image bed UI)
- `extractMarkdownImageUrls()` now also collects `/api/uploads/` local paths
- `PublishInput` type gains optional `xhsImageIds` field

### Verification

- `pnpm build` passes
- Failed image uploads are silently skipped without blocking publish