### PR TITLE
fix: code review bugs (LLM stream retry, SSE disconnect, publish retry variants, rate limit)

### DIFF
--- a/apps/api/src/lib/agent/anthropicProvider.ts
+++ b/apps/api/src/lib/agent/anthropicProvider.ts
@@ -49,6 +49,9 @@ export function createAnthropicProvider(config: AgentConfig): LLMProvider {
         body.system = systemMessages.join('\n\n');
       }
 
+      // 阶段一：建立连接（建连失败可重试）。一旦拿到 response 就 break，
+      // 避免流消费中途失败后重试导致已 yield 的内容被重复输出。
+      let response: Response | undefined;
       let lastError: Error | undefined;
 
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -61,89 +64,39 @@ export function createAnthropicProvider(config: AgentConfig): LLMProvider {
           await delay(backoff);
         }
 
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
         try {
-          const controller = new AbortController();
-          const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': config.apiKey,
+              'anthropic-version': '2023-06-01',
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+          });
 
-          let response: Response;
-          try {
-            response = await fetch(url, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'x-api-key': config.apiKey,
-                'anthropic-version': '2023-06-01',
-              },
-              body: JSON.stringify(body),
-              signal: controller.signal,
-            });
-          } finally {
-            clearTimeout(timeout);
-          }
-
-          if (!response.ok) {
-            const errorText = await response.text().catch(() => '');
+          if (!res.ok) {
+            const errorText = await res.text().catch(() => '');
             const err = new Error(
-              `Anthropic API error ${response.status}: ${errorText || response.statusText}`,
+              `Anthropic API error ${res.status}: ${errorText || res.statusText}`,
             );
-
-            if (isRetryable(response.status) && attempt < MAX_RETRIES) {
+            if (isRetryable(res.status) && attempt < MAX_RETRIES) {
               lastError = err;
               continue;
             }
             throw err;
           }
 
-          if (!response.body) {
+          if (!res.body) {
             throw new Error('Anthropic API returned empty body');
           }
 
-          // Parse SSE stream manually (Anthropic uses a different event format)
-          const reader = response.body.getReader();
-          const decoder = new TextDecoder();
-          let buffer = '';
-
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-
-              buffer += decoder.decode(value, { stream: true });
-              const lines = buffer.split('\n');
-              buffer = lines.pop() ?? '';
-
-              for (const line of lines) {
-                if (!line.startsWith('data: ')) continue;
-                const data = line.slice(6);
-                if (!data || data === '[DONE]') continue;
-
-                try {
-                  const parsed = JSON.parse(data);
-
-                  // Anthropic streaming events:
-                  // content_block_delta: { type: 'content_block_delta', delta: { type: 'text_delta', text: '...' } }
-                  // message_stop: end of stream
-                  if (
-                    parsed.type === 'content_block_delta' &&
-                    parsed.delta?.type === 'text_delta' &&
-                    parsed.delta?.text
-                  ) {
-                    yield parsed.delta.text;
-                  }
-
-                  if (parsed.type === 'message_stop') {
-                    return;
-                  }
-                } catch {
-                  // Skip unparseable events
-                }
-              }
-            }
-          } finally {
-            reader.releaseLock();
-          }
-
-          return;
+          response = res;
+          break;
         } catch (err) {
           if (err instanceof DOMException && err.name === 'AbortError') {
             lastError = new Error('Anthropic request timeout');
@@ -154,10 +107,61 @@ export function createAnthropicProvider(config: AgentConfig): LLMProvider {
           }
 
           if (attempt < MAX_RETRIES) continue;
+          throw lastError;
+        } finally {
+          clearTimeout(timeout);
         }
       }
 
