### PR TITLE
refactor: writing desk layout, blank page fix, UI simplification

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,6 +14,19 @@
   </head>
   <body>
     <div id="root"></div>
+    <!--
+      React Fast Refresh preamble（手动注入）。
+      vite 8 + @vitejs/plugin-react 的 transformIndexHtml 自动注入在此环境失效，
+      导致组件 transform 出的 $RefreshSig$ / $RefreshReg$ 运行时未定义而白屏。
+      此处显式加载 /@react-refresh runtime 并挂全局 hook，须在 main.tsx 之前执行。
+      生产构建时 /@react-refresh 不存在，script 会静默失败（type=module 网络错误不阻断）。
+    -->
+    <script type="module">
+      import { injectIntoGlobalHook } from '/@react-refresh';
+      injectIntoGlobalHook(window);
+      window.$RefreshReg$ = () => {};
+      window.$RefreshSig$ = () => (type) => type;
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "^19.0.0",
     "@types/sanitize-html": "^2.13.0",
     "@vanilla-extract/vite-plugin": "^5.0.0",
-    "@vitejs/plugin-react": "^5.0.0",
+    "@vitejs/plugin-react": "^5.2.0",
     "typescript": "^5.6.0",
     "vite": "^8.0.16"
   }

--- a/apps/web/src/app/styles/layout.css.ts
+++ b/apps/web/src/app/styles/layout.css.ts
@@ -43,13 +43,34 @@ export const shell = style({
   },
 });
 
