### PR TITLE
refactor: unify settings page to sidebar + detail layout

### DIFF
--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
 export const metadata: Metadata = {
-  title: '平台设置 — Publio',
+  title: '设置 — Publio',
 };
 
 export default function SettingsLayout({ children }: { children: ReactNode }) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,17 @@
 
 import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { Save, Eye, EyeOff, CheckCircle2, RefreshCw, Unplug, Zap, Sparkles } from 'lucide-react';
+import {
+  Save,
+  Eye,
+  EyeOff,
+  CheckCircle2,
+  RefreshCw,
+  Unplug,
+  Zap,
+  Bot,
+  Sparkles,
+} from 'lucide-react';
 
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import SurfaceCard from '@/components/layout/SurfaceCard';
@@ -88,13 +98,6 @@ function CheckResult({
   return null;
 }
 
-const SECTION_TABS = [
-  { id: 'platforms', label: '平台连接' },
-  { id: 'agent', label: 'AI Agent' },
-] as const;
-
-type SectionId = (typeof SECTION_TABS)[number]['id'];
-
 function SettingsContent() {
   const searchParams = useSearchParams();
   const cachedData = getCachedSettingsPageData();
@@ -104,7 +107,7 @@ function SettingsContent() {
   );
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   const [saved, setSaved] = useState(false);
-  const [selectedPlatform, setSelectedPlatform] = useState<string>(platformConfigs[0].id);
+  const [selectedItem, setSelectedItem] = useState<string>(platformConfigs[0].id);
   const [errorMessage, setErrorMessage] = useState('');
   const [noticeMessage, setNoticeMessage] = useState('');
   const [loading, setLoading] = useState(!cachedData);
@@ -113,7 +116,6 @@ function SettingsContent() {
   const [connectionRecords, setConnectionRecords] = useState<
     Record<PlatformId, PlatformConnectionRecord>
   >(() => cachedData?.connectionRecords ?? ({} as Record<PlatformId, PlatformConnectionRecord>));
-  const [activeSection, setActiveSection] = useState<SectionId>('platforms');
   const [agentTestResult, setAgentTestResult] = useState<{ ok: boolean; message: string } | null>(
     null,
   );
@@ -127,7 +129,7 @@ function SettingsContent() {
     if (connected) {
       const platformName = platformConfigs.find((p) => p.id === connected)?.name ?? connected;
       setNoticeMessage(`${platformName} 授权成功，连接已建立。`);
-      setSelectedPlatform(connected);
+      setSelectedItem(connected);
     } else if (error) {
       setErrorMessage(`授权失败：${decodeURIComponent(error)}`);
     }
@@ -317,12 +319,19 @@ function SettingsContent() {
     }
   }
 
+  const isPlatformSelected = platformConfigs.some((p) => p.id === selectedItem);
+  const agentConfigured = !!(
+    values['AGENT_BASE_URL'] &&
+    values['AGENT_API_KEY'] &&
+    values['AGENT_MODEL']
+  );
+
   return (
     <div className={styles.pageWrap}>
       <AppShellHeader
         kicker="Operational control"
-        title="平台设置"
-        description="统一管理各平台 API 凭证与登录态。"
+        title="设置"
+        description="管理发布平台凭证与 AI 助手配置。"
         action={
           <div className={styles.saveActions}>
             <button
@@ -348,256 +357,152 @@ function SettingsContent() {
         }
       />
 
-      <nav className={styles.sectionNav}>
-        {SECTION_TABS.map((tab) => (
+      {/* Mobile: horizontal pill tabs */}
+      <nav className={styles.platformMobileTabs}>
+        {platformConfigs.map((platform) => (
           <button
-            key={tab.id}
+            key={platform.id}
             type="button"
-            className={styles.sectionTab({ active: activeSection === tab.id })}
-            onClick={() => setActiveSection(tab.id)}
+            className={styles.platformMobileTab({ active: selectedItem === platform.id })}
+            onClick={() => setSelectedItem(platform.id)}
           >
-            {tab.label}
+            {platform.name}
           </button>
         ))}
+        <button
+          type="button"
+          className={styles.platformMobileTab({ active: selectedItem === 'agent-config' })}
+          onClick={() => setSelectedItem('agent-config')}
+        >
+          AI 配置
+        </button>
+        <button
+          type="button"
+          className={styles.platformMobileTab({ active: selectedItem === 'agent-prompt' })}
+          onClick={() => setSelectedItem('agent-prompt')}
+        >
+          Prompt
+        </button>
       </nav>
 
-      {activeSection === 'platforms' ? (
-        <div id="platforms" className={styles.sectionAnchor}>
-          {/* Mobile: horizontal pill tabs */}
-          <nav className={styles.platformMobileTabs}>
-            {platformConfigs.map((platform) => (
+      <div className={styles.platformLayout}>
+        {/* Desktop: sidebar */}
+        <nav className={styles.platformSidebar}>
+          {platformConfigs.map((platform) => {
+            const { Icon } = platform;
+            const connectionProfile = connectionProfiles.find((p) => p.platform === platform.id);
+            return (
               <button
                 key={platform.id}
                 type="button"
-                className={styles.platformMobileTab({ active: selectedPlatform === platform.id })}
-                onClick={() => setSelectedPlatform(platform.id)}
+                className={styles.platformSidebarItem({
+                  active: selectedItem === platform.id,
+                })}
+                onClick={() => setSelectedItem(platform.id)}
               >
-                {platform.name}
+                <span className={styles.sidebarItemIcon}>
+                  <Icon size={18} />
+                </span>
+                <span className={styles.sidebarItemBody}>
+                  <p className={styles.sidebarItemName}>{platform.name}</p>
+                  <p className={styles.sidebarItemStatus}>
+                    {connectionProfile ? statusLabels[connectionProfile.status] : '未配置'}
+                  </p>
+                </span>
               </button>
-            ))}
-          </nav>
+            );
+          })}
+          <div className={styles.sidebarDivider}>AI 助手</div>
+          <button
+            type="button"
+            className={styles.platformSidebarItem({ active: selectedItem === 'agent-config' })}
+            onClick={() => setSelectedItem('agent-config')}
+          >
+            <span className={styles.sidebarItemIcon}>
+              <Bot size={18} />
+            </span>
+            <span className={styles.sidebarItemBody}>
+              <p className={styles.sidebarItemName}>连接配置</p>
+              <p className={styles.sidebarItemStatus}>{agentConfigured ? '已配置' : '未配置'}</p>
+            </span>
+          </button>
+          <button
+            type="button"
+            className={styles.platformSidebarItem({ active: selectedItem === 'agent-prompt' })}
+            onClick={() => setSelectedItem('agent-prompt')}
+          >
+            <span className={styles.sidebarItemIcon}>
+              <Sparkles size={18} />
+            </span>
+            <span className={styles.sidebarItemBody}>
+              <p className={styles.sidebarItemName}>Prompt 设置</p>
+              <p className={styles.sidebarItemStatus}>自定义提示词</p>
+            </span>
+          </button>
+        </nav>
 
-          <div className={styles.platformLayout}>
-            {/* Desktop: sidebar list */}
-            <nav className={styles.platformSidebar}>
-              {platformConfigs.map((platform) => {
-                const { Icon } = platform;
-                const connectionProfile = connectionProfiles.find(
-                  (p) => p.platform === platform.id,
-                );
-                return (
-                  <button
-                    key={platform.id}
-                    type="button"
-                    className={styles.platformSidebarItem({
-                      active: selectedPlatform === platform.id,
-                    })}
-                    onClick={() => setSelectedPlatform(platform.id)}
-                  >
-                    <span className={styles.sidebarItemIcon}>
-                      <Icon size={18} />
-                    </span>
-                    <span className={styles.sidebarItemBody}>
-                      <p className={styles.sidebarItemName}>{platform.name}</p>
-                      <p className={styles.sidebarItemStatus}>
-                        {connectionProfile ? statusLabels[connectionProfile.status] : '未配置'}
-                      </p>
-                    </span>
-                  </button>
-                );
-              })}
-            </nav>
+        {/* Detail panel */}
+        <div className={styles.platformDetail}>
+          {isPlatformSelected ? (
+            <SurfaceCard tone="soft">
+              <div className={styles.platformDetailInner}>
+                {(() => {
+                  const platform = platformConfigs.find((p) => p.id === selectedItem)!;
+                  const { Icon } = platform;
+                  const connectionProfile = connectionProfiles.find(
+                    (p) => p.platform === platform.id,
+                  );
+                  const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
+                  const record = connectionRecords[platform.id];
+                  const connectedAccountName =
+                    (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
+                    (!checkStates[platform.id] && record?.accountName) ||
+                    null;
+                  const isConnected =
+                    connectionProfile?.status === 'connected' &&
+                    !disconnectStates[platform.id]?.done;
 
-            {/* Detail panel */}
-            <div className={styles.platformDetail}>
-              <SurfaceCard tone="soft">
-                <div className={styles.platformDetailInner}>
-                  {(() => {
-                    const platform = platformConfigs.find((p) => p.id === selectedPlatform)!;
-                    const { Icon } = platform;
-                    const connectionProfile = connectionProfiles.find(
-                      (p) => p.platform === platform.id,
-                    );
-                    const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
-                    const record = connectionRecords[platform.id];
-                    const connectedAccountName =
-                      (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
-                      (!checkStates[platform.id] && record?.accountName) ||
-                      null;
-                    const isConnected =
-                      connectionProfile?.status === 'connected' &&
-                      !disconnectStates[platform.id]?.done;
-
-                    return (
-                      <>
-                        <div className={styles.platformDetailHeader}>
-                          <span className={styles.accordionIcon}>
-                            <Icon size={22} />
-                          </span>
-                          <div>
-                            <p className={styles.accordionTitle}>{platform.name}</p>
-                            {isConnected && connectedAccountName ? (
-                              <p className={styles.accordionAccountName}>
-                                <CheckCircle2 size={11} />
-                                {connectedAccountName}
-                              </p>
-                            ) : (
-                              <p className={styles.accordionSummary}>{platform.summary}</p>
-                            )}
-                          </div>
-                          {connectionProfile ? (
-                            <span
-                              className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
-                            >
-                              {statusLabels[connectionProfile.status]}
-                            </span>
-                          ) : null}
+                  return (
+                    <>
+                      <div className={styles.platformDetailHeader}>
+                        <span className={styles.accordionIcon}>
+                          <Icon size={22} />
+                        </span>
+                        <div>
+                          <p className={styles.accordionTitle}>{platform.name}</p>
+                          {isConnected && connectedAccountName ? (
+                            <p className={styles.accordionAccountName}>
+                              <CheckCircle2 size={11} />
+                              {connectedAccountName}
+                            </p>
+                          ) : (
+                            <p className={styles.accordionSummary}>{platform.summary}</p>
+                          )}
                         </div>
+                        {connectionProfile ? (
+                          <span
+                            className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
+                          >
+                            {statusLabels[connectionProfile.status]}
+                          </span>
+                        ) : null}
+                      </div>
 
-                        {connectionProfile?.mode === 'oauth' ? (
-                          <div className={styles.oauthSteps}>
-                            <div className={styles.oauthStep}>
-                              <div className={styles.oauthStepHeader}>
-                                <span
-                                  className={
-                                    connectionProfile.status === 'connected'
-                                      ? styles.oauthStepBadgeActive
-                                      : styles.oauthStepBadge
-                                  }
-                                >
-                                  1
-                                </span>
-                                <p className={styles.oauthStepTitle}>填写开发者凭证</p>
-                              </div>
-                              <div className={styles.fieldList}>
-                                {platform.fields.map((field) => (
-                                  <div key={field.key} className={styles.fieldWrap}>
-                                    <label htmlFor={field.key} className={styles.fieldLabel}>
-                                      {field.label}
-                                    </label>
-                                    <div className={styles.fieldInputWrap}>
-                                      <input
-                                        id={field.key}
-                                        type={
-                                          field.type === 'password' && !showSecrets[field.key]
-                                            ? 'password'
-                                            : 'text'
-                                        }
-                                        value={values[field.key] || ''}
-                                        onChange={(event) =>
-                                          handleChange(field.key, event.target.value)
-                                        }
-                                        placeholder={field.placeholder}
-                                        className={styles.fieldInput}
-                                      />
-                                      {field.type === 'password' ? (
-                                        <button
-                                          type="button"
-                                          onClick={() => toggleSecret(field.key)}
-                                          aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
-                                          className={styles.eyeButton}
-                                        >
-                                          {showSecrets[field.key] ? (
-                                            <EyeOff size={16} />
-                                          ) : (
-                                            <Eye size={16} />
-                                          )}
-                                        </button>
-                                      ) : null}
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                              <p className={styles.fieldHint}>{platform.hint}</p>
+                      {connectionProfile?.mode === 'oauth' ? (
+                        <div className={styles.oauthSteps}>
+                          <div className={styles.oauthStep}>
+                            <div className={styles.oauthStepHeader}>
+                              <span
+                                className={
+                                  connectionProfile.status === 'connected'
+                                    ? styles.oauthStepBadgeActive
+                                    : styles.oauthStepBadge
+                                }
+                              >
+                                1
+                              </span>
+                              <p className={styles.oauthStepTitle}>填写开发者凭证</p>
                             </div>
-
-                            <div className={styles.oauthStep}>
-                              <div className={styles.oauthStepHeader}>
-                                <span
-                                  className={
-                                    connectionProfile.status === 'connected'
-                                      ? styles.oauthStepBadgeActive
-                                      : styles.oauthStepBadge
-                                  }
-                                >
-                                  2
-                                </span>
-                                <p className={styles.oauthStepTitle}>
-                                  {isVerifyOnly ? '验证连接' : '账号授权'}
-                                </p>
-                              </div>
-                              <p className={styles.oauthStepDesc}>
-                                {isVerifyOnly
-                                  ? connectionProfile.status === 'connected'
-                                    ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
-                                    : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
-                                  : connectionProfile.status === 'connected'
-                                    ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
-                                    : connectionProfile.missingKeys.length > 0
-                                      ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
-                                      : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
-                              </p>
-                              <CheckResult
-                                checkState={checkStates[platform.id]}
-                                connectionRecord={connectionRecords[platform.id]}
-                                disconnectDone={disconnectStates[platform.id]?.done}
-                              />
-                              <div className={styles.oauthAuthorizeRow}>
-                                <button
-                                  type="button"
-                                  className={styles.authorizeButton}
-                                  disabled={
-                                    connectionProfile.missingKeys.length > 0 ||
-                                    checkStates[platform.id]?.checking
-                                  }
-                                  onClick={() =>
-                                    void handleConnectionAction(
-                                      platform.id,
-                                      platform.name,
-                                      connectionProfile.mode,
-                                    )
-                                  }
-                                >
-                                  {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
-                                  {checkStates[platform.id]?.checking
-                                    ? '验证中…'
-                                    : isVerifyOnly
-                                      ? connectionProfile.status === 'connected'
-                                        ? '重新验证'
-                                        : '验证连接'
-                                      : connectionProfile.status === 'connected'
-                                        ? '重新授权'
-                                        : '一键授权'}
-                                </button>
-                                {connectionProfile.status === 'connected' && !isVerifyOnly ? (
-                                  <>
-                                    <button
-                                      type="button"
-                                      className={styles.checkButton}
-                                      disabled={checkStates[platform.id]?.checking}
-                                      onClick={() => void handleCheckConnection(platform.id)}
-                                    >
-                                      <RefreshCw size={13} />
-                                      {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
-                                    </button>
-                                    <button
-                                      type="button"
-                                      className={styles.disconnectButton}
-                                      disabled={disconnectStates[platform.id]?.disconnecting}
-                                      onClick={() => void handleDisconnect(platform.id)}
-                                    >
-                                      <Unplug size={13} />
-                                      {disconnectStates[platform.id]?.disconnecting
-                                        ? '处理中…'
-                                        : '断开连接'}
-                                    </button>
-                                  </>
-                                ) : null}
-                              </div>
-                            </div>
-                          </div>
-                        ) : (
-                          <>
                             <div className={styles.fieldList}>
                               {platform.fields.map((field) => (
                                 <div key={field.key} className={styles.fieldWrap}>
@@ -605,33 +510,20 @@ function SettingsContent() {
                                     {field.label}
                                   </label>
                                   <div className={styles.fieldInputWrap}>
-                                    {field.type === 'textarea' ? (
-                                      <textarea
-                                        id={field.key}
-                                        value={values[field.key] || ''}
-                                        onChange={(event) =>
-                                          handleChange(field.key, event.target.value)
-                                        }
-                                        placeholder={field.placeholder}
-                                        rows={4}
-                                        className={styles.fieldTextarea}
-                                      />
-                                    ) : (
-                                      <input
-                                        id={field.key}
-                                        type={
-                                          field.type === 'password' && !showSecrets[field.key]
-                                            ? 'password'
-                                            : 'text'
-                                        }
-                                        value={values[field.key] || ''}
-                                        onChange={(event) =>
-                                          handleChange(field.key, event.target.value)
-                                        }
-                                        placeholder={field.placeholder}
-                                        className={styles.fieldInput}
-                                      />
-                                    )}
+                                    <input
+                                      id={field.key}
+                                      type={
+                                        field.type === 'password' && !showSecrets[field.key]
+                                          ? 'password'
+                                          : 'text'
+                                      }
+                                      value={values[field.key] || ''}
+                                      onChange={(event) =>
+                                        handleChange(field.key, event.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      className={styles.fieldInput}
+                                    />
                                     {field.type === 'password' ? (
                                       <button
                                         type="button"
@@ -651,52 +543,185 @@ function SettingsContent() {
                               ))}
                             </div>
                             <p className={styles.fieldHint}>{platform.hint}</p>
-                            <div className={styles.oauthAuthorizeRow}>
-                              <button
-                                type="button"
-                                className={styles.checkButton}
-                                disabled={
-                                  checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']
+                          </div>
+
+                          <div className={styles.oauthStep}>
+                            <div className={styles.oauthStepHeader}>
+                              <span
+                                className={
+                                  connectionProfile.status === 'connected'
+                                    ? styles.oauthStepBadgeActive
+                                    : styles.oauthStepBadge
                                 }
-                                onClick={() => void handleCheckConnection(platform.id)}
                               >
-                                <RefreshCw size={13} />
-                                {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
-                              </button>
+                                2
+                              </span>
+                              <p className={styles.oauthStepTitle}>
+                                {isVerifyOnly ? '验证连接' : '账号授权'}
+                              </p>
                             </div>
+                            <p className={styles.oauthStepDesc}>
+                              {isVerifyOnly
+                                ? connectionProfile.status === 'connected'
+                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
+                                  : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
+                                : connectionProfile.status === 'connected'
+                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
+                                  : connectionProfile.missingKeys.length > 0
+                                    ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
+                                    : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
+                            </p>
                             <CheckResult
                               checkState={checkStates[platform.id]}
                               connectionRecord={connectionRecords[platform.id]}
                               disconnectDone={disconnectStates[platform.id]?.done}
                             />
-                          </>
-                        )}
-                      </>
-                    );
-                  })()}
-                </div>
-              </SurfaceCard>
-            </div>
-          </div>
-        </div>
-      ) : null}
-      {activeSection === 'agent' ? (
-        <div className={styles.platformList}>
-          <div id="agent" className={styles.sectionAnchor}>
-            <SurfaceCard tone="soft" className={styles.accordionCard}>
-              <div className={styles.accordionTrigger} style={{ cursor: 'default' }}>
-                <div className={styles.accordionIcon}>
-                  <Sparkles size={20} />
-                </div>
-                <div className={styles.accordionBody}>
-                  <p className={styles.accordionTitle}>AI 助手（Agent）</p>
-                  <p className={styles.accordionSummary}>
-                    配置 LLM 接口，启用 AI 改写、标题建议和平台适配
-                  </p>
-                </div>
+                            <div className={styles.oauthAuthorizeRow}>
+                              <button
+                                type="button"
+                                className={styles.authorizeButton}
+                                disabled={
+                                  connectionProfile.missingKeys.length > 0 ||
+                                  checkStates[platform.id]?.checking
+                                }
+                                onClick={() =>
+                                  void handleConnectionAction(
+                                    platform.id,
+                                    platform.name,
+                                    connectionProfile.mode,
+                                  )
+                                }
+                              >
+                                {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
+                                {checkStates[platform.id]?.checking
+                                  ? '验证中…'
+                                  : isVerifyOnly
+                                    ? connectionProfile.status === 'connected'
+                                      ? '重新验证'
+                                      : '验证连接'
+                                    : connectionProfile.status === 'connected'
+                                      ? '重新授权'
+                                      : '一键授权'}
+                              </button>
+                              {connectionProfile.status === 'connected' && !isVerifyOnly ? (
+                                <>
+                                  <button
+                                    type="button"
+                                    className={styles.checkButton}
+                                    disabled={checkStates[platform.id]?.checking}
+                                    onClick={() => void handleCheckConnection(platform.id)}
+                                  >
+                                    <RefreshCw size={13} />
+                                    {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className={styles.disconnectButton}
+                                    disabled={disconnectStates[platform.id]?.disconnecting}
+                                    onClick={() => void handleDisconnect(platform.id)}
+                                  >
+                                    <Unplug size={13} />
+                                    {disconnectStates[platform.id]?.disconnecting
+                                      ? '处理中…'
+                                      : '断开连接'}
+                                  </button>
+                                </>
+                              ) : null}
+                            </div>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
+                          <div className={styles.fieldList}>
+                            {platform.fields.map((field) => (
+                              <div key={field.key} className={styles.fieldWrap}>
+                                <label htmlFor={field.key} className={styles.fieldLabel}>
+                                  {field.label}
+                                </label>
+                                <div className={styles.fieldInputWrap}>
+                                  {field.type === 'textarea' ? (
+                                    <textarea
+                                      id={field.key}
+                                      value={values[field.key] || ''}
+                                      onChange={(event) =>
+                                        handleChange(field.key, event.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      rows={4}
+                                      className={styles.fieldTextarea}
+                                    />
+                                  ) : (
+                                    <input
+                                      id={field.key}
+                                      type={
+                                        field.type === 'password' && !showSecrets[field.key]
+                                          ? 'password'
+                                          : 'text'
+                                      }
+                                      value={values[field.key] || ''}
+                                      onChange={(event) =>
+                                        handleChange(field.key, event.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      className={styles.fieldInput}
+                                    />
+                                  )}
+                                  {field.type === 'password' ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => toggleSecret(field.key)}
+                                      aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
+                                      className={styles.eyeButton}
+                                    >
+                                      {showSecrets[field.key] ? (
+                                        <EyeOff size={16} />
+                                      ) : (
+                                        <Eye size={16} />
+                                      )}
+                                    </button>
+                                  ) : null}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                          <p className={styles.fieldHint}>{platform.hint}</p>
+                          <div className={styles.oauthAuthorizeRow}>
+                            <button
+                              type="button"
+                              className={styles.checkButton}
+                              disabled={
+                                checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']
+                              }
+                              onClick={() => void handleCheckConnection(platform.id)}
+                            >
+                              <RefreshCw size={13} />
+                              {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
+                            </button>
+                          </div>
+                          <CheckResult
+                            checkState={checkStates[platform.id]}
+                            connectionRecord={connectionRecords[platform.id]}
+                            disconnectDone={disconnectStates[platform.id]?.done}
+                          />
+                        </>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
-
-              <div className={styles.accordionPanel}>
+            </SurfaceCard>
+          ) : selectedItem === 'agent-config' ? (
+            <SurfaceCard tone="soft">
+              <div className={styles.platformDetailInner}>
+                <div className={styles.platformDetailHeader}>
+                  <span className={styles.accordionIcon}>
+                    <Bot size={22} />
+                  </span>
+                  <div>
+                    <p className={styles.accordionTitle}>AI 连接配置</p>
+                    <p className={styles.accordionSummary}>配置 LLM 接口，启用写作辅助与平台适配</p>
+                  </div>
+                </div>
                 <div className={styles.fieldList}>
                   <div className={styles.fieldWrap}>
                     <label htmlFor="AGENT_BASE_URL" className={styles.fieldLabel}>
@@ -780,25 +805,25 @@ function SettingsContent() {
                 </div>
               </div>
             </SurfaceCard>
-            <SurfaceCard>
-              <details>
-                <summary
-                  className={styles.accordionTrigger}
-                  style={{ cursor: 'pointer', listStyle: 'none' }}
-                >
-                  <div className={styles.accordionBody}>
-                    <p className={styles.accordionTitle}>Prompt 高级设置</p>
+          ) : (
+            <SurfaceCard tone="soft">
+              <div className={styles.platformDetailInner}>
+                <div className={styles.platformDetailHeader}>
+                  <span className={styles.accordionIcon}>
+                    <Sparkles size={22} />
+                  </span>
+                  <div>
+                    <p className={styles.accordionTitle}>Prompt 设置</p>
                     <p className={styles.accordionSummary}>自定义 AI 改写和适配的提示词模板</p>
                   </div>
-                </summary>
-                <div className={styles.accordionPanel}>
-                  <PromptEditor />
                 </div>
-              </details>
+                <PromptEditor />
+              </div>
             </SurfaceCard>
-          </div>
+          )}
         </div>
-      ) : null}
+      </div>
+
       {isDirty && !loading && (
         <button type="button" className={styles.floatingSave} onClick={handleSave}>
           <Save size={16} />

--- a/src/app/settings/settings.css.ts
+++ b/src/app/settings/settings.css.ts
@@ -5,62 +5,38 @@ import { vars } from '@/styles/tokens.css';
 export const pageWrap = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing['3xl'],
+  gap: vars.spacing['5xl'],
   paddingBottom: '80px',
 });
 
-// Section anchor nav
-export const sectionNav = style({
-  position: 'sticky',
-  top: '80px',
-  zIndex: 10,
-  display: 'inline-flex',
-  alignSelf: 'flex-start',
-  maxWidth: '100%',
-  gap: vars.spacing['2xs'],
-  overflowX: 'auto',
-  padding: vars.spacing.xs,
-  borderRadius: vars.radius.full,
-  border: `1px solid ${vars.color.borderFaint}`,
-  background: vars.color.glassSurface,
-  backdropFilter: 'blur(16px) saturate(180%)',
-  WebkitBackdropFilter: 'blur(16px) saturate(180%)',
-  boxShadow: vars.shadow.sm,
-  selectors: {
-    '&::-webkit-scrollbar': {
-      display: 'none',
-    },
-  },
+// Section block
+export const sectionBlock = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['3xl'],
 });
 
-export const sectionTab = recipe({
-  base: {
-    flexShrink: 0,
-    borderRadius: vars.radius.full,
-    border: 'none',
-    background: 'transparent',
-    padding: `${vars.spacing['md-lg']} ${vars.spacing['2xl']}`,
-    fontSize: vars.fontSize.sm,
-    fontWeight: 600,
-    lineHeight: 1,
-    color: vars.color.textMuted,
-    cursor: 'pointer',
-    transition: 'background-color 150ms, color 150ms, box-shadow 150ms',
-    ':hover': {
-      color: vars.color.text,
-      background: vars.color.bgElevated,
-    },
-  },
-  variants: {
-    active: {
-      true: {
-        background: vars.color.accent,
-        color: vars.color.surfaceDarkText,
-        boxShadow: `${vars.shadow.md}, inset 0 0 0 1px ${vars.color.accent}`,
-      },
-    },
-  },
-  defaultVariants: { active: false },
+export const sectionHeading = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.md,
+  paddingBottom: vars.spacing.xl,
+  borderBottom: `1px solid ${vars.color.borderFaint}`,
+});
+
+export const sectionTitle = style({
+  margin: 0,
+  fontSize: vars.fontSize['2xl'],
+  fontWeight: 600,
+  letterSpacing: '-0.01em',
+  color: vars.color.text,
+});
+
+export const sectionDescription = style({
+  margin: 0,
+  fontSize: vars.fontSize.sm,
+  color: vars.color.textMuted,
+  lineHeight: 1.5,
 });
 
 // Floating save button
@@ -103,13 +79,12 @@ export const sectionAnchor = style({
 
 export const accordionCard = style({
   overflow: 'hidden',
-  padding: 0,
 });
 
 export const platformList = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing.md,
+  gap: vars.spacing.xl,
 });
 
 // Save button / action area
@@ -270,11 +245,10 @@ export const statusBadgeVariants = styleVariants({
 
 // Expanded panel
 export const accordionPanel = style({
-  borderTop: `1px solid ${vars.color.border}`,
-  padding: vars.spacing['2xl'],
+  padding: `${vars.spacing['3xl']} ${vars.spacing['3xl']}`,
   '@media': {
     'screen and (min-width: 640px)': {
-      padding: `${vars.spacing['2xl']} ${vars.spacing['3xl']}`,
+      padding: `${vars.spacing['3xl']} ${vars.spacing['4xl']}`,
     },
   },
 });
@@ -419,7 +393,7 @@ export const checkResultFail = style({
 export const fieldList = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing.xl,
+  gap: vars.spacing['2xl'],
 });
 
 export const fieldWrap = style({
@@ -429,9 +403,11 @@ export const fieldWrap = style({
 });
 
 export const fieldLabel = style({
-  fontSize: vars.fontSize.md,
+  fontSize: vars.fontSize.sm,
   fontWeight: 500,
-  color: vars.color.text,
+  color: vars.color.textMuted,
+  textTransform: 'uppercase',
+  letterSpacing: '0.03em',
 });
 
 export const fieldInputWrap = style({
@@ -440,39 +416,41 @@ export const fieldInputWrap = style({
 
 export const fieldInput = style({
   width: '100%',
-  borderRadius: vars.radius.lg,
+  borderRadius: vars.radius.md,
   border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
-  padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
+  background: vars.color.bg,
+  padding: `${vars.spacing['md-lg']} ${vars.spacing.xl}`,
   paddingRight: '48px',
   fontSize: vars.fontSize.md,
   color: vars.color.text,
   outline: 'none',
-  transition: 'border-color 150ms',
+  transition: 'border-color 150ms, box-shadow 150ms',
   '::placeholder': {
     color: vars.color.textMuted,
   },
   ':focus': {
     borderColor: vars.color.accent,
+    boxShadow: `0 0 0 3px ${vars.color.accentSoft}`,
   },
 });
 
 export const fieldTextarea = style({
   width: '100%',
   resize: 'none',
-  borderRadius: vars.radius.lg,
+  borderRadius: vars.radius.md,
   border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
-  padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
+  background: vars.color.bg,
+  padding: `${vars.spacing['md-lg']} ${vars.spacing.xl}`,
   fontSize: vars.fontSize.md,
   color: vars.color.text,
   outline: 'none',
-  transition: 'border-color 150ms',
+  transition: 'border-color 150ms, box-shadow 150ms',
   '::placeholder': {
     color: vars.color.textMuted,
   },
   ':focus': {
     borderColor: vars.color.accent,
+    boxShadow: `0 0 0 3px ${vars.color.accentSoft}`,
   },
 });
 
@@ -494,8 +472,8 @@ export const eyeButton = style({
 });
 
 export const fieldHint = style({
-  marginTop: vars.spacing.xl,
-  fontSize: vars.fontSize.sm,
+  marginTop: vars.spacing.lg,
+  fontSize: vars.fontSize.xs,
   lineHeight: 1.75,
   color: vars.color.textMuted,
 });
@@ -505,6 +483,28 @@ export const inlineCode = style({
   border: `1px solid ${vars.color.border}`,
   background: vars.color.bg,
   padding: '1px 4px',
+});
+
+// Sidebar group divider
+export const sidebarDivider = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.md,
+  padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
+  marginTop: vars.spacing.md,
+  fontSize: vars.fontSize.xs,
+  fontWeight: 600,
+  color: vars.color.textMuted,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  selectors: {
+    '&::after': {
+      content: '""',
+      flex: 1,
+      height: '1px',
+      background: vars.color.borderFaint,
+    },
+  },
 });
 
 // Two-step OAuth layout
@@ -615,11 +615,11 @@ export const authorizeButton = style({
 export const platformLayout = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing.xl,
+  gap: vars.spacing['2xl'],
   '@media': {
     'screen and (min-width: 1024px)': {
       flexDirection: 'row',
-      gap: vars.spacing['2xl'],
+      gap: vars.spacing['4xl'],
     },
   },
 });
@@ -630,9 +630,10 @@ export const platformSidebar = style({
     'screen and (min-width: 1024px)': {
       display: 'flex',
       flexDirection: 'column',
-      width: '220px',
+      width: '240px',
       flexShrink: 0,
       gap: vars.spacing.xs,
+      paddingTop: vars.spacing.xs,
     },
   },
 });
@@ -643,13 +644,13 @@ export const platformSidebarItem = recipe({
     alignItems: 'center',
     gap: vars.spacing.lg,
     width: '100%',
-    padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
-    borderRadius: vars.radius.lg,
+    padding: `${vars.spacing['md-lg']} ${vars.spacing.xl}`,
+    borderRadius: vars.radius.md,
     border: 'none',
     background: 'transparent',
     textAlign: 'left',
     cursor: 'pointer',
-    transition: 'background-color 150ms',
+    transition: 'background-color 150ms, box-shadow 150ms',
     ':hover': {
       background: vars.color.bgElevated,
     },
@@ -657,8 +658,8 @@ export const platformSidebarItem = recipe({
   variants: {
     active: {
       true: {
-        background: vars.color.bgElevated,
-        boxShadow: `inset 3px 0 0 ${vars.color.accent}`,
+        background: vars.color.accentSoft,
+        color: vars.color.accent,
       },
     },
   },
@@ -699,17 +700,19 @@ export const platformDetail = style({
 });
 
 export const platformDetailInner = style({
-  maxWidth: '560px',
-  padding: `${vars.spacing['2xl']} ${vars.spacing['2xl']}`,
+  maxWidth: '580px',
+  padding: `${vars.spacing['3xl']} ${vars.spacing['3xl']}`,
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing['2xl'],
+  gap: vars.spacing['3xl'],
 });
 
 export const platformDetailHeader = style({
   display: 'flex',
   alignItems: 'center',
   gap: vars.spacing.xl,
+  paddingBottom: vars.spacing['2xl'],
+  borderBottom: `1px solid ${vars.color.borderFaint}`,
 });
 
 // Mobile platform tabs (horizontal, <1024px only)


### PR DESCRIPTION
Unify settings page from separate "platforms section (sidebar+detail) + AI section (single column cards)" into a single sidebar + detail layout for all settings items.

## Changes

- Remove two independent sections, promote sidebar to page-level navigation
- Platforms and AI assistant share one sidebar with a divider group
- Mobile pill tabs include all 6 items (4 platforms + 2 AI entries)
- Detail panel conditionally renders the appropriate form based on selected item type
- Refine sidebar active state: subtle accent background instead of thick inset box-shadow

## Verification

- `pnpm build` passes
- Desktop sidebar group switching works correctly
- Mobile tabs horizontally scrollable