-      throw lastError ?? new Error('Anthropic request failed after retries');
+      if (!response || !response.body) {
+        throw lastError ?? new Error('Anthropic request failed after retries');
+      }
+
+      // 阶段二：消费流（一旦开始 yield 就不再重试，直接抛错）。
+      // Parse SSE stream manually (Anthropic uses a different event format)
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const data = line.slice(6);
+            if (!data || data === '[DONE]') continue;
+
+            try {
+              const parsed = JSON.parse(data);
+
+              // Anthropic streaming events:
+              // content_block_delta: { type: 'content_block_delta', delta: { type: 'text_delta', text: '...' } }
+              // message_stop: end of stream
+              if (
+                parsed.type === 'content_block_delta' &&
+                parsed.delta?.type === 'text_delta' &&
+                parsed.delta?.text
+              ) {
+                yield parsed.delta.text;
+              }
+
+              if (parsed.type === 'message_stop') {
+                return;
+              }
+            } catch {
+              // Skip unparseable events
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
     },
   };
 }

--- a/apps/api/src/lib/agent/provider.ts
+++ b/apps/api/src/lib/agent/provider.ts
@@ -41,6 +41,9 @@ export function createOpenAIProvider(config: AgentConfig): LLMProvider {
         stream: true,
       };
 
+      // 阶段一：建立连接（建连失败可重试）。一旦拿到 response 就 break，
+      // 避免流消费中途失败后重试导致已 yield 的内容被重复输出。
+      let response: Response | undefined;
       let lastError: Error | undefined;
 
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -50,71 +53,36 @@ export function createOpenAIProvider(config: AgentConfig): LLMProvider {
           await delay(backoff);
         }
 
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
         try {
-          const controller = new AbortController();
-          const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${config.apiKey}`,
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+          });
 
-          let response: Response;
-          try {
-            response = await fetch(url, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${config.apiKey}`,
-              },
-              body: JSON.stringify(body),
-              signal: controller.signal,
-            });
-          } finally {
-            clearTimeout(timeout);
-          }
-
-          if (!response.ok) {
-            const errorText = await response.text().catch(() => '');
-            const err = new Error(
-              `LLM API error ${response.status}: ${errorText || response.statusText}`,
-            );
-
-            if (isRetryable(response.status) && attempt < MAX_RETRIES) {
+          if (!res.ok) {
+            const errorText = await res.text().catch(() => '');
+            const err = new Error(`LLM API error ${res.status}: ${errorText || res.statusText}`);
+            if (isRetryable(res.status) && attempt < MAX_RETRIES) {
               lastError = err;
               continue;
             }
             throw err;
           }
 
-          if (!response.body) {
+          if (!res.body) {
             throw new Error('LLM API returned empty body');
           }
 
-          const eventStream = response.body
-            .pipeThrough(new TextDecoderStream())
-            .pipeThrough(new EventSourceParserStream());
-
-          const reader = eventStream.getReader();
-
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-
-              const data = value.data;
-              if (data === '[DONE]') break;
-
-              try {
-                const parsed = JSON.parse(data);
-                const content = parsed.choices?.[0]?.delta?.content;
-                if (content) {
-                  yield content;
-                }
-              } catch {
-                // 跳过无法解析的 event（如心跳）
-              }
-            }
-          } finally {
-            reader.releaseLock();
-          }
-
-          return;
+          response = res;
+          break;
         } catch (err) {
           if (err instanceof DOMException && err.name === 'AbortError') {
             lastError = new Error('LLM request timeout');
@@ -125,10 +93,44 @@ export function createOpenAIProvider(config: AgentConfig): LLMProvider {
           }
 
           if (attempt < MAX_RETRIES) continue;
+          throw lastError;
+        } finally {
+          clearTimeout(timeout);
         }
       }
 
-      throw lastError ?? new Error('LLM request failed after retries');
+      if (!response || !response.body) {
+        throw lastError ?? new Error('LLM request failed after retries');
+      }
+
+      // 阶段二：消费流（一旦开始 yield 就不再重试，直接抛错）。
+      const eventStream = response.body
+        .pipeThrough(new TextDecoderStream())
+        .pipeThrough(new EventSourceParserStream());
+
+      const reader = eventStream.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const data = value.data;
+          if (data === '[DONE]') break;
+
+          try {
+            const parsed = JSON.parse(data);
+            const content = parsed.choices?.[0]?.delta?.content;
+            if (content) {
+              yield content;
+            }
+          } catch {
+            // 跳过无法解析的 event（如心跳）
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
     },
   };
 }

