### PR TITLE
Release v0.1.0: bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 ## Project Overview
 
 - **Name**: publio
-- **Version**: 0.2.0
+- **Version**: 0.1.0
 - **Tagline**: Write once, adapt per platform.
 - **Runtime**: Vite SPA (React 19) + Hono API server
 - **Private**: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 ## Project Overview
 
 - **Name**: publio
-- **Version**: 0.2.0
+- **Version**: 0.1.0
 - **Tagline**: Write once, adapt per platform.
 - **Runtime**: Vite SPA (React 19) + Hono API server
 - **Private**: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publio",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump the version to `0.1.0` as the first official release. The project has never been tagged before, and `0.2.0` was a leftover historical version number.

## Changes
- \`package.json\`: \`0.2.0\` → \`0.1.0\`
- \`CLAUDE.md\` / \`AGENTS.md\`: sync the documented version to \`0.1.0\`

## Post-merge
After this merges to main, I will tag \`v0.1.0\` and create a GitHub Release with a changelog summarizing the features and fixes in this release.