### PR TITLE
Pin undici to 7.28.0 to fix 6 Dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "shell-quote": ">=1.8.4",
       "esbuild": ">=0.28.1",
       "js-yaml": ">=4.2.0",
-      "@babel/core": ">=7.29.7"
+      "@babel/core": ">=7.29.7",
+      "undici": "7.28.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   esbuild: '>=0.28.1'
   js-yaml: '>=4.2.0'
   '@babel/core': '>=7.29.7'
+  undici: 7.28.0
 
 importers:
 
@@ -2248,8 +2249,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.7:
-    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -3912,7 +3913,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.7
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4903,7 +4904,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.7: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves 6 open Dependabot security alerts, all on the same dependency (`undici`, vulnerable range `>=7.0.0, <7.28.0`).

The 6 vulnerabilities are HTTP/network-layer issues:
1. Set-Cookie SameSite attribute downgrade via permissive substring matching
2. HTTP header injection via Set-Cookie percent-decoding
3. HTTP response queue poisoning via keep-alive socket reuse
4. Cross-origin request routing via SOCKS5 proxy pool reuse
5. Cross-user information disclosure via shared cache whitespace bypass
6. TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent

## Root cause

`undici` is a transitive dependency of `jsdom@29` (used as the Vitest test environment), which requires `^7.24.5`. The resolved version was `7.24.7`.

## Fix

Added a `pnpm.overrides` entry pinning `undici` to `7.28.0`:
- Covers the fix range (`>=7.28.0`) for all 6 alerts in a single change.
- `7.28.0` satisfies jsdom's `^7.24.5` constraint, so no breaking change.
- Pinned to the exact patch version (not `>=7.28.0`) to avoid drifting into the `8.x` major, which would break jsdom.

## Verification
- \`pnpm install\` clean
- \`pnpm build\` passes
- \`pnpm lint\` clean
- \`pnpm test\` passes
- \`pnpm why undici\` confirms the dependency tree resolves to `7.28.0` only; \`pnpm-lock.yaml\` references no other undici version.