--- a/apps/api/src/lib/agent/stream.ts
+++ b/apps/api/src/lib/agent/stream.ts
@@ -11,25 +11,47 @@ export function createSSEResponse(tokens: AsyncIterable<string>, signal?: AbortS
 
   const stream = new ReadableStream({
     async start(controller) {
+      // 客户端断开后 enqueue/close 会抛错，统一容错：已断开则静默结束。
+      const send = (chunk: string) => {
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          // controller 已关闭（客户端断开），忽略
+        }
+      };
+      const close = () => {
+        try {
+          controller.close();
+        } catch {
+          // controller 已关闭，忽略
+        }
+      };
+
       try {
         for await (const token of tokens) {
           if (signal?.aborted) break;
 
           const event: AgentStreamEvent = { type: 'delta', content: token };
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          send(`data: ${JSON.stringify(event)}\n\n`);
         }
+
+        // 客户端主动取消时不再发送尾部事件
+        if (signal?.aborted) return;
 
         // 发送 done 事件
         const doneEvent: AgentStreamEvent = { type: 'done' };
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(doneEvent)}\n\n`));
+        send(`data: ${JSON.stringify(doneEvent)}\n\n`);
       } catch (err) {
+        // 客户端断开导致的中断不算错误，不发送 error 事件
+        if (signal?.aborted) return;
+
         const errorEvent: AgentStreamEvent = {
           type: 'error',
           error: err instanceof Error ? err.message : 'Unknown error',
         };
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`));
+        send(`data: ${JSON.stringify(errorEvent)}\n\n`);
       } finally {
-        controller.close();
+        close();
       }
     },
   });

--- a/apps/api/src/lib/sync/store.ts
+++ b/apps/api/src/lib/sync/store.ts
@@ -95,6 +95,9 @@ export function createSyncHistoryStore(options: SyncHistoryStoreOptions = {}) {
           attempts: 0,
           updatedAt: timestamp,
         })),
+        ...(input.variantIds && Object.keys(input.variantIds).length > 0
+          ? { variantIds: input.variantIds }
+          : {}),
       };
 
       task = appendEvent(task, { type: 'created' });

--- a/apps/api/src/lib/sync/types.ts
+++ b/apps/api/src/lib/sync/types.ts
@@ -75,6 +75,8 @@ export interface SyncTask {
   status: SyncTaskStatus;
   receipts: PlatformSyncReceipt[];
   events: SyncEvent[];
+  /** 发布时各平台选定的变体 ID，用于重试时重建平台专属内容 */
+  variantIds?: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 }
@@ -83,6 +85,7 @@ export interface CreateSyncTaskInput {
   draftId?: string;
   title: string;
   platforms: PlatformId[];
+  variantIds?: Record<string, string>;
 }
 
 export type UpdateSyncReceiptInput = Partial<

--- a/apps/api/src/middleware/localhostGuard.ts
+++ b/apps/api/src/middleware/localhostGuard.ts
@@ -1,5 +1,10 @@
 import type { MiddlewareHandler } from 'hono';
 
