### PR TITLE
feat(write): soft length limit with live counter

### DIFF
--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -106,7 +106,9 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const lastContentForSlashRef = useRef(content);
   const handleContentChange = useCallback(
-    (val?: string) => {
+    (val?: string, event?: React.ChangeEvent<HTMLTextAreaElement>) => {
+      // IME 合成中（拼音未确认）不计入，等选词确认后再更新
+      if ((event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing) return;
       const newValue = val || '';
       setContent(newValue);
       // 仅当内容确实由用户输入变化时检测 slash command
@@ -241,7 +243,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             <textarea
               ref={textareaRef}
               value={content}
-              onChange={(e) => handleContentChange(e.target.value)}
+              onChange={(e) => handleContentChange(e.target.value, e)}
               placeholder="开始写作，支持 Markdown 语法..."
               className={styles.mobileTextarea}
             />

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -109,11 +109,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const lastContentForSlashRef = useRef(content);
   const handleContentChange = useCallback(
-    (val?: string, event?: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // 记录 IME 合成状态：合成中不更新统计用的 confirmedContent（由下面的 effect 同步）
-      isComposingRef.current =
-        (event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing ??
-        isComposingRef.current;
+    (val?: string) => {
       const newValue = val || '';
       setContent(newValue);
       // 仅当内容确实由用户输入变化时检测 slash command
@@ -202,6 +198,15 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           onPaste={handlePaste}
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false;
+            // 合成结束直接读 textarea 最终文本同步统计，避免依赖后续 onChange
+            const ta = editorWrapRef.current?.querySelector<HTMLTextAreaElement>('textarea');
+            if (ta) setConfirmedContent(ta.value);
+          }}
           onClick={(e) => {
             const target = e.target as HTMLElement;
             if (target.closest('.w-md-editor-toolbar')) return;
@@ -254,7 +259,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             <textarea
               ref={textareaRef}
               value={content}
-              onChange={(e) => handleContentChange(e.target.value, e)}
+              onChange={(e) => handleContentChange(e.target.value)}
               placeholder="开始写作，支持 Markdown 语法..."
               className={styles.mobileTextarea}
             />

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -9,6 +9,8 @@ import {
   countParagraphs,
   countHeadings,
   estimateReadTime,
+  TITLE_LIMIT,
+  CONTENT_LIMIT,
 } from '@/lib/contentStats';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
 import { useAgentStream } from '@/hooks/useAgentStream';
@@ -25,10 +27,6 @@ const MDEditor = lazy(() => import('@uiw/react-md-editor'));
 // 隐藏 md-editor 自带的视图模式按钮（编辑/实时/预览），视图切换统一走「源码/实时」toggle
 const stripEditorModeCommands = (_cmd: ICommand, isExtra: boolean): false | ICommand =>
   isExtra ? false : _cmd;
-
-// 草稿长度上限（软提示，超出标红不阻断）。对齐微信公众号最宽限制。
-const TITLE_LIMIT = 64;
-const CONTENT_LIMIT = 20000;
 
 interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -26,6 +26,10 @@ const MDEditor = lazy(() => import('@uiw/react-md-editor'));
 const stripEditorModeCommands = (_cmd: ICommand, isExtra: boolean): false | ICommand =>
   isExtra ? false : _cmd;
 
+// 草稿长度上限（软提示，超出标红不阻断）。对齐微信公众号最宽限制。
+const TITLE_LIMIT = 64;
+const CONTENT_LIMIT = 20000;
+
 interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';
   onSave?: () => Promise<void>;
@@ -173,6 +177,10 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const cleanContent = content.trim();
   const cleanConfirmed = confirmedContent.trim();
+  const titleCount = countCharacters(title);
+  const titleOver = titleCount > TITLE_LIMIT;
+  const contentCount = countCharacters(cleanConfirmed);
+  const contentOver = contentCount > CONTENT_LIMIT;
   const previewHtml = markdownToHtml(cleanContent || '开始写作后，这里会显示文章预览。');
 
   return (
@@ -188,6 +196,9 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             placeholder="给文章起个标题"
             className={styles.titleInput}
           />
+          <span className={styles.limitCount({ over: titleOver })}>
+            {titleCount}/{TITLE_LIMIT}
+          </span>
           <SaveButton onSave={onSave} />
         </div>
 
@@ -270,23 +281,23 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
         <div className={styles.statsBar}>
           <div className={styles.statsRow}>
             <span>
-              <span className={styles.statsValue}>{countCharacters(cleanConfirmed)}</span>{' '}
-              <span className={styles.statsUnit}>字符</span>
+              <span className={styles.statsValue({ over: contentOver })}>{contentCount}</span>{' '}
+              <span className={styles.statsUnit}>/ {CONTENT_LIMIT} 字符</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countParagraphs(cleanConfirmed)}</span>{' '}
+              <span className={styles.statsValue()}>{countParagraphs(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>段落</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countHeadings(cleanConfirmed)}</span>{' '}
+              <span className={styles.statsValue()}>{countHeadings(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>标题</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
               <span className={styles.statsUnit}>约</span>{' '}
-              <span className={styles.statsValue}>
+              <span className={styles.statsValue()}>
                 {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'}
               </span>{' '}
               <span className={styles.statsUnit}>阅读</span>

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -42,9 +42,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   const setContent = usePublishStore((s) => s.setContent);
   const setActiveTab = usePublishStore((s) => s.setActiveTab);
   const editorMode = usePublishStore((s) => s.editorMode);
-  // 统计用的"已确认内容"：IME 合成中不更新，避免拼音临时字符计入字符统计
+  // 统计用的"已确认"值：IME 合成中不更新，避免拼音临时字符计入字符统计
   const isComposingRef = useRef(false);
   const [confirmedContent, setConfirmedContent] = useState(content);
+  const isComposingTitleRef = useRef(false);
+  const [confirmedTitle, setConfirmedTitle] = useState(title);
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -129,6 +131,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
     if (!isComposingRef.current) setConfirmedContent(content);
   }, [content]);
 
+  // title 变化时同步统计用的 confirmedTitle，但跳过 IME 合成中
+  useEffect(() => {
+    if (!isComposingTitleRef.current) setConfirmedTitle(title);
+  }, [title]);
+
   const handleImageUpload = useCallback(
     async (file: File) => {
       if (!file.type.startsWith('image/')) return;
@@ -175,7 +182,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const cleanContent = content.trim();
   const cleanConfirmed = confirmedContent.trim();
-  const titleCount = countCharacters(title);
+  const titleCount = countCharacters(confirmedTitle);
   const titleOver = titleCount > TITLE_LIMIT;
   const contentCount = countCharacters(cleanConfirmed);
   const contentOver = contentCount > CONTENT_LIMIT;
@@ -191,6 +198,13 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            onCompositionStart={() => {
+              isComposingTitleRef.current = true;
+            }}
+            onCompositionEnd={(e) => {
+              isComposingTitleRef.current = false;
+              setConfirmedTitle(e.currentTarget.value);
+            }}
             placeholder="给文章起个标题"
             className={styles.titleInput}
           />

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -40,6 +40,9 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   const setContent = usePublishStore((s) => s.setContent);
   const setActiveTab = usePublishStore((s) => s.setActiveTab);
   const editorMode = usePublishStore((s) => s.editorMode);
+  // 统计用的"已确认内容"：IME 合成中不更新，避免拼音临时字符计入字符统计
+  const isComposingRef = useRef(false);
+  const [confirmedContent, setConfirmedContent] = useState(content);
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -107,8 +110,10 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   const lastContentForSlashRef = useRef(content);
   const handleContentChange = useCallback(
     (val?: string, event?: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // IME 合成中（拼音未确认）不计入，等选词确认后再更新
-      if ((event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing) return;
+      // 记录 IME 合成状态：合成中不更新统计用的 confirmedContent（由下面的 effect 同步）
+      isComposingRef.current =
+        (event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing ??
+        isComposingRef.current;
       const newValue = val || '';
       setContent(newValue);
       // 仅当内容确实由用户输入变化时检测 slash command
@@ -120,6 +125,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
     },
     [setContent, slash],
   );
+
+  // content 变化时同步统计用的 confirmedContent，但跳过 IME 合成中
+  useEffect(() => {
+    if (!isComposingRef.current) setConfirmedContent(content);
+  }, [content]);
 
   const handleImageUpload = useCallback(
     async (file: File) => {
@@ -166,6 +176,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   );
 
   const cleanContent = content.trim();
+  const cleanConfirmed = confirmedContent.trim();
   const previewHtml = markdownToHtml(cleanContent || '开始写作后，这里会显示文章预览。');
 
   return (
@@ -254,24 +265,24 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
         <div className={styles.statsBar}>
           <div className={styles.statsRow}>
             <span>
-              <span className={styles.statsValue}>{countCharacters(cleanContent)}</span>{' '}
+              <span className={styles.statsValue}>{countCharacters(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>字符</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countParagraphs(cleanContent)}</span>{' '}
+              <span className={styles.statsValue}>{countParagraphs(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>段落</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countHeadings(cleanContent)}</span>{' '}
+              <span className={styles.statsValue}>{countHeadings(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>标题</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
               <span className={styles.statsUnit}>约</span>{' '}
               <span className={styles.statsValue}>
-                {cleanContent ? estimateReadTime(cleanContent) : '1 分钟'}
+                {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'}
               </span>{' '}
               <span className={styles.statsUnit}>阅读</span>
             </span>
@@ -357,8 +368,8 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           </div>
           <div className={styles.immersiveFooter}>
             <span className={styles.immersiveFooterText}>
-              {countCharacters(cleanContent)} 字符 · {countParagraphs(cleanContent)} 段落 · 约{' '}
-              {cleanContent ? estimateReadTime(cleanContent) : '1 分钟'} 阅读 · ESC 退出
+              {countCharacters(cleanConfirmed)} 字符 · {countParagraphs(cleanConfirmed)} 段落 · 约{' '}
+              {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'} 阅读 · ESC 退出
             </span>
           </div>
         </div>

--- a/apps/web/src/components/editor/SaveButton.tsx
+++ b/apps/web/src/components/editor/SaveButton.tsx
@@ -1,6 +1,7 @@
 import { Save } from 'lucide-react';
 import { useSaveStatusStore } from '@/stores/saveStatusStore';
 import { usePublishStore } from '@/stores/publishStore';
+import { countCharacters, TITLE_LIMIT, CONTENT_LIMIT } from '@/lib/contentStats';
 import * as styles from './editor.css';
 
 interface SaveButtonProps {
@@ -16,7 +17,9 @@ export default function SaveButton({ onSave }: SaveButtonProps) {
   const isDirty = useSaveStatusStore((s) => s.isDirty);
   const title = usePublishStore((s) => s.title);
   const content = usePublishStore((s) => s.content);
-  const canSave = isDirty && !!title.trim() && !!content.trim();
+  const titleOver = countCharacters(title) > TITLE_LIMIT;
+  const contentOver = countCharacters(content) > CONTENT_LIMIT;
+  const canSave = isDirty && !!title.trim() && !!content.trim() && !titleOver && !contentOver;
 
   return (
     <button

--- a/apps/web/src/components/editor/editor.css.ts
+++ b/apps/web/src/components/editor/editor.css.ts
@@ -201,13 +201,39 @@ export const statsDot = style({
 });
 
 // 统计栏：数字用主色提对比，单位保持弱化，改善暗色下 11px 文字可读性
-export const statsValue = style({
-  color: vars.color.text,
-  fontWeight: 500,
+export const statsValue = recipe({
+  base: {
+    color: vars.color.text,
+    fontWeight: 500,
+  },
+  variants: {
+    over: {
+      true: { color: vars.color.errorText },
+      false: {},
+    },
+  },
+  defaultVariants: { over: false },
 });
 
 export const statsUnit = style({
   color: vars.color.textMuted,
+});
+
+// 长度限制计数（标题）：超出上限标红提醒
+export const limitCount = recipe({
+  base: {
+    fontSize: vars.fontSize['2xs'],
+    color: vars.color.textMuted,
+    fontVariantNumeric: 'tabular-nums',
+    flexShrink: 0,
+  },
+  variants: {
+    over: {
+      true: { color: vars.color.errorText, fontWeight: 500 },
+      false: {},
+    },
+  },
+  defaultVariants: { over: false },
 });
 
 // Preview area — 容器零内边距，使 frame 与写作态编辑卡同位置同尺寸

--- a/apps/web/src/components/publish/PublishButton.tsx
+++ b/apps/web/src/components/publish/PublishButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishStore } from '@/stores/publishStore';
+import { countCharacters, TITLE_LIMIT, CONTENT_LIMIT } from '@/lib/contentStats';
 import { PlatformId, PublishResponse } from '@/types';
 import { SendHorizonal, Loader2, AlertCircle } from 'lucide-react';
 import { publishButton } from './publish.css';
@@ -42,9 +43,13 @@ export default function PublishButton() {
     return !draft?.title?.trim() || !draft?.body?.trim();
   });
 
+  const titleOver = countCharacters(title) > TITLE_LIMIT;
+  const contentOver = countCharacters(content) > CONTENT_LIMIT;
   const isDisabled =
     !title.trim() ||
     !content.trim() ||
+    titleOver ||
+    contentOver ||
     selectedPlatforms.length === 0 ||
     notReadyPlatforms.length > 0 ||
     overallStatus === 'publishing';
@@ -177,6 +182,8 @@ export default function PublishButton() {
   let label: string;
   if (overallStatus === 'publishing') {
     label = '提交中...';
+  } else if (titleOver || contentOver) {
+    label = '内容超出长度限制';
   } else if (selectedPlatforms.length === 0) {
     label = '请先选择平台';
   } else if (notReadyPlatforms.length > 0) {

--- a/apps/web/src/lib/contentStats.ts
+++ b/apps/web/src/lib/contentStats.ts
@@ -1,3 +1,7 @@
+// 草稿长度上限（软提示 + 超出阻断保存/发布）。对齐微信公众号最宽限制。
+export const TITLE_LIMIT = 64;
+export const CONTENT_LIMIT = 20000;
+
 export function countCharacters(content: string) {
   return content.replace(/\s/g, '').length;
 }


### PR DESCRIPTION
## What
Live character counter for draft length limits (soft warning, never blocks input):
- Title: `X/64` next to the title input
- Content: `X/20000` in the stats bar (replaces the plain count)

Both turn red when over the limit. Limits align with WeChat (the common platform); spaces stay excluded (matches existing count behavior).

## Note
Builds on top of #113 (IME composition fix) — touches the same MarkdownEditor stats area. Merge #113 first; after that this PR shows only the length-limit commit.

## Verification
- `pnpm lint` + `pnpm build` pass.
- Screenshots: normal (title 5/64 grey, content 17/20000 grey) and over-limit (title 70/64 red).