### PR TITLE
refactor: settings page layout — top tabs + centered content

### DIFF
--- a/apps/web/src/components/layout/PageSection.css.ts
+++ b/apps/web/src/components/layout/PageSection.css.ts
@@ -47,9 +47,9 @@ export const eyebrow = style({
 
 export const sectionTitle = style({
   fontFamily: vars.font.serif,
-  marginTop: vars.spacing.md,
+  marginTop: vars.spacing.lg,
   fontSize: vars.fontSize['4xl'],
-  lineHeight: 1.3,
+  lineHeight: 1.4,
   color: vars.color.text,
   '@media': {
     'screen and (min-width: 640px)': {
@@ -59,7 +59,7 @@ export const sectionTitle = style({
 });
 
 export const sectionDescription = style({
-  marginTop: vars.spacing.lg,
+  marginTop: vars.spacing.xl,
   maxWidth: '48rem',
   fontSize: vars.fontSize.md,
   lineHeight: 1.75,

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from 'react';
+import { Fragment, Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Save,
@@ -324,6 +324,35 @@ function SettingsContent() {
     values['AGENT_MODEL']
   );
 
+  const tabItems = [
+    ...platformConfigs.map((platform) => {
+      const profile = connectionProfiles.find((p) => p.platform === platform.id);
+      return {
+        id: platform.id as string,
+        name: platform.name,
+        Icon: platform.Icon,
+        status: profile?.status ?? ('manual-required' as const),
+        group: 'platform' as const,
+      };
+    }),
+    {
+      id: 'agent-config',
+      name: '连接配置',
+      Icon: Bot,
+      status: (agentConfigured ? 'connected' : 'manual-required') as
+        | 'connected'
+        | 'manual-required',
+      group: 'agent' as const,
+    },
+    {
+      id: 'agent-prompt',
+      name: 'Prompt',
+      Icon: Sparkles,
+      status: 'available' as const,
+      group: 'agent' as const,
+    },
+  ];
+
   return (
     <div className={styles.pageWrap}>
       <AppShellHeader
@@ -383,62 +412,32 @@ function SettingsContent() {
         </button>
       </nav>
 
-      <div className={styles.platformLayout}>
-        {/* Desktop: sidebar */}
-        <nav className={styles.platformSidebar}>
-          {platformConfigs.map((platform) => {
-            const { Icon } = platform;
-            const connectionProfile = connectionProfiles.find((p) => p.platform === platform.id);
-            return (
+      {/* Desktop: horizontal top tabs */}
+      <nav className={styles.topTabsBar}>
+        {tabItems.map((tab, index) => {
+          const { Icon } = tab;
+          const prev = tabItems[index - 1];
+          const showDivider = prev && prev.group !== tab.group;
+          return (
+            <Fragment key={tab.id}>
+              {showDivider ? <span className={styles.topTabDivider} /> : null}
               <button
-                key={platform.id}
                 type="button"
-                className={styles.platformSidebarItem({
-                  active: selectedItem === platform.id,
-                })}
-                onClick={() => setSelectedItem(platform.id)}
+                className={styles.topTab({ active: selectedItem === tab.id })}
+                onClick={() => setSelectedItem(tab.id)}
               >
-                <span className={styles.sidebarItemIcon}>
-                  <Icon size={18} />
+                <span className={styles.topTabIcon}>
+                  <Icon size={16} />
                 </span>
-                <span className={styles.sidebarItemBody}>
-                  <p className={styles.sidebarItemName}>{platform.name}</p>
-                  <p className={styles.sidebarItemStatus}>
-                    {connectionProfile ? statusLabels[connectionProfile.status] : '未配置'}
-                  </p>
-                </span>
+                {tab.name}
+                <span className={styles.topTabDot[tab.status]} />
               </button>
-            );
-          })}
-          <div className={styles.sidebarDivider}>AI 助手</div>
-          <button
-            type="button"
-            className={styles.platformSidebarItem({ active: selectedItem === 'agent-config' })}
-            onClick={() => setSelectedItem('agent-config')}
-          >
-            <span className={styles.sidebarItemIcon}>
-              <Bot size={18} />
-            </span>
-            <span className={styles.sidebarItemBody}>
-              <p className={styles.sidebarItemName}>连接配置</p>
-              <p className={styles.sidebarItemStatus}>{agentConfigured ? '已配置' : '未配置'}</p>
-            </span>
-          </button>
-          <button
-            type="button"
-            className={styles.platformSidebarItem({ active: selectedItem === 'agent-prompt' })}
-            onClick={() => setSelectedItem('agent-prompt')}
-          >
-            <span className={styles.sidebarItemIcon}>
-              <Sparkles size={18} />
-            </span>
-            <span className={styles.sidebarItemBody}>
-              <p className={styles.sidebarItemName}>Prompt 设置</p>
-              <p className={styles.sidebarItemStatus}>自定义提示词</p>
-            </span>
-          </button>
-        </nav>
+            </Fragment>
+          );
+        })}
+      </nav>
 
+      <div className={styles.platformLayout}>
         {/* Detail panel */}
         <div className={styles.platformDetail}>
           {isPlatformSelected ? (

--- a/apps/web/src/pages/settings.css.ts
+++ b/apps/web/src/pages/settings.css.ts
@@ -7,6 +7,10 @@ export const pageWrap = style({
   flexDirection: 'column',
   gap: vars.spacing['5xl'],
   paddingBottom: '80px',
+  width: '100%',
+  maxWidth: '1080px',
+  marginLeft: 'auto',
+  marginRight: 'auto',
 });
 
 // Section block
@@ -485,28 +489,6 @@ export const inlineCode = style({
   padding: '1px 4px',
 });
 
-// Sidebar group divider
-export const sidebarDivider = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: vars.spacing.md,
-  padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
-  marginTop: vars.spacing.md,
-  fontSize: vars.fontSize.xs,
-  fontWeight: 600,
-  color: vars.color.textMuted,
-  textTransform: 'uppercase',
-  letterSpacing: '0.04em',
-  selectors: {
-    '&::after': {
-      content: '""',
-      flex: 1,
-      height: '1px',
-      background: vars.color.borderFaint,
-    },
-  },
-});
-
 // Two-step OAuth layout
 export const oauthSteps = style({
   display: 'flex',
@@ -618,85 +600,20 @@ export const platformLayout = style({
   gap: vars.spacing['2xl'],
   '@media': {
     'screen and (min-width: 1024px)': {
-      flexDirection: 'row',
-      gap: vars.spacing['4xl'],
+      marginTop: vars.spacing['3xl'],
     },
   },
-});
-
-export const platformSidebar = style({
-  display: 'none',
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      display: 'flex',
-      flexDirection: 'column',
-      width: '240px',
-      flexShrink: 0,
-      gap: vars.spacing.xs,
-      paddingTop: vars.spacing.xs,
-    },
-  },
-});
-
-export const platformSidebarItem = recipe({
-  base: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: vars.spacing.lg,
-    width: '100%',
-    padding: `${vars.spacing['md-lg']} ${vars.spacing.xl}`,
-    borderRadius: vars.radius.md,
-    border: 'none',
-    background: 'transparent',
-    textAlign: 'left',
-    cursor: 'pointer',
-    transition: 'background-color 150ms, box-shadow 150ms',
-    ':hover': {
-      background: vars.color.bgElevated,
-    },
-  },
-  variants: {
-    active: {
-      true: {
-        background: vars.color.accentSoft,
-        color: vars.color.accent,
-      },
-    },
-  },
-  defaultVariants: { active: false },
-});
-
-export const sidebarItemIcon = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '28px',
-  height: '28px',
-  flexShrink: 0,
-});
-
-export const sidebarItemBody = style({
-  flex: 1,
-  minWidth: 0,
-});
-
-export const sidebarItemName = style({
-  margin: 0,
-  fontSize: vars.fontSize.sm,
-  fontWeight: 500,
-  color: vars.color.text,
-});
-
-export const sidebarItemStatus = style({
-  margin: 0,
-  marginTop: '2px',
-  fontSize: vars.fontSize.xs,
-  color: vars.color.textMuted,
 });
 
 export const platformDetail = style({
   flex: 1,
   minWidth: 0,
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      width: '100%',
+      maxWidth: '680px',
+    },
+  },
 });
 
 export const platformDetailInner = style({
@@ -766,4 +683,117 @@ export const platformMobileTab = recipe({
     },
   },
   defaultVariants: { active: false },
+});
+
+// ── 方案1: 顶部 tab 横排 + 单栏内容 (desktop ≥1024px) ──────────────
+export const topTabsBar = style({
+  display: 'none',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'flex',
+      alignItems: 'flex-end',
+      gap: vars.spacing.xs,
+      width: '100%',
+      borderBottom: `1px solid ${vars.color.borderFaint}`,
+      overflowX: 'auto',
+    },
+  },
+  selectors: {
+    '&::-webkit-scrollbar': { display: 'none' },
+  },
+});
+
+export const topTab = recipe({
+  base: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: vars.spacing.md,
+    flexShrink: 0,
+    border: 'none',
+    background: 'transparent',
+    padding: `${vars.spacing.lg} ${vars.spacing.lg}`,
+    marginBottom: '-1px',
+    fontSize: vars.fontSize.md,
+    fontWeight: 500,
+    color: vars.color.textMuted,
+    cursor: 'pointer',
+    borderBottom: '2px solid transparent',
+    transition: 'color 150ms, border-color 150ms',
+    ':hover': {
+      color: vars.color.text,
+    },
+  },
+  variants: {
+    active: {
+      true: {
+        color: vars.color.text,
+        fontWeight: 600,
+        borderBottom: `2px solid ${vars.color.accent}`,
+      },
+    },
+  },
+  defaultVariants: { active: false },
+});
+
+export const topTabIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  color: 'inherit',
+});
+
+export const topTabDot = styleVariants({
+  connected: {
+    width: '6px',
+    height: '6px',
+    borderRadius: vars.radius.full,
+    flexShrink: 0,
+    background: vars.color.successText,
+  },
+  available: {
+    width: '6px',
+    height: '6px',
+    borderRadius: vars.radius.full,
+    flexShrink: 0,
+    background: vars.color.signal,
+  },
+  'manual-required': {
+    width: '6px',
+    height: '6px',
+    borderRadius: vars.radius.full,
+    flexShrink: 0,
+    background: vars.color.borderStrong,
+  },
+});
+
+export const topTabDivider = style({
+  display: 'none',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'block',
+      alignSelf: 'center',
+      width: '1px',
+      height: '18px',
+      flexShrink: 0,
+      margin: `0 ${vars.spacing.sm}`,
+      background: vars.color.borderFaint,
+    },
+  },
+});
+
+// 单栏内容容器：居中收窄，消灭右侧留白
+export const singleColumnContent = style({
+  display: 'none',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      display: 'block',
+      width: '100%',
+      maxWidth: '640px',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      marginTop: vars.spacing['3xl'],
+    },
+  },
 });


### PR DESCRIPTION
## Summary

Reworks the settings page layout and loosens the shared page header spacing.

- **Header rhythm**: bump eyebrow→title / title→description spacing and title line-height so the shared `PageSection` header (Home, Drafts, Settings) reads less cramped.
- **Top tabs over two-level sidebar**: replace the desktop master-detail sidebar with a horizontal top tab row (platform + AI groups, active underline, per-tab status dots), flattening the previously three-deep navigation (global sidebar → platform sidebar → form).
- **Centered content**: constrain page content to a max-width and center it, so wide viewports get symmetric left/right whitespace instead of a left-skewed form with a large empty right gutter.

## Verification

- `tsc --noEmit` → passes
- `pnpm lint` → clean
- `pnpm build` → passes
- Manually verified in browser at 1280 / 1680 / 2000px widths; content centered with symmetric margins (measured 200px each side at 1680px), tabs switch correctly, mobile pill tabs unaffected.