### PR TITLE
style(write): refine desk visual hierarchy, toolbar and stats

### DIFF
--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -234,13 +234,28 @@ export default function MarkdownEditor({
         {/* 底部数据栏 */}
         <div className={styles.statsBar}>
           <div className={styles.statsRow}>
-            <span>{countCharacters(cleanContent)} 字符</span>
+            <span>
+              <span className={styles.statsValue}>{countCharacters(cleanContent)}</span>{' '}
+              <span className={styles.statsUnit}>字符</span>
+            </span>
             <span className={styles.statsDot}>·</span>
-            <span>{countParagraphs(cleanContent)} 段落</span>
+            <span>
+              <span className={styles.statsValue}>{countParagraphs(cleanContent)}</span>{' '}
+              <span className={styles.statsUnit}>段落</span>
+            </span>
             <span className={styles.statsDot}>·</span>
-            <span>{countHeadings(cleanContent)} 标题</span>
+            <span>
+              <span className={styles.statsValue}>{countHeadings(cleanContent)}</span>{' '}
+              <span className={styles.statsUnit}>标题</span>
+            </span>
             <span className={styles.statsDot}>·</span>
-            <span>约 {cleanContent ? estimateReadTime(cleanContent) : '1 分钟'} 阅读</span>
+            <span>
+              <span className={styles.statsUnit}>约</span>{' '}
+              <span className={styles.statsValue}>
+                {cleanContent ? estimateReadTime(cleanContent) : '1 分钟'}
+              </span>{' '}
+              <span className={styles.statsUnit}>阅读</span>
+            </span>
             <button
               type="button"
               onClick={immersive.enter}

--- a/apps/web/src/components/editor/editor.css.ts
+++ b/apps/web/src/components/editor/editor.css.ts
@@ -69,16 +69,18 @@ globalStyle(`${editorWrap} .w-md-editor:focus-within`, {
 globalStyle(`${editorWrap} .w-md-editor-toolbar`, {
   borderTop: `1px solid ${vars.color.borderFaint}`,
   borderBottom: `1px solid ${vars.color.borderFaint}`,
-  background: vars.color.surface,
+  background: vars.color.surfaceStrong,
   padding: `${vars.spacing.sm} ${vars.spacing.lg}`,
 });
 
 globalStyle(`${editorWrap} .w-md-editor-toolbar button`, {
   color: vars.color.textMuted,
+  borderRadius: vars.radius.xs,
+  padding: `${vars.spacing.xs} ${vars.spacing.sm}`,
 });
 
 globalStyle(`${editorWrap} .w-md-editor-toolbar button:hover`, {
-  background: vars.color.bgElevated,
+  background: vars.color.accentSoft,
   color: vars.color.text,
 });
 
@@ -167,6 +169,16 @@ export const statsRow = style({
 
 export const statsDot = style({
   color: vars.color.borderStrong,
+});
+
+// 统计栏：数字用主色提对比，单位保持弱化，改善暗色下 11px 文字可读性
+export const statsValue = style({
+  color: vars.color.text,
+  fontWeight: 500,
+});
+
+export const statsUnit = style({
+  color: vars.color.textMuted,
 });
 
 // Preview area — 容器零内边距，使 frame 与写作态编辑卡同位置同尺寸

--- a/apps/web/src/pages/page.css.ts
+++ b/apps/web/src/pages/page.css.ts
@@ -31,13 +31,15 @@ export const editorSection = style({
   gap: vars.spacing.xl,
 });
 
-// 发布区：编辑器下方，主稿宽度内居中收窄
+// 发布区：编辑器下方配角卡，elevation(shadow.sm) 弱于 editorCard(shadow.md) 以建立主次
 export const publishPanel = style({
   display: 'flex',
   flexDirection: 'column',
   gap: vars.spacing.xl,
   borderRadius: vars.radius.xl,
   background: vars.color.surface,
+  border: `1px solid ${vars.color.border}`,
+  boxShadow: vars.shadow.sm,
   padding: vars.spacing.xl,
   '@media': {
     'screen and (min-width: 640px)': {
@@ -60,14 +62,18 @@ export const editorCard = recipe({
     outline: 'none',
     borderRadius: vars.radius.xl,
     background: vars.color.surface,
+    border: `1px solid ${vars.color.border}`,
+    boxShadow: vars.shadow.md,
   },
   variants: {
-    // 预览态去掉卡底色/圆角，让 phone frame 直接浮在页面背景上，消除卡中卡
+    // 预览态去掉卡底色/圆角/边框/阴影，让 phone frame 直接浮在页面背景上，消除卡中卡
     preview: {
       true: {
         overflow: 'visible',
         borderRadius: 0,
         background: 'transparent',
+        border: 'none',
+        boxShadow: 'none',
       },
     },
   },
@@ -184,7 +190,7 @@ export const newDraftButton = style({
   height: 38,
   borderRadius: vars.radius.md,
   border: `1px solid ${vars.color.border}`,
-  background: 'transparent',
+  background: vars.color.bgElevated,
   padding: `0 ${vars.spacing['md-lg']}`,
   fontSize: vars.fontSize.sm,
   color: vars.color.textMuted,


### PR DESCRIPTION
## What
Refines the writing desk (写作台) UI for clearer visual hierarchy while staying within the existing design tokens — no new colors/shadows/radii, no layout structure changes.

## Changes
- **Card hierarchy** (`page.css.ts`): `editorCard` gets `border + shadow.md` (primary), `publishPanel` gets `border + shadow.sm` (secondary). The preview variant explicitly clears border/shadow so the phone-frame mockup stays transparent.
- **Editor toolbar** (`editor.css.ts`): `surfaceStrong` background, rounded buttons with padding, `accentSoft` hover — aligns the third-party `@uiw/react-md-editor` toolbar with the desk's design language.
- **Header controls** (`page.css.ts`): `newDraftButton` background aligned with `tabSwitcher`; `saveButton` left as-is (matches Settings primary button, cross-page consistency).
- **Stats bar** (`editor.css.ts` + `MarkdownEditor.tsx`): split value/unit spans so numbers use `text` and units use `textMuted`, improving dark-mode legibility.

## Why
The desk looked flat/gray on dark theme — cards had no border/shadow, so `surface #141414` merged into `bg #0A0A0A`; the editor toolbar felt like a pasted-in third-party widget; and the publish panel competed with the editor for focus. The global `main` 920px max-width ruled out a two-column layout without touching global layout, so this keeps it single-column and uses elevation to re-establish primary/secondary focus.

## Verification
- `pnpm lint` + `pnpm build` pass.
- Screenshot-checked dark + light edit modes, and dark preview mode: cards now lift with clear hierarchy, toolbar is unified, stats are legible, and the phone-frame mockup renders clean (no residual border/shadow).
- No layout/breakpoint changes — all pure visual token references.

## Out of scope
- Two-column layout (editor + publish sidebar) — blocked by the global `main` 920px max-width; left as a separate decision.