### PR TITLE
perf(write): defer stats and platform adapt for large content

### DIFF
--- a/apps/web/src/components/editor/ArticlePreview.tsx
+++ b/apps/web/src/components/editor/ArticlePreview.tsx
@@ -1,0 +1,55 @@
+import { memo, useDeferredValue, useMemo } from 'react';
+import { markdownToHtml } from '@/lib/markdown';
+import * as styles from './editor.css';
+
+interface ArticlePreviewProps {
+  title: string;
+  content: string;
+}
+
+/**
+ * 成稿预览：把 markdownToHtml 的重计算（marked.lexer + sanitize-html）
+ * 隔离在独立子组件里，并只在「预览」态挂载，编辑态零开销。
+ *
+ * - 仅在 activeTab === 'preview' 时由父组件渲染，编辑态完全不挂载。
+ * - memo 包裹，title/content 引用不变则跳过重渲。
+ * - 内部用 useDeferredValue + useMemo 把 markdown 解析推到低优先级，
+ *   避免切换到预览态或大文本更新时阻塞输入。
+ */
+function ArticlePreview({ title, content }: ArticlePreviewProps) {
+  // 大文本下把解析推到低优先级，避免与输入/切换竞争主线程。
+  const deferredContent = useDeferredValue(content);
+  const previewHtml = useMemo(
+    () => markdownToHtml(deferredContent.trim() || '开始写作后，这里会显示文章预览。'),
+    [deferredContent],
+  );
+
+  return (
+    <div className={styles.previewWrap}>
+      <div className={styles.previewPhoneFrame}>
+        {/* 模拟公众号/手机阅读顶栏 */}
+        <div className={styles.previewPhoneBar}>
+          <div className={styles.previewPhoneBarDots}>
+            <span className={styles.previewPhoneBarDot} />
+            <span className={styles.previewPhoneBarDot} />
+            <span className={styles.previewPhoneBarDot} />
+          </div>
+          <span className={styles.previewPhoneBarLabel}>成稿预览</span>
+          <div style={{ width: '36px' }} />
+        </div>
+        <div className={styles.previewInner}>
+          <div className={styles.previewTitleBlock}>
+            <p className={styles.previewKicker}>文章</p>
+            <h3 className={styles.previewTitle}>{title || '未命名稿件'}</h3>
+          </div>
+          <div
+            className={styles.previewContent}
+            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default memo(ArticlePreview);

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -106,7 +106,9 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const lastContentForSlashRef = useRef(content);
   const handleContentChange = useCallback(
-    (val?: string) => {
+    (val?: string, event?: React.ChangeEvent<HTMLTextAreaElement>) => {
+      // IME 合成中（拼音未确认）不计入，等选词确认后再更新
+      if ((event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing) return;
       const newValue = val || '';
       setContent(newValue);
       // 仅当内容确实由用户输入变化时检测 slash command
@@ -241,7 +243,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             <textarea
               ref={textareaRef}
               value={content}
-              onChange={(e) => handleContentChange(e.target.value)}
+              onChange={(e) => handleContentChange(e.target.value, e)}
               placeholder="开始写作，支持 Markdown 语法..."
               className={styles.mobileTextarea}
             />

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -6,13 +6,13 @@ import {
   Suspense,
   useEffect,
   useDeferredValue,
+  useMemo,
   useRef,
   useState,
   useCallback,
 } from 'react';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
-import { markdownToHtml } from '@/lib/markdown';
 import {
   countCharacters,
   countParagraphs,
@@ -29,6 +29,7 @@ import { useClickOutside } from '@/hooks/useClickOutside';
 import SlashCommandMenu from './SlashCommandMenu';
 import EditorModeToggle from './EditorModeToggle';
 import SaveButton from './SaveButton';
+import ArticlePreview from './ArticlePreview';
 import * as styles from './editor.css';
 
 const MDEditor = lazy(() => import('@uiw/react-md-editor'));
@@ -189,16 +190,23 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
     [handleImageUpload],
   );
 
-  const cleanContent = content.trim();
   // 统计用 deferred 值：大文本下输入时不阻塞（低优先级重算）
   const deferredConfirmedContent = useDeferredValue(confirmedContent);
   const deferredConfirmedTitle = useDeferredValue(confirmedTitle);
   const cleanConfirmed = deferredConfirmedContent.trim();
   const titleCount = countCharacters(deferredConfirmedTitle);
   const titleOver = titleCount > TITLE_LIMIT;
-  const contentCount = countCharacters(cleanConfirmed);
-  const contentOver = contentCount > CONTENT_LIMIT;
-  const previewHtml = markdownToHtml(cleanContent || '开始写作后，这里会显示文章预览。');
+  // 正文统计合并一次算完，避免底部栏和沉浸态 footer 各扫一遍。
+  const stats = useMemo(
+    () => ({
+      chars: countCharacters(cleanConfirmed),
+      paragraphs: countParagraphs(cleanConfirmed),
+      headings: countHeadings(cleanConfirmed),
+      readTime: cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟',
+    }),
+    [cleanConfirmed],
+  );
+  const contentOver = stats.chars > CONTENT_LIMIT;
 
   return (
     <div data-color-mode="light" className={styles.editorRoot}>
@@ -288,6 +296,10 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
                 preview={editorMode === 'live' ? 'live' : 'edit'}
                 visibleDragbar={false}
                 commandsFilter={stripEditorModeCommands}
+                // 源码模式下关闭语法高亮 overlay：库会为 textarea 挂一个每次按键
+                // 对全文同步跑 rehype-prism 的 overlay（processSync），大文本下
+                // 阻塞主线程造成卡顿。live 模式保留高亮，实时预览仍需着色。
+                highlightEnable={editorMode === 'live'}
                 textareaProps={{ spellCheck: false, autoCapitalize: 'off', autoCorrect: 'off' }}
               />
             </Suspense>
@@ -306,25 +318,23 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
         <div className={styles.statsBar}>
           <div className={styles.statsRow}>
             <span>
-              <span className={styles.statsValue({ over: contentOver })}>{contentCount}</span>{' '}
+              <span className={styles.statsValue({ over: contentOver })}>{stats.chars}</span>{' '}
               <span className={styles.statsUnit}>/ {CONTENT_LIMIT} 字符</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue()}>{countParagraphs(cleanConfirmed)}</span>{' '}
+              <span className={styles.statsValue()}>{stats.paragraphs}</span>{' '}
               <span className={styles.statsUnit}>段落</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue()}>{countHeadings(cleanConfirmed)}</span>{' '}
+              <span className={styles.statsValue()}>{stats.headings}</span>{' '}
               <span className={styles.statsUnit}>标题</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
               <span className={styles.statsUnit}>约</span>{' '}
-              <span className={styles.statsValue()}>
-                {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'}
-              </span>{' '}
+              <span className={styles.statsValue()}>{stats.readTime}</span>{' '}
               <span className={styles.statsUnit}>阅读</span>
             </span>
             <button
@@ -341,33 +351,8 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
         </div>
       </div>
 
-      {/* 预览区 */}
-      {activeTab === 'preview' && (
-        <div className={styles.previewWrap}>
-          <div className={styles.previewPhoneFrame}>
-            {/* 模拟公众号/手机阅读顶栏 */}
-            <div className={styles.previewPhoneBar}>
-              <div className={styles.previewPhoneBarDots}>
-                <span className={styles.previewPhoneBarDot} />
-                <span className={styles.previewPhoneBarDot} />
-                <span className={styles.previewPhoneBarDot} />
-              </div>
-              <span className={styles.previewPhoneBarLabel}>成稿预览</span>
-              <div style={{ width: '36px' }} />
-            </div>
-            <div className={styles.previewInner}>
-              <div className={styles.previewTitleBlock}>
-                <p className={styles.previewKicker}>文章</p>
-                <h3 className={styles.previewTitle}>{title || '未命名稿件'}</h3>
-              </div>
-              <div
-                className={styles.previewContent}
-                dangerouslySetInnerHTML={{ __html: previewHtml }}
-              />
-            </div>
-          </div>
-        </div>
-      )}
+      {/* 预览区：仅在预览态挂载，markdown 解析隔离在子组件内，编辑态零开销 */}
+      {activeTab === 'preview' && <ArticlePreview title={title} content={content} />}
 
       {/* 沉浸式写作模式 */}
       {immersive.active && (
@@ -402,6 +387,8 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
                     preview="edit"
                     visibleDragbar={false}
                     commandsFilter={stripEditorModeCommands}
+                    // 沉浸模式固定源码态，关闭语法高亮 overlay 避免大文本卡顿。
+                    highlightEnable={false}
                   />
                 </Suspense>
               </div>
@@ -409,8 +396,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           </div>
           <div className={styles.immersiveFooter}>
             <span className={styles.immersiveFooterText}>
-              {countCharacters(cleanConfirmed)} 字符 · {countParagraphs(cleanConfirmed)} 段落 · 约{' '}
-              {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'} 阅读 · ESC 退出
+              {stats.chars} 字符 · {stats.paragraphs} 段落 · 约 {stats.readTime} 阅读 · ESC 退出
             </span>
           </div>
         </div>

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -109,11 +109,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const lastContentForSlashRef = useRef(content);
   const handleContentChange = useCallback(
-    (val?: string, event?: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // 记录 IME 合成状态：合成中不更新统计用的 confirmedContent（由下面的 effect 同步）
-      isComposingRef.current =
-        (event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing ??
-        isComposingRef.current;
+    (val?: string) => {
       const newValue = val || '';
       setContent(newValue);
       // 仅当内容确实由用户输入变化时检测 slash command
@@ -202,6 +198,15 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           onPaste={handlePaste}
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false;
+            // 合成结束直接读 textarea 最终文本同步统计，避免依赖后续 onChange
+            const ta = editorWrapRef.current?.querySelector<HTMLTextAreaElement>('textarea');
+            if (ta) setConfirmedContent(ta.value);
+          }}
           onClick={(e) => {
             const target = e.target as HTMLElement;
             if (target.closest('.w-md-editor-toolbar')) return;
@@ -254,7 +259,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             <textarea
               ref={textareaRef}
               value={content}
-              onChange={(e) => handleContentChange(e.target.value, e)}
+              onChange={(e) => handleContentChange(e.target.value)}
               placeholder="开始写作，支持 Markdown 语法..."
               className={styles.mobileTextarea}
             />

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -9,6 +9,8 @@ import {
   countParagraphs,
   countHeadings,
   estimateReadTime,
+  TITLE_LIMIT,
+  CONTENT_LIMIT,
 } from '@/lib/contentStats';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
 import { useAgentStream } from '@/hooks/useAgentStream';
@@ -25,10 +27,6 @@ const MDEditor = lazy(() => import('@uiw/react-md-editor'));
 // 隐藏 md-editor 自带的视图模式按钮（编辑/实时/预览），视图切换统一走「源码/实时」toggle
 const stripEditorModeCommands = (_cmd: ICommand, isExtra: boolean): false | ICommand =>
   isExtra ? false : _cmd;
-
-// 草稿长度上限（软提示，超出标红不阻断）。对齐微信公众号最宽限制。
-const TITLE_LIMIT = 64;
-const CONTENT_LIMIT = 20000;
 
 interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -1,6 +1,15 @@
 import '@uiw/react-md-editor/markdown-editor.css';
 import type { ICommand } from '@uiw/react-md-editor';
-import { lazy, memo, Suspense, useEffect, useRef, useState, useCallback } from 'react';
+import {
+  lazy,
+  memo,
+  Suspense,
+  useEffect,
+  useDeferredValue,
+  useRef,
+  useState,
+  useCallback,
+} from 'react';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import { usePublishStore } from '@/stores/publishStore';
 import { markdownToHtml } from '@/lib/markdown';
@@ -181,8 +190,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   );
 
   const cleanContent = content.trim();
-  const cleanConfirmed = confirmedContent.trim();
-  const titleCount = countCharacters(confirmedTitle);
+  // 统计用 deferred 值：大文本下输入时不阻塞（低优先级重算）
+  const deferredConfirmedContent = useDeferredValue(confirmedContent);
+  const deferredConfirmedTitle = useDeferredValue(confirmedTitle);
+  const cleanConfirmed = deferredConfirmedContent.trim();
+  const titleCount = countCharacters(deferredConfirmedTitle);
   const titleOver = titleCount > TITLE_LIMIT;
   const contentCount = countCharacters(cleanConfirmed);
   const contentOver = contentCount > CONTENT_LIMIT;
@@ -276,6 +288,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
                 preview={editorMode === 'live' ? 'live' : 'edit'}
                 visibleDragbar={false}
                 commandsFilter={stripEditorModeCommands}
+                textareaProps={{ spellCheck: false, autoCapitalize: 'off', autoCorrect: 'off' }}
               />
             </Suspense>
           ) : (

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -26,6 +26,10 @@ const MDEditor = lazy(() => import('@uiw/react-md-editor'));
 const stripEditorModeCommands = (_cmd: ICommand, isExtra: boolean): false | ICommand =>
   isExtra ? false : _cmd;
 
+// 草稿长度上限（软提示，超出标红不阻断）。对齐微信公众号最宽限制。
+const TITLE_LIMIT = 64;
+const CONTENT_LIMIT = 20000;
+
 interface MarkdownEditorProps {
   activeTab: 'edit' | 'preview';
   onSave?: () => Promise<void>;
@@ -173,6 +177,10 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const cleanContent = content.trim();
   const cleanConfirmed = confirmedContent.trim();
+  const titleCount = countCharacters(title);
+  const titleOver = titleCount > TITLE_LIMIT;
+  const contentCount = countCharacters(cleanConfirmed);
+  const contentOver = contentCount > CONTENT_LIMIT;
   const previewHtml = markdownToHtml(cleanContent || '开始写作后，这里会显示文章预览。');
 
   return (
@@ -188,6 +196,9 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             placeholder="给文章起个标题"
             className={styles.titleInput}
           />
+          <span className={styles.limitCount({ over: titleOver })}>
+            {titleCount}/{TITLE_LIMIT}
+          </span>
           <SaveButton onSave={onSave} />
         </div>
 
@@ -270,23 +281,23 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
         <div className={styles.statsBar}>
           <div className={styles.statsRow}>
             <span>
-              <span className={styles.statsValue}>{countCharacters(cleanConfirmed)}</span>{' '}
-              <span className={styles.statsUnit}>字符</span>
+              <span className={styles.statsValue({ over: contentOver })}>{contentCount}</span>{' '}
+              <span className={styles.statsUnit}>/ {CONTENT_LIMIT} 字符</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countParagraphs(cleanConfirmed)}</span>{' '}
+              <span className={styles.statsValue()}>{countParagraphs(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>段落</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countHeadings(cleanConfirmed)}</span>{' '}
+              <span className={styles.statsValue()}>{countHeadings(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>标题</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
               <span className={styles.statsUnit}>约</span>{' '}
-              <span className={styles.statsValue}>
+              <span className={styles.statsValue()}>
                 {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'}
               </span>{' '}
               <span className={styles.statsUnit}>阅读</span>

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -42,9 +42,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   const setContent = usePublishStore((s) => s.setContent);
   const setActiveTab = usePublishStore((s) => s.setActiveTab);
   const editorMode = usePublishStore((s) => s.editorMode);
-  // 统计用的"已确认内容"：IME 合成中不更新，避免拼音临时字符计入字符统计
+  // 统计用的"已确认"值：IME 合成中不更新，避免拼音临时字符计入字符统计
   const isComposingRef = useRef(false);
   const [confirmedContent, setConfirmedContent] = useState(content);
+  const isComposingTitleRef = useRef(false);
+  const [confirmedTitle, setConfirmedTitle] = useState(title);
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -129,6 +131,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
     if (!isComposingRef.current) setConfirmedContent(content);
   }, [content]);
 
+  // title 变化时同步统计用的 confirmedTitle，但跳过 IME 合成中
+  useEffect(() => {
+    if (!isComposingTitleRef.current) setConfirmedTitle(title);
+  }, [title]);
+
   const handleImageUpload = useCallback(
     async (file: File) => {
       if (!file.type.startsWith('image/')) return;
@@ -175,7 +182,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
 
   const cleanContent = content.trim();
   const cleanConfirmed = confirmedContent.trim();
-  const titleCount = countCharacters(title);
+  const titleCount = countCharacters(confirmedTitle);
   const titleOver = titleCount > TITLE_LIMIT;
   const contentCount = countCharacters(cleanConfirmed);
   const contentOver = contentCount > CONTENT_LIMIT;
@@ -191,6 +198,13 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            onCompositionStart={() => {
+              isComposingTitleRef.current = true;
+            }}
+            onCompositionEnd={(e) => {
+              isComposingTitleRef.current = false;
+              setConfirmedTitle(e.currentTarget.value);
+            }}
             placeholder="给文章起个标题"
             className={styles.titleInput}
           />

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -40,6 +40,9 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   const setContent = usePublishStore((s) => s.setContent);
   const setActiveTab = usePublishStore((s) => s.setActiveTab);
   const editorMode = usePublishStore((s) => s.editorMode);
+  // 统计用的"已确认内容"：IME 合成中不更新，避免拼音临时字符计入字符统计
+  const isComposingRef = useRef(false);
+  const [confirmedContent, setConfirmedContent] = useState(content);
   const [editorHeight, setEditorHeight] = useState<number | undefined>(undefined);
   const [isDesktop, setIsDesktop] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -107,8 +110,10 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   const lastContentForSlashRef = useRef(content);
   const handleContentChange = useCallback(
     (val?: string, event?: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // IME 合成中（拼音未确认）不计入，等选词确认后再更新
-      if ((event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing) return;
+      // 记录 IME 合成状态：合成中不更新统计用的 confirmedContent（由下面的 effect 同步）
+      isComposingRef.current =
+        (event?.nativeEvent as { isComposing?: boolean } | undefined)?.isComposing ??
+        isComposingRef.current;
       const newValue = val || '';
       setContent(newValue);
       // 仅当内容确实由用户输入变化时检测 slash command
@@ -120,6 +125,11 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
     },
     [setContent, slash],
   );
+
+  // content 变化时同步统计用的 confirmedContent，但跳过 IME 合成中
+  useEffect(() => {
+    if (!isComposingRef.current) setConfirmedContent(content);
+  }, [content]);
 
   const handleImageUpload = useCallback(
     async (file: File) => {
@@ -166,6 +176,7 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
   );
 
   const cleanContent = content.trim();
+  const cleanConfirmed = confirmedContent.trim();
   const previewHtml = markdownToHtml(cleanContent || '开始写作后，这里会显示文章预览。');
 
   return (
@@ -254,24 +265,24 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
         <div className={styles.statsBar}>
           <div className={styles.statsRow}>
             <span>
-              <span className={styles.statsValue}>{countCharacters(cleanContent)}</span>{' '}
+              <span className={styles.statsValue}>{countCharacters(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>字符</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countParagraphs(cleanContent)}</span>{' '}
+              <span className={styles.statsValue}>{countParagraphs(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>段落</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
-              <span className={styles.statsValue}>{countHeadings(cleanContent)}</span>{' '}
+              <span className={styles.statsValue}>{countHeadings(cleanConfirmed)}</span>{' '}
               <span className={styles.statsUnit}>标题</span>
             </span>
             <span className={styles.statsDot}>·</span>
             <span>
               <span className={styles.statsUnit}>约</span>{' '}
               <span className={styles.statsValue}>
-                {cleanContent ? estimateReadTime(cleanContent) : '1 分钟'}
+                {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'}
               </span>{' '}
               <span className={styles.statsUnit}>阅读</span>
             </span>
@@ -357,8 +368,8 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           </div>
           <div className={styles.immersiveFooter}>
             <span className={styles.immersiveFooterText}>
-              {countCharacters(cleanContent)} 字符 · {countParagraphs(cleanContent)} 段落 · 约{' '}
-              {cleanContent ? estimateReadTime(cleanContent) : '1 分钟'} 阅读 · ESC 退出
+              {countCharacters(cleanConfirmed)} 字符 · {countParagraphs(cleanConfirmed)} 段落 · 约{' '}
+              {cleanConfirmed ? estimateReadTime(cleanConfirmed) : '1 分钟'} 阅读 · ESC 退出
             </span>
           </div>
         </div>

--- a/apps/web/src/components/editor/SaveButton.tsx
+++ b/apps/web/src/components/editor/SaveButton.tsx
@@ -1,6 +1,7 @@
 import { Save } from 'lucide-react';
 import { useSaveStatusStore } from '@/stores/saveStatusStore';
 import { usePublishStore } from '@/stores/publishStore';
+import { countCharacters, TITLE_LIMIT, CONTENT_LIMIT } from '@/lib/contentStats';
 import * as styles from './editor.css';
 
 interface SaveButtonProps {
@@ -16,7 +17,9 @@ export default function SaveButton({ onSave }: SaveButtonProps) {
   const isDirty = useSaveStatusStore((s) => s.isDirty);
   const title = usePublishStore((s) => s.title);
   const content = usePublishStore((s) => s.content);
-  const canSave = isDirty && !!title.trim() && !!content.trim();
+  const titleOver = countCharacters(title) > TITLE_LIMIT;
+  const contentOver = countCharacters(content) > CONTENT_LIMIT;
+  const canSave = isDirty && !!title.trim() && !!content.trim() && !titleOver && !contentOver;
 
   return (
     <button

--- a/apps/web/src/components/editor/editor.css.ts
+++ b/apps/web/src/components/editor/editor.css.ts
@@ -201,13 +201,39 @@ export const statsDot = style({
 });
 
 // 统计栏：数字用主色提对比，单位保持弱化，改善暗色下 11px 文字可读性
-export const statsValue = style({
-  color: vars.color.text,
-  fontWeight: 500,
+export const statsValue = recipe({
+  base: {
+    color: vars.color.text,
+    fontWeight: 500,
+  },
+  variants: {
+    over: {
+      true: { color: vars.color.errorText },
+      false: {},
+    },
+  },
+  defaultVariants: { over: false },
 });
 
 export const statsUnit = style({
   color: vars.color.textMuted,
+});
+
+// 长度限制计数（标题）：超出上限标红提醒
+export const limitCount = recipe({
+  base: {
+    fontSize: vars.fontSize['2xs'],
+    color: vars.color.textMuted,
+    fontVariantNumeric: 'tabular-nums',
+    flexShrink: 0,
+  },
+  variants: {
+    over: {
+      true: { color: vars.color.errorText, fontWeight: 500 },
+      false: {},
+    },
+  },
+  defaultVariants: { over: false },
 });
 
 // Preview area — 容器零内边距，使 frame 与写作态编辑卡同位置同尺寸

--- a/apps/web/src/components/editor/editor.css.ts
+++ b/apps/web/src/components/editor/editor.css.ts
@@ -144,6 +144,20 @@ globalStyle(`${editorWrap} .w-md-editor-text-input::placeholder`, {
   color: vars.color.textMuted,
 });
 
+// highlightEnable={false} 时不再渲染高亮 overlay（.w-md-editor-text-pre），
+// 而原布局靠 overlay 的 <pre> 自身内容撑开高度。没有 overlay 时高度链断裂，
+// textarea（absolute/height:100%）随之塌缩。这里给整条高度链显式补上 100%，
+// 让 textarea 直接撑满外层 .w-md-editor 的固定高度。
+globalStyle(`${editorWrap} .w-md-editor-show-edit .w-md-editor-input`, {
+  height: '100%',
+});
+globalStyle(`${editorWrap} .w-md-editor-area`, {
+  height: '100%',
+});
+globalStyle(`${editorWrap} .w-md-editor-text`, {
+  height: '100%',
+});
+
 globalStyle(`${editorWrap} .wmde-markdown`, {
   background: 'transparent',
   color: vars.color.text,
@@ -684,6 +698,17 @@ globalStyle(`${immersiveEditorWrap} .w-md-editor-text-input`, {
   background: 'transparent',
   color: vars.color.text,
   outline: 'none',
+});
+
+// highlightEnable={false}：补全高度链（同 editorWrap 处理）。
+globalStyle(`${immersiveEditorWrap} .w-md-editor-show-edit .w-md-editor-input`, {
+  height: '100%',
+});
+globalStyle(`${immersiveEditorWrap} .w-md-editor-area`, {
+  height: '100%',
+});
+globalStyle(`${immersiveEditorWrap} .w-md-editor-text`, {
+  height: '100%',
 });
 
 globalStyle(`${immersiveEditorWrap} .wmde-markdown`, {

--- a/apps/web/src/components/publish/PublishButton.tsx
+++ b/apps/web/src/components/publish/PublishButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishStore } from '@/stores/publishStore';
+import { countCharacters, TITLE_LIMIT, CONTENT_LIMIT } from '@/lib/contentStats';
 import { PlatformId, PublishResponse } from '@/types';
 import { SendHorizonal, Loader2, AlertCircle } from 'lucide-react';
 import { publishButton } from './publish.css';
@@ -42,9 +43,13 @@ export default function PublishButton() {
     return !draft?.title?.trim() || !draft?.body?.trim();
   });
 
+  const titleOver = countCharacters(title) > TITLE_LIMIT;
+  const contentOver = countCharacters(content) > CONTENT_LIMIT;
   const isDisabled =
     !title.trim() ||
     !content.trim() ||
+    titleOver ||
+    contentOver ||
     selectedPlatforms.length === 0 ||
     notReadyPlatforms.length > 0 ||
     overallStatus === 'publishing';
@@ -177,6 +182,8 @@ export default function PublishButton() {
   let label: string;
   if (overallStatus === 'publishing') {
     label = '提交中...';
+  } else if (titleOver || contentOver) {
+    label = '内容超出长度限制';
   } else if (selectedPlatforms.length === 0) {
     label = '请先选择平台';
   } else if (notReadyPlatforms.length > 0) {

--- a/apps/web/src/lib/contentStats.ts
+++ b/apps/web/src/lib/contentStats.ts
@@ -1,3 +1,7 @@
+// 草稿长度上限（软提示 + 超出阻断保存/发布）。对齐微信公众号最宽限制。
+export const TITLE_LIMIT = 64;
+export const CONTENT_LIMIT = 20000;
+
 export function countCharacters(content: string) {
   return content.replace(/\s/g, '').length;
 }

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -32,19 +32,18 @@ import type { PlatformId } from '@/types';
 import * as styles from './page.css';
 
 function HomePageContent() {
-  const {
-    title,
-    content,
-    platforms,
-    syncPlatformDrafts,
-    setTitle,
-    setContent,
-    reset,
-    currentDraftId,
-    setCurrentDraftId,
-    activeTab,
-    setActiveTab,
-  } = usePublishStore();
+  // 用 selector 订阅，避免 platformDrafts/results 等无关字段变化触发整页重渲染。
+  const title = usePublishStore((s) => s.title);
+  const content = usePublishStore((s) => s.content);
+  const platforms = usePublishStore((s) => s.platforms);
+  const syncPlatformDrafts = usePublishStore((s) => s.syncPlatformDrafts);
+  const setTitle = usePublishStore((s) => s.setTitle);
+  const setContent = usePublishStore((s) => s.setContent);
+  const reset = usePublishStore((s) => s.reset);
+  const currentDraftId = usePublishStore((s) => s.currentDraftId);
+  const setCurrentDraftId = usePublishStore((s) => s.setCurrentDraftId);
+  const activeTab = usePublishStore((s) => s.activeTab);
+  const setActiveTab = usePublishStore((s) => s.setActiveTab);
   const agentStatus = useAgentStore((s) => s.status);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -124,8 +124,9 @@ function HomePageContent() {
   const deferredContent = useDeferredValue(content);
 
   useEffect(() => {
-    syncPlatformDrafts();
-  }, [deferredContent, syncPlatformDrafts, deferredTitle]);
+    const timer = setTimeout(() => syncPlatformDrafts(), 500);
+    return () => clearTimeout(timer);
+  }, [deferredContent, deferredTitle, syncPlatformDrafts]);
 
   useEffect(() => {
     const draftId = searchParams.get('draftId');


### PR DESCRIPTION
## Problem
Typing gets noticeably laggy as content approaches the 20000-char limit — each keystroke triggers stats recomputation (multiple regex passes) and platform adaptation (4 platforms), plus md-editor's own controlled-textarea cost.

## Fix (middle-ground, before considering swapping the editor)
- Stats bar (char/paragraph/heading/read counts) reads from `useDeferredValue` — recomputes at low priority, doesn't block typing.
- Platform draft sync debounced 500ms (was every deferred content change).
- md-editor textarea disables spellCheck / autoCapitalize / autoCorrect to cut browser overhead.

## Note
Builds on #114 (length limit / IME) — same files. Merge #114 first; this PR then shows only the perf commit.

## Verification
- `pnpm lint` + `pnpm build` pass.
- Needs a real large-content typing test to feel the improvement (headless can't simulate fast typing).