### PR TITLE
docs: drop GitHub image bed references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The current app keeps only three user-facing routes:
 |-------|---------|
 | `/` | Write, preview, manage platform variants, run checks, and publish |
 | `/drafts` | Reopen drafts and inspect publish state |
-| `/settings` | Configure platform credentials, AI agent settings, and GitHub image hosting |
+| `/settings` | Configure platform credentials and AI agent settings |
 
 ## Quick Start
 
@@ -48,7 +48,7 @@ Open http://localhost:3000. Configure platform credentials and AI agent in Setti
 
 ### Writing Desk
 
-Markdown editor with live preview, immersive full-screen mode, manual save (with a fallback that runs if the page closes or crashes before saving), version history restore, content templates, media library, and GitHub image bed uploads.
+Markdown editor with live preview, immersive full-screen mode, manual save (with a fallback that runs if the page closes or crashes before saving), version history restore, content templates, and a media library.
 
 ### AI Assistance
 
@@ -70,7 +70,7 @@ The API surface covers drafts, platform variants, publishing, publish status, se
 
 ## Configuration
 
-See [docs/configuration.md](./docs/configuration.md) for platform credentials, AI agent setup, and GitHub image bed.
+See [docs/configuration.md](./docs/configuration.md) for platform credentials and AI agent setup.
 
 Runtime data is stored in `.publio-data/`.
 


### PR DESCRIPTION
## Summary

The English `README.md` still referenced the removed GitHub image bed feature in three places (routes table, feature description, configuration note). This was missed when the feature was removed in #124, which only updated `README_zh.md`.

## Changes

- Routes table: `Configure platform credentials, AI agent settings, and GitHub image hosting` → `Configure platform credentials and AI agent settings`
- Feature description: drop `, and GitHub image bed uploads` from the editor feature list
- Configuration note: drop `, and GitHub image bed` from the `docs/configuration.md` reference

Aligns `README.md` with the already-updated `README_zh.md`. Pure docs change, no code or behavior impact.