### PR TITLE
refactor(ui): align preview card, settings tabs, and draft toolbar

### DIFF
--- a/apps/web/src/components/drafts/drafts.css.ts
+++ b/apps/web/src/components/drafts/drafts.css.ts
@@ -343,24 +343,6 @@ export const listHeader = style({
   gap: vars.spacing.md,
 });
 
-export const editToggleButton = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: vars.spacing.sm,
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: 'transparent',
-  padding: `${vars.spacing.sm} ${vars.spacing['md-lg']}`,
-  fontSize: vars.fontSize.sm,
-  color: vars.color.textMuted,
-  cursor: 'pointer',
-  transition: 'color 150ms, border-color 150ms',
-  ':hover': {
-    color: vars.color.text,
-    borderColor: vars.color.borderStrong,
-  },
-});
-
 // 分发状态步骤变体（按状态显示不同颜色徽标）
 export const syncStatusStepVariants = styleVariants({
   default: {
@@ -487,7 +469,7 @@ export const searchWrap = style({
   position: 'relative',
   width: 240,
   minWidth: 0,
-  height: 40,
+  height: 36,
   '@media': {
     'screen and (max-width: 899px)': {
       display: 'none',
@@ -638,7 +620,7 @@ export const filterButton = recipe({
     alignItems: 'center',
     justifyContent: 'center',
     gap: vars.spacing.sm,
-    height: 40,
+    height: 36,
     borderRadius: vars.radius.lg,
     border: `1px solid ${vars.color.border}`,
     background: 'transparent',

--- a/apps/web/src/components/editor/editor.css.ts
+++ b/apps/web/src/components/editor/editor.css.ts
@@ -2,10 +2,10 @@ import { globalStyle, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/app/styles/tokens.css';
 
-// MarkdownEditor outer wrapper
+// MarkdownEditor outer wrapper（底色由外层 editorCard 提供，自身透明）
 export const editorRoot = style({
   overflow: 'hidden',
-  background: vars.color.surface,
+  background: 'transparent',
 });
 
 // Title input area
@@ -169,34 +169,23 @@ export const statsDot = style({
   color: vars.color.borderStrong,
 });
 
-// Preview area
+// Preview area — 容器零内边距，使 frame 与写作态编辑卡同位置同尺寸
 export const previewWrap = style({
   display: 'flex',
-  minHeight: '34rem',
   alignItems: 'flex-start',
-  justifyContent: 'center',
-  background: `linear-gradient(180deg, ${vars.color.surface} 0%, ${vars.color.bg} 100%)`,
-  padding: vars.spacing['2xl'],
-  '@media': {
-    'screen and (min-width: 640px)': {
-      padding: vars.spacing['4xl'],
-    },
-    'screen and (min-width: 1024px)': {
-      minHeight: '36rem',
-      paddingTop: vars.spacing['5xl'],
-    },
-  },
+  justifyContent: 'stretch',
+  background: 'transparent',
+  padding: 0,
 });
 
 // 模拟手机/公众号文章阅读容器
 export const previewPhoneFrame = style({
   width: '100%',
-  maxWidth: '680px',
-  minHeight: '24rem',
+  // 与写作台编辑卡空态等高：titleRow(70) + 编辑区(420) + 数据栏(~45) ≈ 535px
+  minHeight: '33.5rem',
   borderRadius: vars.radius.xl,
   border: `1px solid ${vars.color.border}`,
   background: vars.color.surface,
-  boxShadow: vars.shadow.lg,
   overflow: 'hidden',
 });
 

--- a/apps/web/src/components/publish/publish.css.ts
+++ b/apps/web/src/components/publish/publish.css.ts
@@ -55,11 +55,11 @@ export const platformLabel = recipe({
         color: vars.color.signal,
       },
       false: {
-        background: vars.color.bgElevated,
-        color: vars.color.textMuted,
+        background: vars.color.surface,
+        color: vars.color.text,
         ':hover': {
-          background: vars.color.surface,
-          color: vars.color.text,
+          background: vars.color.bgElevated,
+          color: vars.color.textMuted,
         },
       },
     },

--- a/apps/web/src/components/ui/FilterChipGroup.css.ts
+++ b/apps/web/src/components/ui/FilterChipGroup.css.ts
@@ -4,15 +4,17 @@ import { vars } from '@/app/styles/tokens.css';
 
 export const filterBar = style({
   display: 'flex',
-  flexWrap: 'nowrap',
+  flexWrap: 'wrap',
   gap: vars.spacing.sm,
 });
 
 export const filterChip = recipe({
   base: {
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
     borderRadius: vars.radius.full,
     border: `1px solid ${vars.color.border}`,
-    padding: `${vars.spacing.xs} ${vars.spacing.lg}`,
+    padding: `${vars.spacing.sm} ${vars.spacing.lg}`,
     fontSize: vars.fontSize.xs,
     cursor: 'pointer',
     transition: 'background-color 150ms, color 150ms, border-color 150ms',

--- a/apps/web/src/pages/Drafts.tsx
+++ b/apps/web/src/pages/Drafts.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Pencil, Plus } from 'lucide-react';
+import { ListChecks, Plus } from 'lucide-react';
 import AppShellHeader from '@/components/layout/AppShellHeader';
 import DraftLibraryClient from '@/components/drafts/DraftLibraryClient';
 import DraftLibraryToolbar from '@/components/drafts/DraftLibraryToolbar';
+import { filterButton } from '@/components/drafts/drafts.css';
 import type { DraftStatus } from '@/lib/drafts/types';
 import * as styles from './drafts.page.css';
 
@@ -37,10 +38,10 @@ export default function DraftsPageClient() {
                 />
                 <button
                   type="button"
-                  className={styles.editToggleButton}
+                  className={filterButton({ active: false })}
                   onClick={() => setIsEditMode(true)}
                 >
-                  <Pencil size={14} />
+                  <ListChecks size={14} />
                   管理
                 </button>
                 <Link to="/" className={styles.newDraftLink}>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -241,7 +241,7 @@ function HomePageContent() {
               <RecentDraftBar />
             </div>
 
-            <div className={styles.editorCard}>
+            <div className={styles.editorCard({ preview: activeTab === 'preview' })}>
               <MarkdownEditor
                 activeTab={activeTab}
                 onSave={triggerSave}

--- a/apps/web/src/pages/drafts.page.css.ts
+++ b/apps/web/src/pages/drafts.page.css.ts
@@ -32,24 +32,6 @@ export const newDraftLink = style({
   },
 });
 
-export const editToggleButton = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: vars.spacing.sm,
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: 'transparent',
-  padding: `${vars.spacing.md} ${vars.spacing['lg-xl']}`,
-  fontSize: vars.fontSize.md,
-  color: vars.color.textMuted,
-  cursor: 'pointer',
-  transition: 'color 150ms, border-color 150ms',
-  ':hover': {
-    color: vars.color.text,
-    borderColor: vars.color.borderStrong,
-  },
-});
-
 export const editCancelButton = style({
   display: 'inline-flex',
   alignItems: 'center',

--- a/apps/web/src/pages/page.css.ts
+++ b/apps/web/src/pages/page.css.ts
@@ -53,11 +53,23 @@ export const mobileOnly = style({
   },
 });
 
-export const editorCard = style({
-  overflow: 'hidden',
-  outline: 'none',
-  borderRadius: vars.radius.xl,
-  background: vars.color.surface,
+export const editorCard = recipe({
+  base: {
+    overflow: 'hidden',
+    outline: 'none',
+    borderRadius: vars.radius.xl,
+    background: vars.color.surface,
+  },
+  variants: {
+    // 预览态去掉卡底色/圆角，让 phone frame 直接浮在页面背景上，消除卡中卡
+    preview: {
+      true: {
+        overflow: 'visible',
+        borderRadius: 0,
+        background: 'transparent',
+      },
+    },
+  },
 });
 
 export const draftLoadError = style({
@@ -96,6 +108,8 @@ export const resetLink = style({
 
 export const tabSwitcher = style({
   display: 'inline-flex',
+  alignItems: 'center',
+  height: 38,
   borderRadius: vars.radius.md,
   border: `1px solid ${vars.color.border}`,
   background: vars.color.bgElevated,
@@ -107,9 +121,10 @@ export const tabButton = recipe({
     display: 'inline-flex',
     alignItems: 'center',
     gap: vars.spacing.sm,
+    height: '100%',
     borderRadius: vars.radius.sm,
     border: 'none',
-    padding: `${vars.spacing.sm} ${vars.spacing.lg}`,
+    padding: `0 ${vars.spacing.lg}`,
     fontSize: vars.fontSize.sm,
     fontWeight: 500,
     cursor: 'pointer',
@@ -163,11 +178,13 @@ export const headerActions = style({
 export const newDraftButton = style({
   display: 'inline-flex',
   alignItems: 'center',
+  justifyContent: 'center',
   gap: vars.spacing.sm,
+  height: 38,
   borderRadius: vars.radius.md,
   border: `1px solid ${vars.color.border}`,
   background: 'transparent',
-  padding: `${vars.spacing.sm} ${vars.spacing['md-lg']}`,
+  padding: `0 ${vars.spacing['md-lg']}`,
   fontSize: vars.fontSize.sm,
   color: vars.color.textMuted,
   cursor: 'pointer',

--- a/apps/web/src/pages/settings.css.ts
+++ b/apps/web/src/pages/settings.css.ts
@@ -7,10 +7,6 @@ export const pageWrap = style({
   flexDirection: 'column',
   gap: vars.spacing['5xl'],
   paddingBottom: '80px',
-  width: '100%',
-  maxWidth: '1080px',
-  marginLeft: 'auto',
-  marginRight: 'auto',
 });
 
 // Section block
@@ -601,6 +597,9 @@ export const platformLayout = style({
   '@media': {
     'screen and (min-width: 1024px)': {
       marginTop: vars.spacing['3xl'],
+      // 各 tab 内容高度不一，切换时若页面变矮会触发浏览器钳制滚动导致跳动。
+      // 用 minHeight 填满 header+tabs 下方视口，保证页面高度稳定，切换不改变滚动位置。
+      minHeight: 'calc(100dvh - 220px)',
     },
   },
 });
@@ -690,9 +689,19 @@ export const topTabsBar = style({
   '@media': {
     'screen and (min-width: 1024px)': {
       display: 'flex',
+      // 贴紧 header 下方并始终悬浮（sticky）。top = header 高度，使其紧贴 header 底部
+      position: 'sticky',
+      top: '83px',
+      zIndex: 30,
       alignItems: 'flex-end',
       gap: vars.spacing.xs,
-      width: '100%',
+      // 抵消 header marginBottom(24) + pageWrap gap(40)，让 tab 紧贴 header
+      marginTop: '-64px',
+      // 全宽出血到页面边缘（与 header 一致），内容靠 padding 内缩与正文对齐
+      marginLeft: '-36px',
+      marginRight: '-36px',
+      padding: `${vars.spacing.md} 36px 0`,
+      background: vars.color.bg,
       borderBottom: `1px solid ${vars.color.borderFaint}`,
       overflowX: 'auto',
     },
@@ -727,7 +736,6 @@ export const topTab = recipe({
     active: {
       true: {
         color: vars.color.text,
-        fontWeight: 600,
         borderBottom: `2px solid ${vars.color.accent}`,
       },
     },


### PR DESCRIPTION
## Overview

A set of layout and presentation refinements across the editor, settings, and draft library — unifying component sizing and removing visual redundancy.

## Changes

### Editor preview
- Removed the nested card-in-card: dropped the outer card background/radius, the frame shadow, and the 680px width cap.
- The preview card now matches the editor card in width, position, and height, and aligns horizontally with the publish panel below.

### Settings tabs
- Tab bar is now sticky, pinned directly under the header and always floating; it no longer scrolls away.
- Full-bleed to the page edges, left/right aligned with the header.
- Scroll position stays stable on tab switch via a minHeight lock — no more jumping.
- Removed the active-state `font-weight` shift that changed tab width on activation (most visible on "X (Twitter)").

### Draft library toolbar
- Search box, filter, and manage buttons unified to a shared 36px-tall style, matching the new-draft button height.
- Manage button hover style aligned with filter; icon swapped from `Pencil` to `ListChecks`.
- Filter popover options now wrap (flow layout) with horizontal text.

### Editor header
- Tab switcher and the more-menu (⋯) button now share the same height and are top/bottom aligned.

### Platform selector
- Swapped the default and hover states.

## Verification
- `pnpm lint` passes
- `pnpm build` passes
- Layout sizing / scroll / alignment verified via Playwright