+/**
+ * 拒绝非本地请求。
+ * 主防线是 API server 只绑定 127.0.0.1，这里基于 Host 头做辅助校验。
+ * 注意：Host 头由客户端发送、可伪造，不能作为唯一安全依据。
+ */
 export const localhostGuard: MiddlewareHandler = async (c, next) => {
   const host = c.req.header('host') || '';
   const isLocal =

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -13,12 +13,6 @@ const CLEANUP_INTERVAL = 300_000;
 const store = new Map<string, RateLimitEntry>();
 let lastCleanup = Date.now();
 
-function getIp(headers: Headers): string {
-  return (
-    headers.get('x-forwarded-for')?.split(',')[0]?.trim() || headers.get('x-real-ip') || '127.0.0.1'
-  );
-}
-
 function isAgentEndpoint(pathname: string): boolean {
   return pathname.startsWith('/api/agent/');
 }
@@ -43,11 +37,12 @@ export const rateLimit: MiddlewareHandler = async (c, next) => {
 
   maybeCleanup();
 
-  const ip = getIp(c.req.raw.headers);
+  // 本地单用户工具：所有请求同源，直接用固定 key。
+  // 之前信任 x-forwarded-for / x-real-ip，这两个头完全可伪造，换 IP 即可绕过限流。
   const isAgent = isAgentEndpoint(pathname);
   const limit = isAgent ? AGENT_LIMIT : DEFAULT_LIMIT;
   const now = Date.now();
-  const key = `${ip}:${isAgent ? 'agent' : 'default'}`;
+  const key = isAgent ? 'local:agent' : 'local:default';
   const entry = store.get(key);
 
   if (!entry || now >= entry.resetAt) {

--- a/apps/api/src/routes/publish.ts
+++ b/apps/api/src/routes/publish.ts
@@ -16,6 +16,35 @@ import { logger } from '@/lib/logger';
 
 const VALID_PLATFORMS = PLATFORMS.map((p) => p.id);
 
+/**
+ * 把各平台选定的变体 ID 解析为平台专属内容，并返回成功命中的变体 ID 映射。
+ * 变体不存在（被删除等）的平台回退到默认 title/content。
+ */
+export function resolveVariantsToDrafts(
+  platforms: PlatformId[],
+  variantIds: Record<string, string> | undefined,
+  fallbackTitle: string,
+  fallbackContent: string,
+  baseDrafts: PlatformPublishDrafts,
+): { drafts: PlatformPublishDrafts; resolvedIds: Record<string, string> } {
+  if (!variantIds || typeof variantIds !== 'object') {
+    return { drafts: baseDrafts, resolvedIds: {} };
+  }
+  const variantRegistry = getPlatformVariantRegistry();
+  const drafts = { ...baseDrafts };
+  const resolvedIds: Record<string, string> = {};
+  for (const platform of platforms) {
+    const vid = variantIds[platform];
+    if (!vid) continue;
+    const variant = variantRegistry.getVariant(vid);
+    if (variant) {
+      drafts[platform] = { title: variant.title, content: variant.content };
+      resolvedIds[platform] = vid;
+    }
+  }
+  return { drafts, resolvedIds };
+}
+
 export const publishRoutes = new Hono();
 
 publishRoutes.post('/', async (c) => {
@@ -33,20 +62,14 @@ publishRoutes.post('/', async (c) => {
     const platformErr = validatePlatforms(platforms);
     if (platformErr) return apiError(c, platformErr);
 
-    const resolvedVariantIds: Record<string, string> = {};
-    if (variantIds && typeof variantIds === 'object') {
-      const variantRegistry = getPlatformVariantRegistry();
-      for (const platform of platforms as PlatformId[]) {
-        const vid = variantIds[platform];
-        if (vid) {
-          const variant = variantRegistry.getVariant(vid);
-          if (variant) {
-            platformDrafts[platform] = { title: variant.title, content: variant.content };
-            resolvedVariantIds[platform] = vid;
-          }
-        }
-      }
-    }
+    const { drafts: resolvedDrafts, resolvedIds: resolvedVariantIds } = resolveVariantsToDrafts(
+      platforms as PlatformId[],
+      variantIds && typeof variantIds === 'object' ? variantIds : undefined,
+      title,
+      content,
+      platformDrafts,
+    );
+    platformDrafts = resolvedDrafts;
 
     const moderation = checkContent(`${title}\n${content}`);
     const forcePublish = body.forcePublish === true;
@@ -81,6 +104,7 @@ publishRoutes.post('/', async (c) => {
       draftId: typeof draftId === 'string' && draftId.trim() ? draftId.trim() : undefined,
       title,
       platforms: platforms as PlatformId[],
+      variantIds: Object.keys(resolvedVariantIds).length > 0 ? resolvedVariantIds : undefined,
     });
 
     syncStore.appendTaskEvent(syncTask.id, {

--- a/apps/api/src/routes/syncTasks.ts
+++ b/apps/api/src/routes/syncTasks.ts
@@ -4,6 +4,7 @@ import { getDraftRegistry } from '@/lib/drafts/registry';
 import { getSyncHistoryStore } from '@/lib/sync/registry';
 import { runPublishJob } from '@/lib/publishers/publishJobRunner';
 import { toDraftStatus } from '@/lib/publishers/executePublish';
+import { resolveVariantsToDrafts } from '@/routes/publish';
 import { apiResponse, apiError } from '@/lib/response';
 
 function isPlatformId(value: unknown): value is PlatformId {
@@ -73,12 +74,23 @@ syncTasksRoutes.post('/:id/retry', async (c) => {
     return apiError(c, '没有可重试的平台（需要重新授权的平台请先前往设置页重新连接）');
   }
 
+  // 重试时用当时选定的平台变体内容，而非原始正文
+  const { drafts: platformDrafts, resolvedIds: resolvedVariantIds } = resolveVariantsToDrafts(
+    retryPlatforms,
+    syncTask.variantIds,
+    draft.title,
+    draft.content,
+    {},
+  );
+
   syncStore.appendRetryEvent(syncTask.id);
   const { syncTask: updatedTask, results } = await runPublishJob({
     syncTaskId: syncTask.id,
     title: draft.title,
     content: draft.content,
     platforms: retryPlatforms,
+    platformDrafts,
+    variantIds: Object.keys(resolvedVariantIds).length > 0 ? resolvedVariantIds : undefined,
   });
 
   return apiResponse(c, { syncTask: updatedTask, retriedPlatforms: retryPlatforms, results });


### PR DESCRIPTION
## Background

Code review surfaced 4 confirmed bugs, split into 4 independent commits by theme.

## Changes

### 1. LLM stream retry after mid-stream failure produced duplicate output (`6d402d9`)
The original retry loop wrapped both connection establishment and stream consumption in a single `try/catch`. When the stream failed mid-way (network drop after some tokens were already yielded), the `catch` branch would trigger a retry that re-yielded content from scratch → duplicated, out-of-order text.

Split into two phases: phase one only retries `fetch` + status check and breaks once a valid response is obtained; phase two consumes the stream and never retries, surfacing any error directly. Both providers (OpenAI / Anthropic) updated symmetrically.

### 2. SSE enqueue/close cascaded errors on client disconnect (`9a18ac0`)
After the client disconnected, `controller.enqueue()` threw a `TypeError`; the `catch` then tried to enqueue an error event (throwing again), and `finally` called `controller.close()` (throwing a third time).

Wrapped `send` / `close` in tolerant helpers and skip the error event when the abort signal indicates the client cancelled.

### 3. Retry publish dropped platform variant content (`36787bf`)
The retry path only passed `title/content/platforms`, omitting `platformDrafts/variantIds`, so a retried task published the original body instead of the selected per-platform variant.

Added an optional `variantIds` field on `SyncTask` (backward compatible, no schema migration), persisted at task creation; extracted the `variantIds → platformDrafts` resolution into `resolveVariantsToDrafts`, shared by both publish and retry.

### 4. rateLimit trusted spoofable XFF header (`dc26853`)
As a local single-user tool with no reverse proxy, `x-forwarded-for` / `x-real-ip` are client-controlled and trivially spoofable — rotating the header bypassed rate limiting entirely.

Dropped IP extraction in favor of a fixed local key, keeping the separate agent/default limits. `localhostGuard` logic is unchanged (binding to 127.0.0.1 is the real boundary); added a clarifying comment on its role.

## Verification

- `pnpm --filter @publio/api exec tsc --noEmit` ✅
- `pnpm --filter @publio/web exec tsc --noEmit` ✅
- `pnpm lint` ✅