### PR TITLE
refactor: flatten main page layouts (remove header chrome + in-page cards)

### DIFF
--- a/apps/web/src/components/drafts/drafts.css.ts
+++ b/apps/web/src/components/drafts/drafts.css.ts
@@ -3,18 +3,19 @@ import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/app/styles/tokens.css';
 
 export const draftList = style({
-  display: 'grid',
-  gap: vars.spacing.lg,
+  display: 'flex',
+  flexDirection: 'column',
 });
 
 export const draftCard = style({
   display: 'grid',
   gap: vars.spacing['xl-2xl'],
-  borderRadius: vars.radius.xl,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
-  boxShadow: vars.shadow.sm,
-  padding: vars.spacing['xl-2xl'],
+  borderBottom: `1px solid ${vars.color.borderFaint}`,
+  padding: `${vars.spacing.xl} ${vars.spacing.md}`,
+  transition: 'background-color 150ms',
+  ':hover': {
+    background: vars.color.bgElevated,
+  },
   '@media': {
     'screen and (min-width: 760px)': {
       gridTemplateColumns: 'minmax(0, 1fr) auto',
@@ -280,12 +281,10 @@ export const draftCardSelectable = recipe({
   base: {
     display: 'grid',
     gap: vars.spacing['xl-2xl'],
-    borderRadius: vars.radius.xl,
-    border: `1px solid ${vars.color.border}`,
-    background: vars.color.surface,
-    padding: vars.spacing['xl-2xl'],
+    borderBottom: `1px solid ${vars.color.borderFaint}`,
+    padding: `${vars.spacing.xl} ${vars.spacing.md}`,
     cursor: 'pointer',
-    transition: 'border-color 150ms, background-color 150ms',
+    transition: 'background-color 150ms',
     '@media': {
       'screen and (min-width: 760px)': {
         gridTemplateColumns: 'auto minmax(0, 1fr) auto',
@@ -296,12 +295,11 @@ export const draftCardSelectable = recipe({
   variants: {
     selected: {
       true: {
-        borderColor: vars.color.accent,
         background: vars.color.accentSoft,
       },
       false: {
         ':hover': {
-          borderColor: vars.color.borderStrong,
+          background: vars.color.bgElevated,
         },
       },
     },

--- a/apps/web/src/components/layout/AppShellHeader.css.ts
+++ b/apps/web/src/components/layout/AppShellHeader.css.ts
@@ -5,29 +5,25 @@ export const header = style({
   position: 'sticky',
   top: 0,
   zIndex: 40,
-  height: '80px',
   width: 'auto',
-  margin: `calc(-1 * ${vars.spacing.xl}) calc(-1 * ${vars.spacing.xl}) ${vars.spacing['2xl']}`,
-  padding: `0 ${vars.spacing.xl}`,
-  borderBottom: `1px solid ${vars.color.glassBorder}`,
-  background: vars.color.glassSurface,
-  backdropFilter: 'blur(16px) saturate(180%)',
-  WebkitBackdropFilter: 'blur(16px) saturate(180%)',
+  margin: `calc(-1 * ${vars.spacing.xl}) calc(-1 * ${vars.spacing.xl}) ${vars.spacing.xl}`,
+  padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
+  borderBottom: `1px solid ${vars.color.borderFaint}`,
+  background: vars.color.bg,
   '@media': {
     'screen and (min-width: 640px)': {
-      margin: `calc(-1 * ${vars.spacing['2xl']}) calc(-1 * ${vars.spacing['3xl']}) ${vars.spacing['2xl']}`,
-      padding: `0 ${vars.spacing['3xl']}`,
+      margin: `calc(-1 * ${vars.spacing['2xl']}) calc(-1 * ${vars.spacing['3xl']}) ${vars.spacing.xl}`,
+      padding: `${vars.spacing.lg} ${vars.spacing['3xl']}`,
     },
     'screen and (min-width: 1024px)': {
-      margin: '-28px -36px 28px',
-      padding: '0 36px',
+      margin: '-28px -36px 24px',
+      padding: '18px 36px',
     },
   },
 });
 
 export const inner = style({
   display: 'flex',
-  height: '100%',
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: vars.spacing.xl,
@@ -42,29 +38,11 @@ export const textBlock = style({
   justifyContent: 'center',
 });
 
-export const kicker = style({
-  margin: 0,
-  fontSize: vars.fontSize['2xs'],
-  fontWeight: 600,
-  letterSpacing: vars.tracking.kicker,
-  lineHeight: 1.1,
-  color: vars.color.textMuted,
-  textTransform: 'uppercase',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  '@media': {
-    'screen and (max-width: 639px)': {
-      display: 'none',
-    },
-  },
-});
-
 export const title = style({
   margin: 0,
-  marginTop: vars.spacing.xs,
   fontSize: vars.fontSize['2xl'],
   fontWeight: 600,
+  letterSpacing: '-0.01em',
   lineHeight: 1.15,
   color: vars.color.text,
   whiteSpace: 'nowrap',

--- a/apps/web/src/components/layout/AppShellHeader.tsx
+++ b/apps/web/src/components/layout/AppShellHeader.tsx
@@ -2,23 +2,16 @@ import type { ReactNode } from 'react';
 import * as styles from './AppShellHeader.css';
 
 interface AppShellHeaderProps {
-  kicker: string;
   title: string;
   description?: string;
   action?: ReactNode;
 }
 
-export default function AppShellHeader({
-  kicker,
-  title,
-  description,
-  action,
-}: AppShellHeaderProps) {
+export default function AppShellHeader({ title, description, action }: AppShellHeaderProps) {
   return (
     <header className={styles.header}>
       <div className={styles.inner}>
         <div className={styles.textBlock}>
-          <p className={styles.kicker}>{kicker}</p>
           <h1 className={styles.title}>{title}</h1>
           {description ? <p className={styles.description}>{description}</p> : null}
         </div>

--- a/apps/web/src/components/publish/publish.css.ts
+++ b/apps/web/src/components/publish/publish.css.ts
@@ -502,14 +502,17 @@ export const previewThreadList = style({
 
 // 右侧面板区块容器
 export const rightPanelSection = style({
-  borderRadius: vars.radius.xl,
-  background: vars.color.surface,
-  border: `1px solid ${vars.color.border}`,
-  boxShadow: vars.shadow.sm,
-  padding: `${vars.spacing['lg-xl']} ${vars.spacing.xl}`,
+  borderTop: `1px solid ${vars.color.borderFaint}`,
+  paddingTop: vars.spacing.xl,
   display: 'flex',
   flexDirection: 'column',
   gap: vars.spacing['md-lg'],
+  selectors: {
+    '&:first-child': {
+      borderTop: 'none',
+      paddingTop: 0,
+    },
+  },
 });
 
 export const rightPanelSectionTitle = style({

--- a/apps/web/src/pages/Drafts.tsx
+++ b/apps/web/src/pages/Drafts.tsx
@@ -11,7 +11,6 @@ export default function DraftsPageClient() {
   return (
     <div className={styles.pageWrap}>
       <AppShellHeader
-        kicker="Draft library"
         title="稿件库"
         description="管理草稿，查看发布进展。"
         action={

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -154,7 +154,6 @@ function HomePageContent() {
   return (
     <div className={styles.pageWrap}>
       <AppShellHeader
-        kicker="Compose & publish"
         title="写作台"
         description="写作、预览、多平台分发。"
         action={

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -13,7 +13,6 @@ import {
 } from 'lucide-react';
 
 import AppShellHeader from '@/components/layout/AppShellHeader';
-import SurfaceCard from '@/components/layout/SurfaceCard';
 import { getPlatformConnectionProfiles } from '@/lib/platformConnections/profiles';
 import type {
   PlatformConnectionMode,
@@ -356,7 +355,6 @@ function SettingsContent() {
   return (
     <div className={styles.pageWrap}>
       <AppShellHeader
-        kicker="Operational control"
         title="设置"
         description="管理发布平台凭证与 AI 助手配置。"
         action={
@@ -441,194 +439,63 @@ function SettingsContent() {
         {/* Detail panel */}
         <div className={styles.platformDetail}>
           {isPlatformSelected ? (
-            <SurfaceCard tone="soft">
-              <div className={styles.platformDetailInner}>
-                {(() => {
-                  const platform = platformConfigs.find((p) => p.id === selectedItem)!;
-                  const { Icon } = platform;
-                  const connectionProfile = connectionProfiles.find(
-                    (p) => p.platform === platform.id,
-                  );
-                  const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
-                  const record = connectionRecords[platform.id];
-                  const connectedAccountName =
-                    (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
-                    (!checkStates[platform.id] && record?.accountName) ||
-                    null;
-                  const isConnected =
-                    connectionProfile?.status === 'connected' &&
-                    !disconnectStates[platform.id]?.done;
+            <div className={styles.platformDetailInner}>
+              {(() => {
+                const platform = platformConfigs.find((p) => p.id === selectedItem)!;
+                const { Icon } = platform;
+                const connectionProfile = connectionProfiles.find(
+                  (p) => p.platform === platform.id,
+                );
+                const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
+                const record = connectionRecords[platform.id];
+                const connectedAccountName =
+                  (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
+                  (!checkStates[platform.id] && record?.accountName) ||
+                  null;
+                const isConnected =
+                  connectionProfile?.status === 'connected' && !disconnectStates[platform.id]?.done;
 
-                  return (
-                    <>
-                      <div className={styles.platformDetailHeader}>
-                        <span className={styles.accordionIcon}>
-                          <Icon size={22} />
-                        </span>
-                        <div>
-                          <p className={styles.accordionTitle}>{platform.name}</p>
-                          {isConnected && connectedAccountName ? (
-                            <p className={styles.accordionAccountName}>
-                              <CheckCircle2 size={11} />
-                              {connectedAccountName}
-                            </p>
-                          ) : (
-                            <p className={styles.accordionSummary}>{platform.summary}</p>
-                          )}
-                        </div>
-                        {connectionProfile ? (
-                          <span
-                            className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
-                          >
-                            {statusLabels[connectionProfile.status]}
-                          </span>
-                        ) : null}
+                return (
+                  <>
+                    <div className={styles.platformDetailHeader}>
+                      <span className={styles.accordionIcon}>
+                        <Icon size={22} />
+                      </span>
+                      <div>
+                        <p className={styles.accordionTitle}>{platform.name}</p>
+                        {isConnected && connectedAccountName ? (
+                          <p className={styles.accordionAccountName}>
+                            <CheckCircle2 size={11} />
+                            {connectedAccountName}
+                          </p>
+                        ) : (
+                          <p className={styles.accordionSummary}>{platform.summary}</p>
+                        )}
                       </div>
+                      {connectionProfile ? (
+                        <span
+                          className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
+                        >
+                          {statusLabels[connectionProfile.status]}
+                        </span>
+                      ) : null}
+                    </div>
 
-                      {connectionProfile?.mode === 'oauth' ? (
-                        <div className={styles.oauthSteps}>
-                          <div className={styles.oauthStep}>
-                            <div className={styles.oauthStepHeader}>
-                              <span
-                                className={
-                                  connectionProfile.status === 'connected'
-                                    ? styles.oauthStepBadgeActive
-                                    : styles.oauthStepBadge
-                                }
-                              >
-                                1
-                              </span>
-                              <p className={styles.oauthStepTitle}>填写开发者凭证</p>
-                            </div>
-                            <div className={styles.fieldList}>
-                              {platform.fields.map((field) => (
-                                <div key={field.key} className={styles.fieldWrap}>
-                                  <label htmlFor={field.key} className={styles.fieldLabel}>
-                                    {field.label}
-                                  </label>
-                                  <div className={styles.fieldInputWrap}>
-                                    <input
-                                      id={field.key}
-                                      type={
-                                        field.type === 'password' && !showSecrets[field.key]
-                                          ? 'password'
-                                          : 'text'
-                                      }
-                                      value={values[field.key] || ''}
-                                      onChange={(event) =>
-                                        handleChange(field.key, event.target.value)
-                                      }
-                                      placeholder={field.placeholder}
-                                      className={styles.fieldInput}
-                                    />
-                                    {field.type === 'password' ? (
-                                      <button
-                                        type="button"
-                                        onClick={() => toggleSecret(field.key)}
-                                        aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
-                                        className={styles.eyeButton}
-                                      >
-                                        {showSecrets[field.key] ? (
-                                          <EyeOff size={16} />
-                                        ) : (
-                                          <Eye size={16} />
-                                        )}
-                                      </button>
-                                    ) : null}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                            <p className={styles.fieldHint}>{platform.hint}</p>
+                    {connectionProfile?.mode === 'oauth' ? (
+                      <div className={styles.oauthSteps}>
+                        <div className={styles.oauthStep}>
+                          <div className={styles.oauthStepHeader}>
+                            <span
+                              className={
+                                connectionProfile.status === 'connected'
+                                  ? styles.oauthStepBadgeActive
+                                  : styles.oauthStepBadge
+                              }
+                            >
+                              1
+                            </span>
+                            <p className={styles.oauthStepTitle}>填写开发者凭证</p>
                           </div>
-
-                          <div className={styles.oauthStep}>
-                            <div className={styles.oauthStepHeader}>
-                              <span
-                                className={
-                                  connectionProfile.status === 'connected'
-                                    ? styles.oauthStepBadgeActive
-                                    : styles.oauthStepBadge
-                                }
-                              >
-                                2
-                              </span>
-                              <p className={styles.oauthStepTitle}>
-                                {isVerifyOnly ? '验证连接' : '账号授权'}
-                              </p>
-                            </div>
-                            <p className={styles.oauthStepDesc}>
-                              {isVerifyOnly
-                                ? connectionProfile.status === 'connected'
-                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
-                                  : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
-                                : connectionProfile.status === 'connected'
-                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
-                                  : connectionProfile.missingKeys.length > 0
-                                    ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
-                                    : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
-                            </p>
-                            <CheckResult
-                              checkState={checkStates[platform.id]}
-                              connectionRecord={connectionRecords[platform.id]}
-                              disconnectDone={disconnectStates[platform.id]?.done}
-                            />
-                            <div className={styles.oauthAuthorizeRow}>
-                              <button
-                                type="button"
-                                className={styles.authorizeButton}
-                                disabled={
-                                  connectionProfile.missingKeys.length > 0 ||
-                                  checkStates[platform.id]?.checking
-                                }
-                                onClick={() =>
-                                  void handleConnectionAction(
-                                    platform.id,
-                                    platform.name,
-                                    connectionProfile.mode,
-                                  )
-                                }
-                              >
-                                {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
-                                {checkStates[platform.id]?.checking
-                                  ? '验证中…'
-                                  : isVerifyOnly
-                                    ? connectionProfile.status === 'connected'
-                                      ? '重新验证'
-                                      : '验证连接'
-                                    : connectionProfile.status === 'connected'
-                                      ? '重新授权'
-                                      : '一键授权'}
-                              </button>
-                              {connectionProfile.status === 'connected' && !isVerifyOnly ? (
-                                <>
-                                  <button
-                                    type="button"
-                                    className={styles.checkButton}
-                                    disabled={checkStates[platform.id]?.checking}
-                                    onClick={() => void handleCheckConnection(platform.id)}
-                                  >
-                                    <RefreshCw size={13} />
-                                    {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className={styles.disconnectButton}
-                                    disabled={disconnectStates[platform.id]?.disconnecting}
-                                    onClick={() => void handleDisconnect(platform.id)}
-                                  >
-                                    <Unplug size={13} />
-                                    {disconnectStates[platform.id]?.disconnecting
-                                      ? '处理中…'
-                                      : '断开连接'}
-                                  </button>
-                                </>
-                              ) : null}
-                            </div>
-                          </div>
-                        </div>
-                      ) : (
-                        <>
                           <div className={styles.fieldList}>
                             {platform.fields.map((field) => (
                               <div key={field.key} className={styles.fieldWrap}>
@@ -636,33 +503,20 @@ function SettingsContent() {
                                   {field.label}
                                 </label>
                                 <div className={styles.fieldInputWrap}>
-                                  {field.type === 'textarea' ? (
-                                    <textarea
-                                      id={field.key}
-                                      value={values[field.key] || ''}
-                                      onChange={(event) =>
-                                        handleChange(field.key, event.target.value)
-                                      }
-                                      placeholder={field.placeholder}
-                                      rows={4}
-                                      className={styles.fieldTextarea}
-                                    />
-                                  ) : (
-                                    <input
-                                      id={field.key}
-                                      type={
-                                        field.type === 'password' && !showSecrets[field.key]
-                                          ? 'password'
-                                          : 'text'
-                                      }
-                                      value={values[field.key] || ''}
-                                      onChange={(event) =>
-                                        handleChange(field.key, event.target.value)
-                                      }
-                                      placeholder={field.placeholder}
-                                      className={styles.fieldInput}
-                                    />
-                                  )}
+                                  <input
+                                    id={field.key}
+                                    type={
+                                      field.type === 'password' && !showSecrets[field.key]
+                                        ? 'password'
+                                        : 'text'
+                                    }
+                                    value={values[field.key] || ''}
+                                    onChange={(event) =>
+                                      handleChange(field.key, event.target.value)
+                                    }
+                                    placeholder={field.placeholder}
+                                    className={styles.fieldInput}
+                                  />
                                   {field.type === 'password' ? (
                                     <button
                                       type="button"
@@ -682,141 +536,276 @@ function SettingsContent() {
                             ))}
                           </div>
                           <p className={styles.fieldHint}>{platform.hint}</p>
-                          <div className={styles.oauthAuthorizeRow}>
-                            <button
-                              type="button"
-                              className={styles.checkButton}
-                              disabled={
-                                checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']
+                        </div>
+
+                        <div className={styles.oauthStep}>
+                          <div className={styles.oauthStepHeader}>
+                            <span
+                              className={
+                                connectionProfile.status === 'connected'
+                                  ? styles.oauthStepBadgeActive
+                                  : styles.oauthStepBadge
                               }
-                              onClick={() => void handleCheckConnection(platform.id)}
                             >
-                              <RefreshCw size={13} />
-                              {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
-                            </button>
+                              2
+                            </span>
+                            <p className={styles.oauthStepTitle}>
+                              {isVerifyOnly ? '验证连接' : '账号授权'}
+                            </p>
                           </div>
+                          <p className={styles.oauthStepDesc}>
+                            {isVerifyOnly
+                              ? connectionProfile.status === 'connected'
+                                ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
+                                : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
+                              : connectionProfile.status === 'connected'
+                                ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
+                                : connectionProfile.missingKeys.length > 0
+                                  ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
+                                  : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
+                          </p>
                           <CheckResult
                             checkState={checkStates[platform.id]}
                             connectionRecord={connectionRecords[platform.id]}
                             disconnectDone={disconnectStates[platform.id]?.done}
                           />
-                        </>
-                      )}
-                    </>
-                  );
-                })()}
-              </div>
-            </SurfaceCard>
+                          <div className={styles.oauthAuthorizeRow}>
+                            <button
+                              type="button"
+                              className={styles.authorizeButton}
+                              disabled={
+                                connectionProfile.missingKeys.length > 0 ||
+                                checkStates[platform.id]?.checking
+                              }
+                              onClick={() =>
+                                void handleConnectionAction(
+                                  platform.id,
+                                  platform.name,
+                                  connectionProfile.mode,
+                                )
+                              }
+                            >
+                              {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
+                              {checkStates[platform.id]?.checking
+                                ? '验证中…'
+                                : isVerifyOnly
+                                  ? connectionProfile.status === 'connected'
+                                    ? '重新验证'
+                                    : '验证连接'
+                                  : connectionProfile.status === 'connected'
+                                    ? '重新授权'
+                                    : '一键授权'}
+                            </button>
+                            {connectionProfile.status === 'connected' && !isVerifyOnly ? (
+                              <>
+                                <button
+                                  type="button"
+                                  className={styles.checkButton}
+                                  disabled={checkStates[platform.id]?.checking}
+                                  onClick={() => void handleCheckConnection(platform.id)}
+                                >
+                                  <RefreshCw size={13} />
+                                  {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
+                                </button>
+                                <button
+                                  type="button"
+                                  className={styles.disconnectButton}
+                                  disabled={disconnectStates[platform.id]?.disconnecting}
+                                  onClick={() => void handleDisconnect(platform.id)}
+                                >
+                                  <Unplug size={13} />
+                                  {disconnectStates[platform.id]?.disconnecting
+                                    ? '处理中…'
+                                    : '断开连接'}
+                                </button>
+                              </>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <>
+                        <div className={styles.fieldList}>
+                          {platform.fields.map((field) => (
+                            <div key={field.key} className={styles.fieldWrap}>
+                              <label htmlFor={field.key} className={styles.fieldLabel}>
+                                {field.label}
+                              </label>
+                              <div className={styles.fieldInputWrap}>
+                                {field.type === 'textarea' ? (
+                                  <textarea
+                                    id={field.key}
+                                    value={values[field.key] || ''}
+                                    onChange={(event) =>
+                                      handleChange(field.key, event.target.value)
+                                    }
+                                    placeholder={field.placeholder}
+                                    rows={4}
+                                    className={styles.fieldTextarea}
+                                  />
+                                ) : (
+                                  <input
+                                    id={field.key}
+                                    type={
+                                      field.type === 'password' && !showSecrets[field.key]
+                                        ? 'password'
+                                        : 'text'
+                                    }
+                                    value={values[field.key] || ''}
+                                    onChange={(event) =>
+                                      handleChange(field.key, event.target.value)
+                                    }
+                                    placeholder={field.placeholder}
+                                    className={styles.fieldInput}
+                                  />
+                                )}
+                                {field.type === 'password' ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleSecret(field.key)}
+                                    aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
+                                    className={styles.eyeButton}
+                                  >
+                                    {showSecrets[field.key] ? (
+                                      <EyeOff size={16} />
+                                    ) : (
+                                      <Eye size={16} />
+                                    )}
+                                  </button>
+                                ) : null}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                        <p className={styles.fieldHint}>{platform.hint}</p>
+                        <div className={styles.oauthAuthorizeRow}>
+                          <button
+                            type="button"
+                            className={styles.checkButton}
+                            disabled={checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']}
+                            onClick={() => void handleCheckConnection(platform.id)}
+                          >
+                            <RefreshCw size={13} />
+                            {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
+                          </button>
+                        </div>
+                        <CheckResult
+                          checkState={checkStates[platform.id]}
+                          connectionRecord={connectionRecords[platform.id]}
+                          disconnectDone={disconnectStates[platform.id]?.done}
+                        />
+                      </>
+                    )}
+                  </>
+                );
+              })()}
+            </div>
           ) : selectedItem === 'agent-config' ? (
-            <SurfaceCard tone="soft">
-              <div className={styles.platformDetailInner}>
-                <div className={styles.platformDetailHeader}>
-                  <span className={styles.accordionIcon}>
-                    <Bot size={22} />
-                  </span>
-                  <div>
-                    <p className={styles.accordionTitle}>AI 连接配置</p>
-                    <p className={styles.accordionSummary}>配置 LLM 接口，启用写作辅助与平台适配</p>
+            <div className={styles.platformDetailInner}>
+              <div className={styles.platformDetailHeader}>
+                <span className={styles.accordionIcon}>
+                  <Bot size={22} />
+                </span>
+                <div>
+                  <p className={styles.accordionTitle}>AI 连接配置</p>
+                  <p className={styles.accordionSummary}>配置 LLM 接口，启用写作辅助与平台适配</p>
+                </div>
+              </div>
+              <div className={styles.fieldList}>
+                <div className={styles.fieldWrap}>
+                  <label htmlFor="AGENT_BASE_URL" className={styles.fieldLabel}>
+                    API Base URL
+                  </label>
+                  <div className={styles.fieldInputWrap}>
+                    <input
+                      id="AGENT_BASE_URL"
+                      type="text"
+                      value={values['AGENT_BASE_URL'] || ''}
+                      onChange={(event) => handleChange('AGENT_BASE_URL', event.target.value)}
+                      placeholder="如 https://api.openai.com/v1 或 https://api.deepseek.com"
+                      className={styles.fieldInput}
+                    />
                   </div>
                 </div>
-                <div className={styles.fieldList}>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="AGENT_BASE_URL" className={styles.fieldLabel}>
-                      API Base URL
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="AGENT_BASE_URL"
-                        type="text"
-                        value={values['AGENT_BASE_URL'] || ''}
-                        onChange={(event) => handleChange('AGENT_BASE_URL', event.target.value)}
-                        placeholder="如 https://api.openai.com/v1 或 https://api.deepseek.com"
-                        className={styles.fieldInput}
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="AGENT_API_KEY" className={styles.fieldLabel}>
-                      API Key
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="AGENT_API_KEY"
-                        type={showSecrets['AGENT_API_KEY'] ? 'text' : 'password'}
-                        value={values['AGENT_API_KEY'] || ''}
-                        onChange={(event) => handleChange('AGENT_API_KEY', event.target.value)}
-                        placeholder="输入 API Key"
-                        className={styles.fieldInput}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => toggleSecret('AGENT_API_KEY')}
-                        aria-label={`${showSecrets['AGENT_API_KEY'] ? '隐藏' : '显示'} API Key`}
-                        className={styles.eyeButton}
-                      >
-                        {showSecrets['AGENT_API_KEY'] ? <EyeOff size={16} /> : <Eye size={16} />}
-                      </button>
-                    </div>
-                  </div>
-                  <div className={styles.fieldWrap}>
-                    <label htmlFor="AGENT_MODEL" className={styles.fieldLabel}>
-                      模型名称
-                    </label>
-                    <div className={styles.fieldInputWrap}>
-                      <input
-                        id="AGENT_MODEL"
-                        type="text"
-                        value={values['AGENT_MODEL'] || ''}
-                        onChange={(event) => handleChange('AGENT_MODEL', event.target.value)}
-                        placeholder="如 gpt-4o-mini、deepseek-chat、qwen-plus"
-                        className={styles.fieldInput}
-                      />
-                    </div>
-                  </div>
-                </div>
-                <p className={styles.fieldHint}>
-                  填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写并保存后：
-                </p>
-                <ul className={styles.fieldHint} style={{ margin: '4px 0 0 16px', padding: 0 }}>
-                  <li>
-                    编辑器输入 <code className={styles.inlineCode}>/</code> 查看 AI 命令
-                  </li>
-                  <li>发布预览面板出现「AI 适配」按钮</li>
-                </ul>
-                <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
-                  <button
-                    type="button"
-                    className={styles.checkButton}
-                    onClick={handleTestAgent}
-                    disabled={agentTesting}
-                  >
-                    {agentTesting ? '测试中...' : '测试连接'}
-                  </button>
-                  {agentTestResult && (
-                    <span
-                      className={agentTestResult.ok ? styles.checkResultOk : styles.checkResultFail}
+                <div className={styles.fieldWrap}>
+                  <label htmlFor="AGENT_API_KEY" className={styles.fieldLabel}>
+                    API Key
+                  </label>
+                  <div className={styles.fieldInputWrap}>
+                    <input
+                      id="AGENT_API_KEY"
+                      type={showSecrets['AGENT_API_KEY'] ? 'text' : 'password'}
+                      value={values['AGENT_API_KEY'] || ''}
+                      onChange={(event) => handleChange('AGENT_API_KEY', event.target.value)}
+                      placeholder="输入 API Key"
+                      className={styles.fieldInput}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => toggleSecret('AGENT_API_KEY')}
+                      aria-label={`${showSecrets['AGENT_API_KEY'] ? '隐藏' : '显示'} API Key`}
+                      className={styles.eyeButton}
                     >
-                      {agentTestResult.message}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </SurfaceCard>
-          ) : (
-            <SurfaceCard tone="soft">
-              <div className={styles.platformDetailInner}>
-                <div className={styles.platformDetailHeader}>
-                  <span className={styles.accordionIcon}>
-                    <Sparkles size={22} />
-                  </span>
-                  <div>
-                    <p className={styles.accordionTitle}>Prompt 设置</p>
-                    <p className={styles.accordionSummary}>自定义 AI 改写和适配的提示词模板</p>
+                      {showSecrets['AGENT_API_KEY'] ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
                   </div>
                 </div>
-                <PromptEditor />
+                <div className={styles.fieldWrap}>
+                  <label htmlFor="AGENT_MODEL" className={styles.fieldLabel}>
+                    模型名称
+                  </label>
+                  <div className={styles.fieldInputWrap}>
+                    <input
+                      id="AGENT_MODEL"
+                      type="text"
+                      value={values['AGENT_MODEL'] || ''}
+                      onChange={(event) => handleChange('AGENT_MODEL', event.target.value)}
+                      placeholder="如 gpt-4o-mini、deepseek-chat、qwen-plus"
+                      className={styles.fieldInput}
+                    />
+                  </div>
+                </div>
               </div>
-            </SurfaceCard>
+              <p className={styles.fieldHint}>
+                填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写并保存后：
+              </p>
+              <ul className={styles.fieldHint} style={{ margin: '4px 0 0 16px', padding: 0 }}>
+                <li>
+                  编辑器输入 <code className={styles.inlineCode}>/</code> 查看 AI 命令
+                </li>
+                <li>发布预览面板出现「AI 适配」按钮</li>
+              </ul>
+              <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+                <button
+                  type="button"
+                  className={styles.checkButton}
+                  onClick={handleTestAgent}
+                  disabled={agentTesting}
+                >
+                  {agentTesting ? '测试中...' : '测试连接'}
+                </button>
+                {agentTestResult && (
+                  <span
+                    className={agentTestResult.ok ? styles.checkResultOk : styles.checkResultFail}
+                  >
+                    {agentTestResult.message}
+                  </span>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className={styles.platformDetailInner}>
+              <div className={styles.platformDetailHeader}>
+                <span className={styles.accordionIcon}>
+                  <Sparkles size={22} />
+                </span>
+                <div>
+                  <p className={styles.accordionTitle}>Prompt 设置</p>
+                  <p className={styles.accordionSummary}>自定义 AI 改写和适配的提示词模板</p>
+                </div>
+              </div>
+              <PromptEditor />
+            </div>
           )}
         </div>
       </div>

--- a/apps/web/src/pages/page.css.ts
+++ b/apps/web/src/pages/page.css.ts
@@ -62,10 +62,6 @@ export const mobileOnly = style({
 
 export const editorCard = style({
   overflow: 'hidden',
-  borderRadius: vars.radius.xl,
-  background: vars.color.surface,
-  border: `1px solid ${vars.color.border}`,
-  boxShadow: vars.shadow.md,
   outline: 'none',
 });
 

--- a/apps/web/src/pages/settings.css.ts
+++ b/apps/web/src/pages/settings.css.ts
@@ -618,7 +618,6 @@ export const platformDetail = style({
 
 export const platformDetailInner = style({
   maxWidth: '580px',
-  padding: `${vars.spacing['3xl']} ${vars.spacing['3xl']}`,
   display: 'flex',
   flexDirection: 'column',
   gap: vars.spacing['3xl'],


### PR DESCRIPTION
## Summary

Flattens the visual chrome across the three main pages (Home / Drafts / Settings) per design feedback that the layout felt heavy and over-boxed.

**Shared header**
- Drop the glassmorphism shell from `AppShellHeader` (backdrop blur, shadow, fixed 80px height) and the decorative uppercase eyebrow.
- Title + optional description + action controls now sit flat on the page background with just a faint bottom border, still sticky on scroll.
- Remove the unused `kicker` prop from all three call sites.

**In-page cards → flat**
- Home: editor and right-panel sections lose their card frames; panel sections separate with a top hairline.
- Drafts: items become list rows (bottom divider + hover tint) instead of shadowed cards.
- Settings: detail panels drop the `SurfaceCard` wrapper and its padding; the top tab row and centered content from #101 are unchanged.

## Verification

- `tsc --noEmit`, `pnpm lint`, `pnpm build` → all pass
- Browser-checked all three pages: header flat + sticky, controls in place, editor/rows/panels borderless and separated by dividers/spacing.
- Verified dark mode: header border and row dividers stay subtle but legible against the dark background.

## Notes

Sticky behavior of header action controls (tab switcher, save, new/edit) is preserved. Mobile pill tabs and FAB unaffected.