### PR TITLE
Editor UI polish: toolbar mode toggle + immersive stats

### DIFF
--- a/apps/web/src/components/editor/EditorModeToggle.tsx
+++ b/apps/web/src/components/editor/EditorModeToggle.tsx
@@ -12,6 +12,7 @@ export default function EditorModeToggle() {
         className={styles.modeToggleBtn({ active: editorMode === 'source' })}
         onClick={() => setEditorMode('source')}
         aria-label="源码模式"
+        title="源码模式（仅编辑，无预览）"
       >
         <Code size={13} />
         源码
@@ -21,6 +22,7 @@ export default function EditorModeToggle() {
         className={styles.modeToggleBtn({ active: editorMode === 'live' })}
         onClick={() => setEditorMode('live')}
         aria-label="实时预览模式"
+        title="实时预览（编辑与渲染并排）"
       >
         <Columns2 size={13} />
         实时

--- a/apps/web/src/components/editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/editor/MarkdownEditor.tsx
@@ -371,13 +371,25 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           </div>
           <div className={styles.immersiveBody}>
             <div className={styles.immersiveInner}>
-              <input
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="给文章起个标题"
-                className={styles.immersiveTitleInput}
-              />
+              <div className={styles.immersiveTitleRow}>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  onCompositionStart={() => {
+                    isComposingTitleRef.current = true;
+                  }}
+                  onCompositionEnd={(e) => {
+                    isComposingTitleRef.current = false;
+                    setConfirmedTitle(e.currentTarget.value);
+                  }}
+                  placeholder="给文章起个标题"
+                  className={styles.immersiveTitleInput}
+                />
+                <span className={styles.limitCount({ over: titleOver })}>
+                  {titleCount}/{TITLE_LIMIT}
+                </span>
+              </div>
               <div className={styles.immersiveEditorWrap}>
                 <Suspense fallback={<div style={{ height: 500 }} />}>
                   <MDEditor
@@ -396,7 +408,19 @@ function MarkdownEditor({ activeTab, onSave, agentEnabled = false }: MarkdownEdi
           </div>
           <div className={styles.immersiveFooter}>
             <span className={styles.immersiveFooterText}>
-              {stats.chars} 字符 · {stats.paragraphs} 段落 · 约 {stats.readTime} 阅读 · ESC 退出
+              <span className={styles.statsValue({ over: contentOver })}>{stats.chars}</span>{' '}
+              <span className={styles.statsUnit}>/ {CONTENT_LIMIT} 字符</span>
+              <span className={styles.statsDot}> · </span>
+              <span className={styles.statsValue()}>{stats.paragraphs}</span>{' '}
+              <span className={styles.statsUnit}>段落</span>
+              <span className={styles.statsDot}> · </span>
+              <span className={styles.statsValue()}>{stats.headings}</span>{' '}
+              <span className={styles.statsUnit}>标题</span>
+              <span className={styles.statsDot}> · </span>
+              <span className={styles.statsUnit}>约</span>{' '}
+              <span className={styles.statsValue()}>{stats.readTime}</span>{' '}
+              <span className={styles.statsUnit}>阅读</span>
+              <span className={styles.statsDot}> · ESC 退出</span>
             </span>
           </div>
         </div>

--- a/apps/web/src/components/editor/editor.css.ts
+++ b/apps/web/src/components/editor/editor.css.ts
@@ -654,16 +654,23 @@ export const immersiveInner = style({
   maxWidth: '720px',
 });
 
+export const immersiveTitleRow = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: vars.spacing.lg,
+  marginBottom: vars.spacing['3xl'],
+});
+
 export const immersiveTitleInput = style({
   fontFamily: vars.font.serif,
-  width: '100%',
+  flex: 1,
+  minWidth: 0,
   border: 0,
   background: 'transparent',
   fontSize: '32px',
   lineHeight: 1.3,
   color: vars.color.text,
   outline: 'none',
-  marginBottom: vars.spacing['3xl'],
   '::placeholder': {
     color: vars.color.textMuted,
   },
@@ -762,12 +769,12 @@ export const immersiveEntryBtn = style({
 });
 
 // --- Editor Mode Toggle ---
+// 与 md-editor 工具栏原生按钮视觉对齐：无边框容器、小圆角、hover 用 accentSoft。
 
 export const modeToggle = style({
   display: 'inline-flex',
-  borderRadius: vars.radius.lg,
-  border: `1px solid ${vars.color.border}`,
-  overflow: 'hidden',
+  alignItems: 'center',
+  gap: vars.spacing['2xs'],
 });
 
 export const modeToggleBtn = recipe({
@@ -777,19 +784,21 @@ export const modeToggleBtn = recipe({
     gap: vars.spacing.xs,
     border: 'none',
     background: 'transparent',
-    padding: `${vars.spacing.xs} ${vars.spacing['md-lg']}`,
+    borderRadius: vars.radius.xs,
+    padding: `${vars.spacing.xs} ${vars.spacing.sm}`,
     fontSize: vars.fontSize.xs,
     color: vars.color.textMuted,
     cursor: 'pointer',
     transition: 'all 150ms',
     ':hover': {
+      background: vars.color.accentSoft,
       color: vars.color.text,
     },
   },
   variants: {
     active: {
       true: {
-        background: vars.color.bgElevated,
+        background: vars.color.accentSoft,
         color: vars.color.text,
         fontWeight: 500,
       },


### PR DESCRIPTION
## Changes

### Align toolbar mode toggle style
The 源码/实时 (source/live) toggle was a bordered pill control that visually clashed with the md-editor native flat icon buttons.

- Removed container border and `overflow:hidden`; switched to borderless `inline-flex` flat layout.
- Button corner radius set to `radius.xs` (matching native buttons); hover/active use `accentSoft` background, identical to native toolbar button:hover.
- Added `title` attributes to both buttons to match the native command buttons' browser tooltip behavior (previously only had `aria-label` without `title`, so hover showed nothing).

### Align immersive mode stats
Immersive mode stats now match the writing desk editor area exactly.

- Added char limit `{titleCount}/{TITLE_LIMIT}` next to the title input (red when over), plus IME composition event handling (previously missing in immersive title input, so pinyin intermediate chars were counted).
- Filled out the footer: chars `/ CONTENT_LIMIT` (red when over) · paragraphs · headings · read time, reusing the `statsValue/statsUnit/statsDot` styles, consistent with the editor bottom stats bar.

## Verification
- `pnpm build` passes
- lint-staged (prettier + eslint) passes

## Out of scope
The immersive mode top bar is intentionally kept clean, without 源码/实时 or 保存 buttons — immersive mode is a focused-writing context where a live split view conflicts with focus, and autosave provides a fallback.