+// main 改为定高 flex 列容器：顶部固定区(header/tabs) + 正文滚动区。
+// 这样透明 header 滚动时不会被下方内容穿透（容器滚动后内容不进入 header 区域）。
 export const main = style({
   minWidth: 0,
   flex: 1,
   position: 'relative',
   width: '100%',
+  height: '100dvh',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
   marginLeft: 'auto',
   marginRight: 'auto',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      maxWidth: '920px',
+    },
+  },
+});
+
+// 共享滚动区：正文容器，padding 从原 main 下放至此处。
+// 滚动区顶边天然紧贴 header 底边，移动端 paddingBottom 避开底部 mobileTabBar。
+export const scrollArea = style({
+  flex: 1,
+  minWidth: 0,
+  minHeight: 0,
+  overflowY: 'auto',
+  WebkitOverflowScrolling: 'touch',
   padding: vars.spacing.xl,
   paddingBottom: `calc(48px + ${vars.layout.tabBarHeight} + env(safe-area-inset-bottom))`,
   '@media': {
@@ -58,7 +79,6 @@ export const main = style({
       paddingBottom: `calc(52px + ${vars.layout.tabBarHeight} + env(safe-area-inset-bottom))`,
     },
     'screen and (min-width: 1024px)': {
-      maxWidth: '920px',
       padding: '28px 36px',
       paddingBottom: '28px',
     },

--- a/apps/web/src/components/drafts/drafts.css.ts
+++ b/apps/web/src/components/drafts/drafts.css.ts
@@ -83,9 +83,6 @@ export const syncSummary = style({
   flexDirection: 'column',
   gap: vars.spacing.xs,
   marginTop: vars.spacing['lg-xl'],
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.bgElevated,
   padding: `${vars.spacing['md-lg']} ${vars.spacing.lg}`,
 });
 
@@ -137,9 +134,6 @@ export const statePanel = style({
   display: 'flex',
   alignItems: 'center',
   gap: vars.spacing['md-lg'],
-  borderRadius: vars.radius.xl,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.surface,
   padding: vars.spacing['xl-2xl'],
   color: vars.color.textMuted,
 });
@@ -151,9 +145,6 @@ export const emptyState = style({
   alignItems: 'center',
   justifyContent: 'center',
   gap: vars.spacing.lg,
-  borderRadius: vars.radius.xl,
-  border: `1px dashed ${vars.color.borderStrong}`,
-  background: vars.color.surface,
   padding: vars.spacing['4xl'],
   textAlign: 'center',
 });
@@ -215,9 +206,6 @@ export const editModeBar = style({
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: vars.spacing.lg,
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.bgElevated,
   padding: `${vars.spacing['md-lg']} ${vars.spacing['lg-xl']}`,
 });
 
@@ -702,9 +690,21 @@ export const compactRow = style({
   display: 'flex',
   alignItems: 'flex-start',
   gap: vars.spacing.lg,
+  position: 'relative',
   padding: `${vars.spacing['xl-2xl']} ${vars.spacing['lg-xl']}`,
-  borderBottom: `1px solid ${vars.color.borderFaint}`,
   borderRadius: vars.radius.md,
+  // 分割线用 ::after 伪元素绘制，左右内缩到与文字内容齐宽（扣除 row 的左右 padding）
+  selectors: {
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      left: vars.spacing['lg-xl'],
+      right: vars.spacing['lg-xl'],
+      bottom: 0,
+      height: '1px',
+      background: vars.color.borderFaint,
+    },
+  },
   cursor: 'pointer',
   color: 'inherit',
   textDecoration: 'none',

--- a/apps/web/src/components/feedback/EmptyState.css.ts
+++ b/apps/web/src/components/feedback/EmptyState.css.ts
@@ -8,9 +8,6 @@ export const container = style({
   justifyContent: 'center',
   gap: vars.spacing['lg-xl'],
   minHeight: 280,
-  borderRadius: vars.radius.xl,
-  background: vars.color.surface,
-  border: `1px solid ${vars.color.border}`,
   padding: `${vars.spacing['5xl']} ${vars.spacing['4xl']}`,
   textAlign: 'center',
 });

--- a/apps/web/src/components/layout/AppShellHeader.css.ts
+++ b/apps/web/src/components/layout/AppShellHeader.css.ts
@@ -2,22 +2,41 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/app/styles/tokens.css';
 
 export const header = style({
-  position: 'sticky',
-  top: 0,
-  zIndex: 40,
+  flexShrink: 0,
+  position: 'relative',
   width: 'auto',
-  margin: `calc(-1 * ${vars.spacing.xl}) calc(-1 * ${vars.spacing.xl}) ${vars.spacing.xl}`,
   padding: `${vars.spacing.lg} ${vars.spacing.xl}`,
-  borderBottom: `1px solid ${vars.color.borderFaint}`,
   background: 'transparent',
+  // 底部分割线用 ::after 伪元素，左右内缩到与标题文字内容齐宽
+  selectors: {
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      left: vars.spacing.xl,
+      right: vars.spacing.xl,
+      bottom: 0,
+      height: '1px',
+      background: vars.color.borderFaint,
+    },
+  },
   '@media': {
     'screen and (min-width: 640px)': {
-      margin: `calc(-1 * ${vars.spacing['2xl']}) calc(-1 * ${vars.spacing['3xl']}) ${vars.spacing.xl}`,
       padding: `${vars.spacing.lg} ${vars.spacing['3xl']}`,
+      selectors: {
+        '&::after': {
+          left: vars.spacing['3xl'],
+          right: vars.spacing['3xl'],
+        },
+      },
     },
     'screen and (min-width: 1024px)': {
-      margin: '-28px -36px 24px',
       padding: '18px 36px',
+      selectors: {
+        '&::after': {
+          left: '36px',
+          right: '36px',
+        },
+      },
     },
   },
 });

--- a/apps/web/src/pages/Drafts.tsx
+++ b/apps/web/src/pages/Drafts.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ListChecks, Plus } from 'lucide-react';
 import AppShellHeader from '@/components/layout/AppShellHeader';
+import * as layoutStyles from '@/app/styles/layout.css';
 import DraftLibraryClient from '@/components/drafts/DraftLibraryClient';
 import DraftLibraryToolbar from '@/components/drafts/DraftLibraryToolbar';
 import { filterButton } from '@/components/drafts/drafts.css';
@@ -53,16 +54,18 @@ export default function DraftsPageClient() {
           </div>
         }
       />
-      <DraftLibraryClient
-        isEditMode={isEditMode}
-        onExitEditMode={() => setIsEditMode(false)}
-        searchQuery={searchQuery}
-        statusFilter={statusFilter}
-        onClearFilters={() => {
-          setSearchQuery('');
-          setStatusFilter('all');
-        }}
-      />
+      <div className={layoutStyles.scrollArea}>
+        <DraftLibraryClient
+          isEditMode={isEditMode}
+          onExitEditMode={() => setIsEditMode(false)}
+          searchQuery={searchQuery}
+          statusFilter={statusFilter}
+          onClearFilters={() => {
+            setSearchQuery('');
+            setStatusFilter('all');
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { Eye, SquarePen, Eraser, MoreHorizontal, FileText } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
 import { useAgentStore } from '@/stores/agentStore';
 import AppShellHeader from '@/components/layout/AppShellHeader';
+import * as layoutStyles from '@/app/styles/layout.css';
 
 const MarkdownEditor = lazy(() => import('@/components/editor/MarkdownEditor'));
 import RecentDraftBar from '@/components/editor/RecentDraftBar';
@@ -228,44 +229,46 @@ function HomePageContent() {
         }
       />
 
-      <div className={styles.editorLayout}>
-        <div className={styles.mainContentArea}>
-          <div className={styles.editorSection}>
-            {draftLoadError ? (
-              <div className={styles.draftLoadError} role="status">
-                {draftLoadError}
-              </div>
-            ) : null}
-
-            <div className={styles.mobileOnly}>
-              <RecentDraftBar />
-            </div>
-
-            <div className={styles.editorCard({ preview: activeTab === 'preview' })}>
-              <MarkdownEditor
-                activeTab={activeTab}
-                onSave={triggerSave}
-                agentEnabled={agentEnabled}
-              />
-            </div>
-
-            {agentStatus !== 'idle' && <AgentPanel />}
-
-            {/* 发布区：编辑区下方 */}
-            <div className={styles.publishPanel}>
-              <div className={publishStyles.rightPanelSection}>
-                <PublishChecklist />
-              </div>
-
-              {currentDraftId && (
-                <div className={publishStyles.rightPanelSection}>
-                  <span className={publishStyles.rightPanelSectionTitle}>渠道版本</span>
-                  <PlatformVariantPanel
-                    selectedPlatforms={selectedPlatforms}
-                    agentEnabled={agentEnabled}
-                  />
+      <div className={layoutStyles.scrollArea}>
+        <div className={styles.editorLayout}>
+          <div className={styles.mainContentArea}>
+            <div className={styles.editorSection}>
+              {draftLoadError ? (
+                <div className={styles.draftLoadError} role="status">
+                  {draftLoadError}
                 </div>
-              )}
+              ) : null}
+
+              <div className={styles.mobileOnly}>
+                <RecentDraftBar />
+              </div>
+
+              <div className={styles.editorCard({ preview: activeTab === 'preview' })}>
+                <MarkdownEditor
+                  activeTab={activeTab}
+                  onSave={triggerSave}
+                  agentEnabled={agentEnabled}
+                />
+              </div>
+
+              {agentStatus !== 'idle' && <AgentPanel />}
+
+              {/* 发布区：编辑区下方 */}
+              <div className={styles.publishPanel}>
+                <div className={publishStyles.rightPanelSection}>
+                  <PublishChecklist />
+                </div>
+
+                {currentDraftId && (
+                  <div className={publishStyles.rightPanelSection}>
+                    <span className={publishStyles.rightPanelSectionTitle}>渠道版本</span>
+                    <PlatformVariantPanel
+                      selectedPlatforms={selectedPlatforms}
+                      agentEnabled={agentEnabled}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 
 import AppShellHeader from '@/components/layout/AppShellHeader';
+import * as layoutStyles from '@/app/styles/layout.css';
 import { getPlatformConnectionProfiles } from '@/lib/platformConnections/profiles';
 import type {
   PlatformConnectionMode,
@@ -326,12 +327,24 @@ function SettingsContent() {
   const tabItems = [
     ...platformConfigs.map((platform) => {
       const profile = connectionProfiles.find((p) => p.platform === platform.id);
+      const status = profile?.status ?? ('manual-required' as const);
+      const accountName =
+        (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
+        (!checkStates[platform.id] && connectionRecords[platform.id]?.accountName) ||
+        null;
+      // tooltip 组合 header 原有的独有信息：摘要 + 状态 + 账号名
+      const tooltipParts = [
+        platform.summary,
+        statusLabels[status],
+        accountName ? `账号：${accountName}` : '',
+      ].filter(Boolean);
       return {
         id: platform.id as string,
         name: platform.name,
         Icon: platform.Icon,
-        status: profile?.status ?? ('manual-required' as const),
+        status,
         group: 'platform' as const,
+        tooltip: tooltipParts.join(' · '),
       };
     }),
     {
@@ -342,6 +355,7 @@ function SettingsContent() {
         | 'connected'
         | 'manual-required',
       group: 'agent' as const,
+      tooltip: agentConfigured ? 'AI 助手已配置' : '配置 LLM 接口以启用写作辅助',
     },
     {
       id: 'agent-prompt',
@@ -349,6 +363,7 @@ function SettingsContent() {
       Icon: Sparkles,
       status: 'available' as const,
       group: 'agent' as const,
+      tooltip: '自定义 AI 改写和适配的提示词模板',
     },
   ];
 
@@ -384,18 +399,24 @@ function SettingsContent() {
 
       {/* Mobile: horizontal pill tabs */}
       <nav className={styles.platformMobileTabs}>
-        {platformConfigs.map((platform) => (
-          <button
-            key={platform.id}
-            type="button"
-            className={styles.platformMobileTab({ active: selectedItem === platform.id })}
-            onClick={() => setSelectedItem(platform.id)}
-          >
-            {platform.name}
-          </button>
-        ))}
+        {platformConfigs.map((platform) => {
+          const profile = connectionProfiles.find((p) => p.platform === platform.id);
+          const tooltip = `${platform.summary} · ${statusLabels[profile?.status ?? 'manual-required']}`;
+          return (
+            <button
+              key={platform.id}
+              type="button"
+              title={tooltip}
+              className={styles.platformMobileTab({ active: selectedItem === platform.id })}
+              onClick={() => setSelectedItem(platform.id)}
+            >
+              {platform.name}
+            </button>
+          );
+        })}
         <button
           type="button"
+          title={agentConfigured ? 'AI 助手已配置' : '配置 LLM 接口以启用写作辅助'}
           className={styles.platformMobileTab({ active: selectedItem === 'agent-config' })}
           onClick={() => setSelectedItem('agent-config')}
         >
@@ -403,6 +424,7 @@ function SettingsContent() {
         </button>
         <button
           type="button"
+          title="自定义 AI 改写和适配的提示词模板"
           className={styles.platformMobileTab({ active: selectedItem === 'agent-prompt' })}
           onClick={() => setSelectedItem('agent-prompt')}
         >
@@ -421,6 +443,7 @@ function SettingsContent() {
               {showDivider ? <span className={styles.topTabDivider} /> : null}
               <button
                 type="button"
+                title={tab.tooltip}
                 className={styles.topTab({ active: selectedItem === tab.id })}
                 onClick={() => setSelectedItem(tab.id)}
               >
@@ -435,67 +458,166 @@ function SettingsContent() {
         })}
       </nav>
 
-      <div className={styles.platformLayout}>
-        {/* Detail panel */}
-        <div className={styles.platformDetail}>
-          {isPlatformSelected ? (
-            <div className={styles.platformDetailInner}>
-              {(() => {
-                const platform = platformConfigs.find((p) => p.id === selectedItem)!;
-                const { Icon } = platform;
-                const connectionProfile = connectionProfiles.find(
-                  (p) => p.platform === platform.id,
-                );
-                const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
-                const record = connectionRecords[platform.id];
-                const connectedAccountName =
-                  (checkStates[platform.id]?.ok && checkStates[platform.id]?.accountName) ||
-                  (!checkStates[platform.id] && record?.accountName) ||
-                  null;
-                const isConnected =
-                  connectionProfile?.status === 'connected' && !disconnectStates[platform.id]?.done;
+      <div className={layoutStyles.scrollArea}>
+        <div className={styles.platformLayout}>
+          {/* Detail panel */}
+          <div className={styles.platformDetail}>
+            {isPlatformSelected ? (
+              <div className={styles.platformDetailInner}>
+                {(() => {
+                  const platform = platformConfigs.find((p) => p.id === selectedItem)!;
+                  const connectionProfile = connectionProfiles.find(
+                    (p) => p.platform === platform.id,
+                  );
+                  const isVerifyOnly = VERIFY_ONLY_PLATFORMS.has(platform.id);
+                  const record = connectionRecords[platform.id];
 
-                return (
-                  <>
-                    <div className={styles.platformDetailHeader}>
-                      <span className={styles.accordionIcon}>
-                        <Icon size={22} />
-                      </span>
-                      <div>
-                        <p className={styles.accordionTitle}>{platform.name}</p>
-                        {isConnected && connectedAccountName ? (
-                          <p className={styles.accordionAccountName}>
-                            <CheckCircle2 size={11} />
-                            {connectedAccountName}
-                          </p>
-                        ) : (
-                          <p className={styles.accordionSummary}>{platform.summary}</p>
-                        )}
-                      </div>
-                      {connectionProfile ? (
-                        <span
-                          className={`${styles.statusBadge} ${styles.statusBadgeVariants[connectionProfile.status]}`}
-                        >
-                          {statusLabels[connectionProfile.status]}
-                        </span>
-                      ) : null}
-                    </div>
-
-                    {connectionProfile?.mode === 'oauth' ? (
-                      <div className={styles.oauthSteps}>
-                        <div className={styles.oauthStep}>
-                          <div className={styles.oauthStepHeader}>
-                            <span
-                              className={
-                                connectionProfile.status === 'connected'
-                                  ? styles.oauthStepBadgeActive
-                                  : styles.oauthStepBadge
-                              }
-                            >
-                              1
-                            </span>
-                            <p className={styles.oauthStepTitle}>填写开发者凭证</p>
+                  return (
+                    <>
+                      {connectionProfile?.mode === 'oauth' ? (
+                        <div className={styles.oauthSteps}>
+                          <div className={styles.oauthStep}>
+                            <div className={styles.oauthStepHeader}>
+                              <span
+                                className={
+                                  connectionProfile.status === 'connected'
+                                    ? styles.oauthStepBadgeActive
+                                    : styles.oauthStepBadge
+                                }
+                              >
+                                1
+                              </span>
+                              <p className={styles.oauthStepTitle}>填写开发者凭证</p>
+                            </div>
+                            <div className={styles.fieldList}>
+                              {platform.fields.map((field) => (
+                                <div key={field.key} className={styles.fieldWrap}>
+                                  <label htmlFor={field.key} className={styles.fieldLabel}>
+                                    {field.label}
+                                  </label>
+                                  <div className={styles.fieldInputWrap}>
+                                    <input
+                                      id={field.key}
+                                      type={
+                                        field.type === 'password' && !showSecrets[field.key]
+                                          ? 'password'
+                                          : 'text'
+                                      }
+                                      value={values[field.key] || ''}
+                                      onChange={(event) =>
+                                        handleChange(field.key, event.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      className={styles.fieldInput}
+                                    />
+                                    {field.type === 'password' ? (
+                                      <button
+                                        type="button"
+                                        onClick={() => toggleSecret(field.key)}
+                                        aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
+                                        className={styles.eyeButton}
+                                      >
+                                        {showSecrets[field.key] ? (
+                                          <EyeOff size={16} />
+                                        ) : (
+                                          <Eye size={16} />
+                                        )}
+                                      </button>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                            <p className={styles.fieldHint}>{platform.hint}</p>
                           </div>
+
+                          <div className={styles.oauthStep}>
+                            <div className={styles.oauthStepHeader}>
+                              <span
+                                className={
+                                  connectionProfile.status === 'connected'
+                                    ? styles.oauthStepBadgeActive
+                                    : styles.oauthStepBadge
+                                }
+                              >
+                                2
+                              </span>
+                              <p className={styles.oauthStepTitle}>
+                                {isVerifyOnly ? '验证连接' : '账号授权'}
+                              </p>
+                            </div>
+                            <p className={styles.oauthStepDesc}>
+                              {isVerifyOnly
+                                ? connectionProfile.status === 'connected'
+                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
+                                  : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
+                                : connectionProfile.status === 'connected'
+                                  ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
+                                  : connectionProfile.missingKeys.length > 0
+                                    ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
+                                    : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
+                            </p>
+                            <CheckResult
+                              checkState={checkStates[platform.id]}
+                              connectionRecord={connectionRecords[platform.id]}
+                              disconnectDone={disconnectStates[platform.id]?.done}
+                            />
+                            <div className={styles.oauthAuthorizeRow}>
+                              <button
+                                type="button"
+                                className={styles.authorizeButton}
+                                disabled={
+                                  connectionProfile.missingKeys.length > 0 ||
+                                  checkStates[platform.id]?.checking
+                                }
+                                onClick={() =>
+                                  void handleConnectionAction(
+                                    platform.id,
+                                    platform.name,
+                                    connectionProfile.mode,
+                                  )
+                                }
+                              >
+                                {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
+                                {checkStates[platform.id]?.checking
+                                  ? '验证中…'
+                                  : isVerifyOnly
+                                    ? connectionProfile.status === 'connected'
+                                      ? '重新验证'
+                                      : '验证连接'
+                                    : connectionProfile.status === 'connected'
+                                      ? '重新授权'
+                                      : '一键授权'}
+                              </button>
+                              {connectionProfile.status === 'connected' && !isVerifyOnly ? (
+                                <>
+                                  <button
+                                    type="button"
+                                    className={styles.checkButton}
+                                    disabled={checkStates[platform.id]?.checking}
+                                    onClick={() => void handleCheckConnection(platform.id)}
+                                  >
+                                    <RefreshCw size={13} />
+                                    {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className={styles.disconnectButton}
+                                    disabled={disconnectStates[platform.id]?.disconnecting}
+                                    onClick={() => void handleDisconnect(platform.id)}
+                                  >
+                                    <Unplug size={13} />
+                                    {disconnectStates[platform.id]?.disconnecting
+                                      ? '处理中…'
+                                      : '断开连接'}
+                                  </button>
+                                </>
+                              ) : null}
+                            </div>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
                           <div className={styles.fieldList}>
                             {platform.fields.map((field) => (
                               <div key={field.key} className={styles.fieldWrap}>
@@ -503,20 +625,33 @@ function SettingsContent() {
                                   {field.label}
                                 </label>
                                 <div className={styles.fieldInputWrap}>
-                                  <input
-                                    id={field.key}
-                                    type={
-                                      field.type === 'password' && !showSecrets[field.key]
-                                        ? 'password'
-                                        : 'text'
-                                    }
-                                    value={values[field.key] || ''}
-                                    onChange={(event) =>
-                                      handleChange(field.key, event.target.value)
-                                    }
-                                    placeholder={field.placeholder}
-                                    className={styles.fieldInput}
-                                  />
+                                  {field.type === 'textarea' ? (
+                                    <textarea
+                                      id={field.key}
+                                      value={values[field.key] || ''}
+                                      onChange={(event) =>
+                                        handleChange(field.key, event.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      rows={4}
+                                      className={styles.fieldTextarea}
+                                    />
+                                  ) : (
+                                    <input
+                                      id={field.key}
+                                      type={
+                                        field.type === 'password' && !showSecrets[field.key]
+                                          ? 'password'
+                                          : 'text'
+                                      }
+                                      value={values[field.key] || ''}
+                                      onChange={(event) =>
+                                        handleChange(field.key, event.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      className={styles.fieldInput}
+                                    />
+                                  )}
                                   {field.type === 'password' ? (
                                     <button
                                       type="button"
@@ -536,277 +671,138 @@ function SettingsContent() {
                             ))}
                           </div>
                           <p className={styles.fieldHint}>{platform.hint}</p>
-                        </div>
-
-                        <div className={styles.oauthStep}>
-                          <div className={styles.oauthStepHeader}>
-                            <span
-                              className={
-                                connectionProfile.status === 'connected'
-                                  ? styles.oauthStepBadgeActive
-                                  : styles.oauthStepBadge
+                          <div className={styles.oauthAuthorizeRow}>
+                            <button
+                              type="button"
+                              className={styles.checkButton}
+                              disabled={
+                                checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']
                               }
+                              onClick={() => void handleCheckConnection(platform.id)}
                             >
-                              2
-                            </span>
-                            <p className={styles.oauthStepTitle}>
-                              {isVerifyOnly ? '验证连接' : '账号授权'}
-                            </p>
+                              <RefreshCw size={13} />
+                              {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
+                            </button>
                           </div>
-                          <p className={styles.oauthStepDesc}>
-                            {isVerifyOnly
-                              ? connectionProfile.status === 'connected'
-                                ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「验证连接」确认凭证有效性。`
-                                : `填写上方全部凭证后点击「验证连接」。还差 ${connectionProfile.missingKeys.length} 项。`
-                              : connectionProfile.status === 'connected'
-                                ? `已配置全部 ${connectionProfile.configuredKeys.length} 项凭证。点击「检查连接」验证有效性，或重新授权刷新令牌。`
-                                : connectionProfile.missingKeys.length > 0
-                                  ? `填写上方全部凭证后，即可点击「一键授权」完成账号绑定。还差 ${connectionProfile.missingKeys.length} 项。`
-                                  : '凭证已填写完毕，点击「一键授权」完成账号绑定。'}
-                          </p>
                           <CheckResult
                             checkState={checkStates[platform.id]}
                             connectionRecord={connectionRecords[platform.id]}
                             disconnectDone={disconnectStates[platform.id]?.done}
                           />
-                          <div className={styles.oauthAuthorizeRow}>
-                            <button
-                              type="button"
-                              className={styles.authorizeButton}
-                              disabled={
-                                connectionProfile.missingKeys.length > 0 ||
-                                checkStates[platform.id]?.checking
-                              }
-                              onClick={() =>
-                                void handleConnectionAction(
-                                  platform.id,
-                                  platform.name,
-                                  connectionProfile.mode,
-                                )
-                              }
-                            >
-                              {isVerifyOnly ? <RefreshCw size={15} /> : <Zap size={15} />}
-                              {checkStates[platform.id]?.checking
-                                ? '验证中…'
-                                : isVerifyOnly
-                                  ? connectionProfile.status === 'connected'
-                                    ? '重新验证'
-                                    : '验证连接'
-                                  : connectionProfile.status === 'connected'
-                                    ? '重新授权'
-                                    : '一键授权'}
-                            </button>
-                            {connectionProfile.status === 'connected' && !isVerifyOnly ? (
-                              <>
-                                <button
-                                  type="button"
-                                  className={styles.checkButton}
-                                  disabled={checkStates[platform.id]?.checking}
-                                  onClick={() => void handleCheckConnection(platform.id)}
-                                >
-                                  <RefreshCw size={13} />
-                                  {checkStates[platform.id]?.checking ? '检查中…' : '检查连接'}
-                                </button>
-                                <button
-                                  type="button"
-                                  className={styles.disconnectButton}
-                                  disabled={disconnectStates[platform.id]?.disconnecting}
-                                  onClick={() => void handleDisconnect(platform.id)}
-                                >
-                                  <Unplug size={13} />
-                                  {disconnectStates[platform.id]?.disconnecting
-                                    ? '处理中…'
-                                    : '断开连接'}
-                                </button>
-                              </>
-                            ) : null}
-                          </div>
-                        </div>
-                      </div>
-                    ) : (
-                      <>
-                        <div className={styles.fieldList}>
-                          {platform.fields.map((field) => (
-                            <div key={field.key} className={styles.fieldWrap}>
-                              <label htmlFor={field.key} className={styles.fieldLabel}>
-                                {field.label}
-                              </label>
-                              <div className={styles.fieldInputWrap}>
-                                {field.type === 'textarea' ? (
-                                  <textarea
-                                    id={field.key}
-                                    value={values[field.key] || ''}
-                                    onChange={(event) =>
-                                      handleChange(field.key, event.target.value)
-                                    }
-                                    placeholder={field.placeholder}
-                                    rows={4}
-                                    className={styles.fieldTextarea}
-                                  />
-                                ) : (
-                                  <input
-                                    id={field.key}
-                                    type={
-                                      field.type === 'password' && !showSecrets[field.key]
-                                        ? 'password'
-                                        : 'text'
-                                    }
-                                    value={values[field.key] || ''}
-                                    onChange={(event) =>
-                                      handleChange(field.key, event.target.value)
-                                    }
-                                    placeholder={field.placeholder}
-                                    className={styles.fieldInput}
-                                  />
-                                )}
-                                {field.type === 'password' ? (
-                                  <button
-                                    type="button"
-                                    onClick={() => toggleSecret(field.key)}
-                                    aria-label={`${showSecrets[field.key] ? '隐藏' : '显示'} ${field.label}`}
-                                    className={styles.eyeButton}
-                                  >
-                                    {showSecrets[field.key] ? (
-                                      <EyeOff size={16} />
-                                    ) : (
-                                      <Eye size={16} />
-                                    )}
-                                  </button>
-                                ) : null}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                        <p className={styles.fieldHint}>{platform.hint}</p>
-                        <div className={styles.oauthAuthorizeRow}>
-                          <button
-                            type="button"
-                            className={styles.checkButton}
-                            disabled={checkStates[platform.id]?.checking || !values['ZHIHU_COOKIE']}
-                            onClick={() => void handleCheckConnection(platform.id)}
-                          >
-                            <RefreshCw size={13} />
-                            {checkStates[platform.id]?.checking ? '验证中…' : '测试连接'}
-                          </button>
-                        </div>
-                        <CheckResult
-                          checkState={checkStates[platform.id]}
-                          connectionRecord={connectionRecords[platform.id]}
-                          disconnectDone={disconnectStates[platform.id]?.done}
-                        />
-                      </>
-                    )}
-                  </>
-                );
-              })()}
-            </div>
-          ) : selectedItem === 'agent-config' ? (
-            <div className={styles.platformDetailInner}>
-              <div className={styles.platformDetailHeader}>
-                <span className={styles.accordionIcon}>
-                  <Bot size={22} />
-                </span>
-                <div>
-                  <p className={styles.accordionTitle}>AI 连接配置</p>
-                  <p className={styles.accordionSummary}>配置 LLM 接口，启用写作辅助与平台适配</p>
-                </div>
+                        </>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
-              <div className={styles.fieldList}>
-                <div className={styles.fieldWrap}>
-                  <label htmlFor="AGENT_BASE_URL" className={styles.fieldLabel}>
-                    API Base URL
-                  </label>
-                  <div className={styles.fieldInputWrap}>
-                    <input
-                      id="AGENT_BASE_URL"
-                      type="text"
-                      value={values['AGENT_BASE_URL'] || ''}
-                      onChange={(event) => handleChange('AGENT_BASE_URL', event.target.value)}
-                      placeholder="如 https://api.openai.com/v1 或 https://api.deepseek.com"
-                      className={styles.fieldInput}
-                    />
-                  </div>
-                </div>
-                <div className={styles.fieldWrap}>
-                  <label htmlFor="AGENT_API_KEY" className={styles.fieldLabel}>
-                    API Key
-                  </label>
-                  <div className={styles.fieldInputWrap}>
-                    <input
-                      id="AGENT_API_KEY"
-                      type={showSecrets['AGENT_API_KEY'] ? 'text' : 'password'}
-                      value={values['AGENT_API_KEY'] || ''}
-                      onChange={(event) => handleChange('AGENT_API_KEY', event.target.value)}
-                      placeholder="输入 API Key"
-                      className={styles.fieldInput}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => toggleSecret('AGENT_API_KEY')}
-                      aria-label={`${showSecrets['AGENT_API_KEY'] ? '隐藏' : '显示'} API Key`}
-                      className={styles.eyeButton}
-                    >
-                      {showSecrets['AGENT_API_KEY'] ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
-                  </div>
-                </div>
-                <div className={styles.fieldWrap}>
-                  <label htmlFor="AGENT_MODEL" className={styles.fieldLabel}>
-                    模型名称
-                  </label>
-                  <div className={styles.fieldInputWrap}>
-                    <input
-                      id="AGENT_MODEL"
-                      type="text"
-                      value={values['AGENT_MODEL'] || ''}
-                      onChange={(event) => handleChange('AGENT_MODEL', event.target.value)}
-                      placeholder="如 gpt-4o-mini、deepseek-chat、qwen-plus"
-                      className={styles.fieldInput}
-                    />
-                  </div>
-                </div>
-              </div>
-              <p className={styles.fieldHint}>
-                填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写并保存后：
-              </p>
-              <ul className={styles.fieldHint} style={{ margin: '4px 0 0 16px', padding: 0 }}>
-                <li>
-                  编辑器输入 <code className={styles.inlineCode}>/</code> 查看 AI 命令
-                </li>
-                <li>发布预览面板出现「AI 适配」按钮</li>
-              </ul>
-              <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
-                <button
-                  type="button"
-                  className={styles.checkButton}
-                  onClick={handleTestAgent}
-                  disabled={agentTesting}
-                >
-                  {agentTesting ? '测试中...' : '测试连接'}
-                </button>
-                {agentTestResult && (
-                  <span
-                    className={agentTestResult.ok ? styles.checkResultOk : styles.checkResultFail}
-                  >
-                    {agentTestResult.message}
+            ) : selectedItem === 'agent-config' ? (
+              <div className={styles.platformDetailInner}>
+                <div className={styles.platformDetailHeader}>
+                  <span className={styles.accordionIcon}>
+                    <Bot size={22} />
                   </span>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className={styles.platformDetailInner}>
-              <div className={styles.platformDetailHeader}>
-                <span className={styles.accordionIcon}>
-                  <Sparkles size={22} />
-                </span>
-                <div>
-                  <p className={styles.accordionTitle}>Prompt 设置</p>
-                  <p className={styles.accordionSummary}>自定义 AI 改写和适配的提示词模板</p>
+                  <div>
+                    <p className={styles.accordionTitle}>AI 连接配置</p>
+                    <p className={styles.accordionSummary}>配置 LLM 接口，启用写作辅助与平台适配</p>
+                  </div>
+                </div>
+                <div className={styles.fieldList}>
+                  <div className={styles.fieldWrap}>
+                    <label htmlFor="AGENT_BASE_URL" className={styles.fieldLabel}>
+                      API Base URL
+                    </label>
+                    <div className={styles.fieldInputWrap}>
+                      <input
+                        id="AGENT_BASE_URL"
+                        type="text"
+                        value={values['AGENT_BASE_URL'] || ''}
+                        onChange={(event) => handleChange('AGENT_BASE_URL', event.target.value)}
+                        placeholder="如 https://api.openai.com/v1 或 https://api.deepseek.com"
+                        className={styles.fieldInput}
+                      />
+                    </div>
+                  </div>
+                  <div className={styles.fieldWrap}>
+                    <label htmlFor="AGENT_API_KEY" className={styles.fieldLabel}>
+                      API Key
+                    </label>
+                    <div className={styles.fieldInputWrap}>
+                      <input
+                        id="AGENT_API_KEY"
+                        type={showSecrets['AGENT_API_KEY'] ? 'text' : 'password'}
+                        value={values['AGENT_API_KEY'] || ''}
+                        onChange={(event) => handleChange('AGENT_API_KEY', event.target.value)}
+                        placeholder="输入 API Key"
+                        className={styles.fieldInput}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => toggleSecret('AGENT_API_KEY')}
+                        aria-label={`${showSecrets['AGENT_API_KEY'] ? '隐藏' : '显示'} API Key`}
+                        className={styles.eyeButton}
+                      >
+                        {showSecrets['AGENT_API_KEY'] ? <EyeOff size={16} /> : <Eye size={16} />}
+                      </button>
+                    </div>
+                  </div>
+                  <div className={styles.fieldWrap}>
+                    <label htmlFor="AGENT_MODEL" className={styles.fieldLabel}>
+                      模型名称
+                    </label>
+                    <div className={styles.fieldInputWrap}>
+                      <input
+                        id="AGENT_MODEL"
+                        type="text"
+                        value={values['AGENT_MODEL'] || ''}
+                        onChange={(event) => handleChange('AGENT_MODEL', event.target.value)}
+                        placeholder="如 gpt-4o-mini、deepseek-chat、qwen-plus"
+                        className={styles.fieldInput}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <p className={styles.fieldHint}>
+                  填写任意 OpenAI 兼容 API 的地址、密钥和模型名称。三项全部填写并保存后：
+                </p>
+                <ul className={styles.fieldHint} style={{ margin: '4px 0 0 16px', padding: 0 }}>
+                  <li>
+                    编辑器输入 <code className={styles.inlineCode}>/</code> 查看 AI 命令
+                  </li>
+                  <li>发布预览面板出现「AI 适配」按钮</li>
+                </ul>
+                <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <button
+                    type="button"
+                    className={styles.checkButton}
+                    onClick={handleTestAgent}
+                    disabled={agentTesting}
+                  >
+                    {agentTesting ? '测试中...' : '测试连接'}
+                  </button>
+                  {agentTestResult && (
+                    <span
+                      className={agentTestResult.ok ? styles.checkResultOk : styles.checkResultFail}
+                    >
+                      {agentTestResult.message}
+                    </span>
+                  )}
                 </div>
               </div>
-              <PromptEditor />
-            </div>
-          )}
+            ) : (
+              <div className={styles.platformDetailInner}>
+                <div className={styles.platformDetailHeader}>
+                  <span className={styles.accordionIcon}>
+                    <Sparkles size={22} />
+                  </span>
+                  <div>
+                    <p className={styles.accordionTitle}>Prompt 设置</p>
+                    <p className={styles.accordionSummary}>自定义 AI 改写和适配的提示词模板</p>
+                  </div>
+                </div>
+                <PromptEditor />
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/pages/drafts.page.css.ts
+++ b/apps/web/src/pages/drafts.page.css.ts
@@ -2,9 +2,10 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/app/styles/tokens.css';
 
 export const pageWrap = style({
+  flex: 1,
+  minHeight: 0,
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing['3xl'],
 });
 
 export const headerActions = style({

--- a/apps/web/src/pages/page.css.ts
+++ b/apps/web/src/pages/page.css.ts
@@ -3,9 +3,10 @@ import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/app/styles/tokens.css';
 
 export const pageWrap = style({
+  flex: 1,
+  minHeight: 0,
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing['2xl'],
 });
 
 export const editorLayout = style({

--- a/apps/web/src/pages/settings.css.ts
+++ b/apps/web/src/pages/settings.css.ts
@@ -3,10 +3,10 @@ import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/app/styles/tokens.css';
 
 export const pageWrap = style({
+  flex: 1,
+  minHeight: 0,
   display: 'flex',
   flexDirection: 'column',
-  gap: vars.spacing['5xl'],
-  paddingBottom: '80px',
 });
 
 // Section block
@@ -258,9 +258,6 @@ export const connectionPanel = style({
   flexDirection: 'column',
   gap: vars.spacing.xl,
   marginBottom: vars.spacing['2xl'],
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  background: vars.color.bgElevated,
   padding: vars.spacing.xl,
   '@media': {
     'screen and (min-width: 720px)': {
@@ -334,16 +331,15 @@ export const checkButton = style({
   gap: vars.spacing.sm,
   flexShrink: 0,
   borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.borderStrong}`,
-  background: vars.color.surface,
+  border: '1px solid transparent',
+  background: vars.color.accent,
   padding: `${vars.spacing.md} ${vars.spacing['lg-xl']}`,
   fontSize: vars.fontSize.sm,
   fontWeight: 500,
-  color: vars.color.text,
-  transition: 'border-color 150ms, background-color 150ms',
+  color: vars.color.surfaceDarkText,
+  transition: 'filter 150ms',
   ':hover': {
-    borderColor: vars.color.accent,
-    background: vars.color.accentSoft,
+    filter: 'brightness(1.05)',
   },
   ':disabled': {
     opacity: 0.5,
@@ -596,10 +592,8 @@ export const platformLayout = style({
   gap: vars.spacing['2xl'],
   '@media': {
     'screen and (min-width: 1024px)': {
-      marginTop: vars.spacing['3xl'],
-      // 各 tab 内容高度不一，切换时若页面变矮会触发浏览器钳制滚动导致跳动。
-      // 用 minHeight 填满 header+tabs 下方视口，保证页面高度稳定，切换不改变滚动位置。
-      minHeight: 'calc(100dvh - 220px)',
+      // 容器滚动后切 tab 不再触发 window 滚动钳制跳动，移除原 minHeight hack。
+      minHeight: '100%',
     },
   },
 });
@@ -625,10 +619,13 @@ export const platformDetailHeader = style({
 });
 
 // Mobile platform tabs (horizontal, <1024px only)
+// 留在固定区（scrollArea 之前），紧贴 header 下方；自带内边距与正文对齐。
 export const platformMobileTabs = style({
   display: 'inline-flex',
+  flexShrink: 0,
   alignSelf: 'flex-start',
   maxWidth: '100%',
+  margin: `${vars.spacing.sm} ${vars.spacing.xl} 0`,
   gap: vars.spacing['2xs'],
   overflowX: 'auto',
   padding: vars.spacing.xs,
@@ -638,6 +635,9 @@ export const platformMobileTabs = style({
   backdropFilter: 'blur(16px) saturate(180%)',
   WebkitBackdropFilter: 'blur(16px) saturate(180%)',
   '@media': {
+    'screen and (min-width: 640px)': {
+      margin: `${vars.spacing.md} ${vars.spacing['3xl']} 0`,
+    },
     'screen and (min-width: 1024px)': {
       display: 'none',
     },
@@ -683,20 +683,12 @@ export const topTabsBar = style({
   '@media': {
     'screen and (min-width: 1024px)': {
       display: 'flex',
-      // 贴紧 header 下方并始终悬浮（sticky）。top = header 高度，使其紧贴 header 底部
-      position: 'sticky',
-      top: '83px',
-      zIndex: 30,
+      // 容器滚动后，topTabsBar 留在固定区（scrollArea 之前），自然紧贴 header 下方。
+      flexShrink: 0,
       alignItems: 'flex-end',
       gap: vars.spacing.xs,
-      // 抵消 header marginBottom(24) + pageWrap gap(40)，让 tab 紧贴 header
-      marginTop: '-64px',
-      // 全宽出血到页面边缘（与 header 一致），内容靠 padding 内缩与正文对齐
-      marginLeft: '-36px',
-      marginRight: '-36px',
       padding: `${vars.spacing.md} 36px 0`,
       background: 'transparent',
-      borderBottom: `1px solid ${vars.color.borderFaint}`,
       overflowX: 'auto',
     },
   },

--- a/docs/plans/2026-06-18-manual-save-design.md
+++ b/docs/plans/2026-06-18-manual-save-design.md
@@ -1,0 +1,104 @@
+# 写作台手动保存改造计划
+
+日期：2026-06-18
+
+## 背景
+
+写作台当前完全依赖自动保存（`useAutoSave` hook，停止输入 1s 防抖触发）。用户要求：
+
+1. **删除全部自动保存逻辑**。
+2. **加手动保存按钮**。
+3. **页面被关掉或崩溃前**，若当前版本未被保存，触发兜底保存。
+
+## 目标结构
+
+新建 `useManualSave` hook 替代 `useAutoSave`，对外暴露手动 `save()`、`saveStatus`、`isDirty`；内部管理 dirty 标志 + 注册 unload 类事件监听做兜底保存。UI 在 header 加保存按钮，复用 Cmd/Ctrl+S 快捷键（MarkdownEditor 已内置）。
+
+## 改动清单
+
+### 1. 新建 `apps/web/src/hooks/useManualSave.ts`
+
+替代 `useAutoSave`。对外接口：
+
+```ts
+interface UseManualSaveOptions {
+  title: string;
+  content: string;
+  draftId: string | null;
+  onDraftCreated: (id: string) => void;
+}
+interface UseManualSaveResult {
+  saveStatus: SaveStatus; // 'idle' | 'saving' | 'saved' | 'error'
+  isDirty: boolean;
+  save: () => Promise<void>;
+}
+```
+
+核心逻辑：
+
+- **dirty 判断**：维护 `lastSavedRef = { title, content }`。title/content 任一与快照不同 → `isDirty = true`；成功保存后更新快照、`isDirty = false`。初始（无草稿）快照为空串 → 非空输入即 dirty；通过 `draftId` 载入草稿后，把快照设为载入值（载入即"已保存"态，不误判）。
+- **手动 `save()`**：沿用旧保存流程——有 `draftId` → `PATCH /api/drafts/:id`；无 → `POST /api/drafts` 创建（首次保存创建草稿，标题和内容须都非空，沿用旧保护逻辑）。保存成功后更新快照 + `isDirty=false` + `saveStatus='saved'`；失败 → `saveStatus='error'` + Toast 提示。
+- **空内容保护**：标题和内容都为空时，`save()` 直接返回（避免空草稿垃圾）。
+
+### 2. 兜底保存（beforeunload + visibilitychange）
+
+在 hook 内用 `useEffect` 注册两个事件监听，依赖 `isDirty` 与最新内容的 ref：
+
+- `beforeunload`：页面刷新/关闭/跳转时，若 `isDirty` 触发兜底保存。
+- `visibilitychange`（切到 `hidden`）：覆盖移动端切后台、标签页隐藏、部分崩溃场景，若 `isDirty` 触发兜底保存。
+
+**关键技术点**：unload 时普通 async fetch 会被浏览器中断。兜底保存用 **`fetch(url, { keepalive: true })`**——`keepalive` 标志让请求在页面卸载后仍由浏览器发出，且支持 PATCH 与自定义 headers（比 `sendBeacon` 更适合，后者仅支持 POST、无法带 JSON body 以 PATCH 语义更新）。
+
+兜底保存内部复用一个 `flushSave()`：
+
+- 读取 title/content/draftId 的最新 ref（同步）。
+- 空内容跳过。
+- 已无 dirty 跳过（兜底成功后立即置 `isDirty=false`，避免 beforeunload 与 visibilitychange 重复发请求）。
+- 选 endpoint + method：有 draftId → PATCH；无 → POST。
+- `fetch(url, { method, headers, body, keepalive: true })`。不 await（unload 期间无法等），不更新 React 状态（组件即将卸载/已卸载）。
+
+### 3. 删除 `apps/web/src/hooks/useAutoSave.ts`
+
+整体删除。确认无其他引用（Home.tsx 之外应无）。
+
+### 4. `apps/web/src/pages/Home.tsx`
+
+- import 从 `useAutoSave` 改为 `useManualSave`。
+- 解构改为 `{ saveStatus, isDirty, save }`（原 `{ saveStatus, triggerSave }`）。
+- 把传给 `<MarkdownEditor onSave={...}>` 的回调改为 `save`（Cmd/Ctrl+S 快捷键通道不变）。
+- header 的 `action` 区域加**保存按钮**：复用项目内已有的主按钮视觉（黑底白字，与设置页 `saveButton` / "测试连接"一致）。`disabled={!isDirty}`，点击调 `save()`。按钮内文案：saving 时"保存中…"，否则"保存"。
+- 移除原 `saveStatusHint`（"保存中…/已自动保存"）——状态由按钮自身反映。
+
+### 5. `apps/web/src/pages/page.css.ts`
+
+- 新增 `saveButton` 样式（黑底白字主按钮，参考 settings.css.ts 的 `saveButton`：`background: accent`、`color: surfaceDarkText`、`borderRadius: lg`、hover `brightness(1.05)`、disabled `opacity:0.5`）。
+- 若 `saveStatusHint` 样式不再被任何地方引用则删除（grep 确认）。
+
+## 不改动
+
+- API 端点（`/api/drafts` POST、`/api/drafts/:id` PATCH）。
+- `lib/drafts/client.ts` 的 `ensureDraft` / `updateDraft`。
+- MarkdownEditor 的 `onSave` prop 接口（已接好 Cmd+S）。
+- 草稿载入流程（通过 `draftId` 从 API 读取并 `setTitle`/`setContent`）。
+
+## 关键复用 / 注意
+
+- **快照同步**：title/content 是受控状态，载入草稿的 effect 里 `setTitle`/`setContent` 后，需同步更新 `lastSavedRef`，否则载入后立即被判为 dirty。实现方式：载入 effect 内 `setTitle/setContent` 成功后，把 ref 置为载入值；或用一个 `loadedDraftIdRef` 标记，在快照比较时跳过本次。推荐前者，直观。
+- **事件去重**：visibilitychange 与 beforeunload 可能连续触发（手机端切后台再关闭）。`flushSave` 成功后立即把 dirty ref 置 false，后续事件读到非 dirty 即跳过。
+- **移动端 visibilitychange 误触发**：切到其他 app 再回来会触发 hidden→visible，hidden 时已兜底保存（置 dirty=false），回来继续编辑会重新变 dirty，属正常行为，不会丢失数据。
+- **keepalive 体积限制**：浏览器对 keepalive 请求 body 有 64KB 限制。草稿是 Markdown 文本，正常远小于此；超大草稿（如粘贴巨量内容）可能被截断——属可接受边界情况，手动保存走正常 fetch 不受限。
+- **状态显示**：按钮文案区分 saving/saved，但兜底保存（unload 期间）不更新 React 状态（组件即将消失），用户看不到——这是预期行为，兜底只为防丢失。
+
+## 验证
+
+1. `pnpm lint` + `pnpm test`（如有相关测试）。
+2. `pnpm build`（tsc + vite 通过）。
+3. `pnpm dev`，写作台手动测试：
+   - 输入内容 → 按钮变为可点（dirty）；**停止输入不再自动保存**。
+   - 点"保存" / 按 Cmd+S → 状态变"保存中…"→"保存"；刷新后草稿仍在。
+   - 首次保存（无 draftId）→ POST 创建草稿，URL 变 `/?draftId=xxx`。
+   - 载入已有草稿（`/?draftId=xxx`）→ 进入时不误判 dirty。
+   - 改动后不保存，直接刷新/关闭 → beforeunload 触发兜底保存，重开仍在（DevTools Network 可见 keepalive 请求）。
+   - 改动后切到其他标签页/最小化 → visibilitychange 触发兜底保存。
+   - 空内容（标题和正文都空）→ 按钮禁用/保存跳过。
+4. 移动端视口（DevTools）验证 visibilitychange 兜底。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
         specifier: ^5.0.0
         version: 5.2.2(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(yaml@2.8.4)
       '@vitejs/plugin-react':
-        specifier: ^5.0.0
+        specifier: ^5.2.0
         version: 5.2.0(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       typescript:
         specifier: ^5.6.0
@@ -211,16 +211,8 @@ packages:
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -234,11 +226,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -277,10 +264,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -2579,11 +2562,7 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -2593,10 +2572,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -2638,11 +2613,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -2970,24 +2940,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:


### PR DESCRIPTION
## Summary

This PR contains 4 independent commits, organized by semantic boundaries — each can be reviewed / reverted on its own.

## Changes

### 1. fix(web): resolve blank page (`ae4af4b`)
- **Root cause**: Under the current environment, vite 8 + `@vitejs/plugin-react` fails to inject the React Fast Refresh preamble via `transformIndexHtml`. This leaves the `$RefreshSig$` / `$RefreshReg$` globals undefined (which the component transform emits), causing the entire React tree to fail mounting → blank page.
- **Fix**: Manually inject the React Fast Refresh preamble in `index.html` (loads the `/@react-refresh` runtime and sets up global hooks), executed before `main.tsx`. In production builds the runtime doesn't exist, so the script fails silently without blocking.
- Pinned `@vitejs/plugin-react` from `^5.0.0` to `^5.2.0`.
- **This bug also exists on the original `main` branch** (introduced by the Next.js → Vite migration), not by any other change in this PR.

### 2. refactor(layout): fixed header + container scroll + divider alignment (`b665f40`)
- Switched all three pages (writing desk / drafts / settings) from window scrolling to **container scrolling**, fixing the issue where content visually bled through the transparent header while scrolling.
- `main` becomes a fixed-height flex column (`100dvh` + `overflow:hidden`), with a new shared `scrollArea`.
- Header drops `sticky` / `zIndex` / negative `margin` in favor of `flexShrink:0`.
- Header bottom divider switched from `borderBottom` to an `::after` pseudo-element, inset horizontally to align with the title text.

### 3. refactor(ui): flatten cards, simplify settings, unify button style (`a2d5acf`)
- **Flattened cards** (removed background / border / border-radius): settings `connectionPanel`, drafts `statePanel` and friends, shared `EmptyState` / `ErrorState`. The writing desk publish cards keep their original styling; status-color cards (error/success/warning) are kept; overlay components are kept.
- **Settings page simplification**: removed `platformDetailHeader` (the tab bar already shows platform name + status, avoiding duplication); added `title` attributes to tab items so hovering shows summary + status + account name; changed the "test connection" button to a black-on-white style matching the primary button; removed the topTabsBar bottom divider.
- **Drafts list**: `compactRow` divider switched to a pseudo-element aligned with the text; kept the border-radius.

### 4. docs(plans): manual save design doc (`b200a36`)
- Design document for refactoring writing desk draft saving (manual save button + save-on-close/crash fallback). Not yet implemented.

## Verification

- [x] `pnpm build` (tsc + vite) passes
- [x] `pnpm dev` browser-tested: all three pages render correctly, header stays fixed while scrolling, dividers align
- [ ] CI status checks (pending)

## Not committed

`.next/` and `next-env.d.ts` are legacy Next.js artifacts (the project has migrated to Vite) and were intentionally left out. They should be cleaned up separately or added to `.gitignore` later.