### PR TITLE
fix(write): prevent editor flash on save

### DIFF
--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -1,8 +1,7 @@
 import '@uiw/react-md-editor/markdown-editor.css';
 import type { ICommand } from '@uiw/react-md-editor';
-import { lazy, Suspense, useEffect, useRef, useState, useCallback } from 'react';
-import { Maximize2, Minimize2, Save } from 'lucide-react';
-import type { SaveStatus } from '@/hooks/useManualSave';
+import { lazy, memo, Suspense, useEffect, useRef, useState, useCallback } from 'react';
+import { Maximize2, Minimize2 } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
 import { markdownToHtml } from '@/lib/markdown';
 import {
@@ -18,6 +17,7 @@ import { useImmersiveMode } from '@/hooks/useImmersiveMode';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import SlashCommandMenu from './SlashCommandMenu';
 import EditorModeToggle from './EditorModeToggle';
+import SaveButton from './SaveButton';
 import * as styles from './editor.css';
 
 const MDEditor = lazy(() => import('@uiw/react-md-editor'));
@@ -30,18 +30,16 @@ interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';
   onSave?: () => Promise<void>;
   agentEnabled?: boolean;
-  saveStatus?: SaveStatus;
-  canSave?: boolean;
 }
 
-export default function MarkdownEditor({
-  activeTab,
-  onSave,
-  agentEnabled = false,
-  saveStatus = 'idle',
-  canSave = false,
-}: MarkdownEditorProps) {
-  const { title, setTitle, content, setContent, setActiveTab, editorMode } = usePublishStore();
+function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEditorProps) {
+  // 用 selector 订阅，避免 currentDraftId 等无关字段变化触发重渲染。
+  const title = usePublishStore((s) => s.title);
+  const setTitle = usePublishStore((s) => s.setTitle);
+  const content = usePublishStore((s) => s.content);
+  const setContent = usePublishStore((s) => s.setContent);
+  const setActiveTab = usePublishStore((s) => s.setActiveTab);
+  const editorMode = usePublishStore((s) => s.editorMode);
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -107,16 +105,19 @@ export default function MarkdownEditor({
   }, [slash]);
 
   const lastContentForSlashRef = useRef(content);
-  const handleContentChange = (val?: string) => {
-    const newValue = val || '';
-    setContent(newValue);
-    // 仅当内容确实由用户输入变化时检测 slash command
-    if (newValue !== lastContentForSlashRef.current) {
-      lastContentForSlashRef.current = newValue;
-      // 简单检测：如果新内容比旧内容多且包含 /，触发 slash 检测
-      slash.onTextChange(newValue, newValue.length);
-    }
-  };
+  const handleContentChange = useCallback(
+    (val?: string) => {
+      const newValue = val || '';
+      setContent(newValue);
+      // 仅当内容确实由用户输入变化时检测 slash command
+      if (newValue !== lastContentForSlashRef.current) {
+        lastContentForSlashRef.current = newValue;
+        // 简单检测：如果新内容比旧内容多且包含 /，触发 slash 检测
+        slash.onTextChange(newValue, newValue.length);
+      }
+    },
+    [setContent, slash],
+  );
 
   const handleImageUpload = useCallback(
     async (file: File) => {
@@ -178,16 +179,7 @@ export default function MarkdownEditor({
             placeholder="给文章起个标题"
             className={styles.titleInput}
           />
-          <button
-            type="button"
-            className={styles.editorSaveBtn}
-            onClick={() => void onSave?.()}
-            disabled={!canSave || saveStatus === 'saving'}
-            title="保存草稿 (Ctrl+S)"
-          >
-            <Save size={13} />
-            {saveStatus === 'saving' ? '保存中…' : '保存'}
-          </button>
+          <SaveButton onSave={onSave} />
         </div>
 
         {/* 正文编辑区 */}
@@ -372,3 +364,5 @@ export default function MarkdownEditor({
     </div>
   );
 }
+
+export default memo(MarkdownEditor);

--- a/apps/web/src/components/editor/SaveButton.tsx
+++ b/apps/web/src/components/editor/SaveButton.tsx
@@ -1,0 +1,33 @@
+import { Save } from 'lucide-react';
+import { useSaveStatusStore } from '@/stores/saveStatusStore';
+import { usePublishStore } from '@/stores/publishStore';
+import * as styles from './editor.css';
+
+interface SaveButtonProps {
+  onSave?: () => Promise<void> | void;
+}
+
+/**
+ * 保存按钮：自行订阅保存状态 store（saveStatus/isDirty），状态变化只重渲染
+ * 本按钮，不会连带重渲染整棵编辑器（MDEditor）导致正文瞬间空白。
+ */
+export default function SaveButton({ onSave }: SaveButtonProps) {
+  const saveStatus = useSaveStatusStore((s) => s.saveStatus);
+  const isDirty = useSaveStatusStore((s) => s.isDirty);
+  const title = usePublishStore((s) => s.title);
+  const content = usePublishStore((s) => s.content);
+  const canSave = isDirty && !!title.trim() && !!content.trim();
+
+  return (
+    <button
+      type="button"
+      className={styles.editorSaveBtn}
+      onClick={() => void onSave?.()}
+      disabled={!canSave || saveStatus === 'saving'}
+      title="保存草稿 (Ctrl+S)"
+    >
+      <Save size={13} />
+      {saveStatus === 'saving' ? '保存中…' : '保存'}
+    </button>
+  );
+}

--- a/apps/web/src/hooks/useManualSave.ts
+++ b/apps/web/src/hooks/useManualSave.ts
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { updateDraft, ensureDraft } from '@/lib/drafts/client';
 import { useToastStore } from '@/stores/toastStore';
-
-export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+import { useSaveStatusStore } from '@/stores/saveStatusStore';
 
 interface UseManualSaveOptions {
   title: string;
@@ -12,17 +11,14 @@ interface UseManualSaveOptions {
 }
 
 interface UseManualSaveResult {
-  saveStatus: SaveStatus;
-  isDirty: boolean;
-  /** 是否允许保存：dirty 且标题与内容都非空。 */
-  canSave: boolean;
   save: () => Promise<void>;
   /** 载入草稿后调用，把快照同步为载入值，避免载入即误判 dirty。 */
   syncSnapshot: (snapshot: { title: string; content: string }) => void;
 }
 
 /**
- * 写作台手动保存 + 兜底保存。
+ * 写作台手动保存 + 兜底保存。保存状态（saveStatus/isDirty）写入独立的
+ * useSaveStatusStore，由保存按钮组件自行订阅，避免保存时整棵编辑器重渲染。
  *
  * - 手动保存：`save()` 走正常 fetch（有 draftId → PATCH；无 → POST 创建）。
  * - 兜底保存：页面 beforeunload / 切到后台（visibilitychange）时，若 dirty
@@ -36,8 +32,6 @@ export function useManualSave({
   draftId,
   onDraftCreated,
 }: UseManualSaveOptions): UseManualSaveResult {
-  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
-
   // 最新值与快照都放 ref，事件监听器读最新值，无需重建监听器。
   const titleRef = useRef(title);
   const contentRef = useRef(content);
@@ -47,9 +41,8 @@ export function useManualSave({
     title,
     content,
   });
-  // dirty 用 ref 存，避免事件回调闭包陈旧；同时镜像到 state 供 UI 渲染。
+  // dirty 用 ref 存，避免事件回调闭包陈旧；UI 侧通过 store 订阅。
   const dirtyRef = useRef(false);
-  const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     titleRef.current = title;
@@ -64,11 +57,12 @@ export function useManualSave({
     onDraftCreatedRef.current = onDraftCreated;
   }, [onDraftCreated]);
 
-  // title/content 变化 → 比对快照 → 更新 dirty。
+  // title/content 变化 → 比对快照 → 更新 dirty（写入 store）。
   useEffect(() => {
     const changed =
       title !== lastSavedRef.current.title || content !== lastSavedRef.current.content;
     dirtyRef.current = changed;
+    const { setIsDirty, setSaveStatus } = useSaveStatusStore.getState();
     setIsDirty(changed);
     // 进入编辑即清除"已保存"提示，避免误导。
     if (changed) setSaveStatus('idle');
@@ -78,6 +72,7 @@ export function useManualSave({
   const syncSnapshot = useCallback((snapshot: { title: string; content: string }) => {
     lastSavedRef.current = snapshot;
     dirtyRef.current = false;
+    const { setIsDirty, setSaveStatus } = useSaveStatusStore.getState();
     setIsDirty(false);
     setSaveStatus('idle');
   }, []);
@@ -89,6 +84,7 @@ export function useManualSave({
       content: contentRef.current,
     };
     dirtyRef.current = false;
+    const { setIsDirty, setSaveStatus } = useSaveStatusStore.getState();
     setIsDirty(false);
     setSaveStatus('saved');
   }, []);
@@ -101,7 +97,7 @@ export function useManualSave({
     // 空校验：标题与内容必须都非空才保存（收紧：任一为空即跳过）。
     if (!currentTitle.trim() || !currentContent.trim()) return;
 
-    setSaveStatus('saving');
+    useSaveStatusStore.getState().setSaveStatus('saving');
     try {
       if (draftIdRef.current) {
         await updateDraft(draftIdRef.current, {
@@ -119,7 +115,7 @@ export function useManualSave({
       markSaved();
       useToastStore.getState().addToast('success', '草稿已保存');
     } catch {
-      setSaveStatus('error');
+      useSaveStatusStore.getState().setSaveStatus('error');
       useToastStore.getState().addToast('error', '草稿保存失败，请检查网络后重试');
     }
   }, [markSaved]);
@@ -166,9 +162,6 @@ export function useManualSave({
   }, [flushSave]);
 
   return {
-    saveStatus,
-    isDirty,
-    canSave: isDirty && !!title.trim() && !!content.trim(),
     save,
     syncSnapshot,
   };

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -267,7 +267,11 @@ function HomePageContent() {
                 <MarkdownEditor activeTab={activeTab} onSave={save} agentEnabled={agentEnabled} />
               </div>
 
-              {agentStatus !== 'idle' && <AgentPanel />}
+              {agentStatus !== 'idle' && (
+                <Suspense fallback={null}>
+                  <AgentPanel />
+                </Suspense>
+              )}
 
               {/* 发布区：编辑区下方 */}
               <div className={styles.publishPanel}>
@@ -291,7 +295,9 @@ function HomePageContent() {
           </div>
         </div>
       </div>
-      <PublishProgressOverlay />
+      <Suspense fallback={null}>
+        <PublishProgressOverlay />
+      </Suspense>
 
       {/* Clear confirm modal */}
       {clearConfirming && (

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -94,7 +94,7 @@ function HomePageContent() {
     [setCurrentDraftId, navigate],
   );
 
-  const { saveStatus, canSave, save, syncSnapshot } = useManualSave({
+  const { save, syncSnapshot } = useManualSave({
     title,
     content,
     draftId: currentDraftId,
@@ -264,13 +264,7 @@ function HomePageContent() {
               </div>
 
               <div className={styles.editorCard({ preview: activeTab === 'preview' })}>
-                <MarkdownEditor
-                  activeTab={activeTab}
-                  onSave={save}
-                  agentEnabled={agentEnabled}
-                  saveStatus={saveStatus}
-                  canSave={canSave}
-                />
+                <MarkdownEditor activeTab={activeTab} onSave={save} agentEnabled={agentEnabled} />
               </div>
 
               {agentStatus !== 'idle' && <AgentPanel />}
@@ -284,10 +278,12 @@ function HomePageContent() {
                 {currentDraftId && (
                   <div className={publishStyles.rightPanelSection}>
                     <span className={publishStyles.rightPanelSectionTitle}>渠道版本</span>
-                    <PlatformVariantPanel
-                      selectedPlatforms={selectedPlatforms}
-                      agentEnabled={agentEnabled}
-                    />
+                    <Suspense fallback={null}>
+                      <PlatformVariantPanel
+                        selectedPlatforms={selectedPlatforms}
+                        agentEnabled={agentEnabled}
+                      />
+                    </Suspense>
                   </div>
                 )}
               </div>

--- a/apps/web/src/stores/saveStatusStore.ts
+++ b/apps/web/src/stores/saveStatusStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+interface SaveStatusState {
+  saveStatus: SaveStatus;
+  isDirty: boolean;
+  setSaveStatus: (status: SaveStatus) => void;
+  setIsDirty: (dirty: boolean) => void;
+}
+
+/**
+ * 保存状态独立 store：保存按钮组件自行订阅，避免保存时整棵编辑器
+ * （含 MDEditor）跟着重渲染导致正文瞬间空白。
+ */
+export const useSaveStatusStore = create<SaveStatusState>((set) => ({
+  saveStatus: 'idle',
+  isDirty: false,
+  setSaveStatus: (saveStatus) => set({ saveStatus }),
+  setIsDirty: (isDirty) => set({ isDirty }),
+}));


### PR DESCRIPTION
## Problem
Saving caused the editor to visually flash — the whole editor card went blank for a frame.

## Root cause
`PlatformVariantPanel` is lazy-loaded but had **no Suspense boundary**. On first save, `currentDraftId` flips null → id and the panel mounts; its lazy load suspends and bubbles up to the top-level Suspense, which falls the **whole page (including the editor)** back to empty for a frame.

## Fix
- Wrap `PlatformVariantPanel` in `<Suspense fallback={null}>` so its lazy load suspends locally instead of blanking the page. (the actual root cause)
- Move save status (`saveStatus`/`isDirty`) into a dedicated store; `SaveButton` subscribes directly so saving re-renders only the button, not the whole editor (MDEditor).
- `React.memo(MarkdownEditor)` + selector-based store subscription so unrelated store fields don't re-render the editor.

## Verification
- `pnpm lint` + `pnpm build` pass.
- CDP diagnostic: across save the editor DOM stays stable (no `.wmde-markdown-color` remount) and the mid-save screenshot no longer goes blank (was ~412KB empty frame, now ~626KB = same as before/after save).